### PR TITLE
Adds -B flag to make when parsing a makefile.

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -223,7 +223,7 @@ function! ale#c#GetMakeCommand(buffer) abort
         let l:makefile_path = ale#path#FindNearestFile(a:buffer, 'Makefile')
 
         if !empty(l:makefile_path)
-            return 'cd '. fnamemodify(l:makefile_path, ':p:h') . ' && make -n'
+            return 'cd '. fnamemodify(l:makefile_path, ':p:h') . ' && make -Bn'
         endif
     endif
 


### PR DESCRIPTION
Its a pretty simple change.

Before, if `g:ale_c_parse_makefile` was enabled but the target was already built, many makefiles would output nothing. This should make all targets dry-run unconditionally.