### PR TITLE
Pass extra command args to pyls on start

### DIFF
--- a/ale_linters/python/pyls.vim
+++ b/ale_linters/python/pyls.vim
@@ -4,6 +4,7 @@
 call ale#Set('python_pyls_executable', 'pyls')
 call ale#Set('python_pyls_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_pyls_auto_pipenv', 0)
+call ale#Set('python_pyls_extra_args', get(g:, 'ale_python_pyls_extra_args', []))
 
 function! ale_linters#python#pyls#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pyls_auto_pipenv'))
@@ -14,12 +15,24 @@ function! ale_linters#python#pyls#GetExecutable(buffer) abort
     return ale#python#FindExecutable(a:buffer, 'python_pyls', ['pyls'])
 endfunction
 
+function! ale_linters#python#pyls#GetExtraArguments(buffer) abort
+    let l:extra_args = ""
+
+    for arg in ale#Var(a:buffer, 'python_pyls_extra_args')
+        let l:extra_args .= " " . ale#Escape(arg)
+    endfor
+
+    return l:extra_args
+endfunction
+
 function! ale_linters#python#pyls#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyls#GetExecutable(a:buffer)
 
     let l:exec_args = l:executable =~? 'pipenv$'
     \   ? ' run pyls'
     \   : ''
+
+    let l:exec_args .= ale_linters#python#pyls#GetExtraArguments(a:buffer)
 
     return ale#Escape(l:executable) . l:exec_args
 endfunction


### PR DESCRIPTION
New option `g:ale_python_pyls_extra_args` may provide a list of extra arguments to pyls.

No tests and doc yet.