### PR TITLE
Add the source file's directory to the include path [erlc]

### DIFF
--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -7,6 +7,7 @@ function! ale_linters#erlang#erlc#GetCommand(buffer) abort
     call ale#engine#ManageFile(a:buffer, l:output_file)
 
     return 'erlc -o ' . ale#Escape(l:output_file)
+    \   . ' -I' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
     \   . ' ' . ale#Var(a:buffer, 'erlang_erlc_options')
     \   . ' %t'
 endfunction


### PR DESCRIPTION
This may address #1512, and implements the suggestion by w0rp to include the directory containing the source file via `-I`.  The directory is included before `ale_erlang_erlc_options` so that user-supplied flags can take precedence.

I ran into this issue independently using Rebar, not erlang.mk, so I'm not sure whether it does fix #1512, but it fixes a similar issue for me with Rebar.