### PR TITLE
linters/systemd: adds systemd-analyse as new linter

### DIFF
--- a/ale_linters/systemd/systemd_analyze.vim
+++ b/ale_linters/systemd/systemd_analyze.vim
@@ -1,0 +1,35 @@
+" Author: Vincent (wahrwolf [ät] wolfpit.net)
+" Description: systemd-analyze unit for systemd files
+
+function! ale_linters#systemd#systemd_analyze#Handle(buffer, lines) abort
+   " Example output
+   " $ systemd-analyze
+   " /home/bar/.config/systemd/user/synergys.socket:3: Unknown lvalue 'Bar' in section 'Unit'
+   " /home/bar/.config/systemd/user/synergys.socket:4: Unknown lvalue 'Accept' in section 'Unit'
+   " Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
+    let l:pattern = '^\v(.+):(\d+): (.+)$'
+    let l:output = []
+
+    " Extract the header line first
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:item = {
+            \   'lnum'    : str2nr(l:match[2]),
+            \   'col'     : 1,
+            \   'end_col' : len(l:match[0]),
+            \   'type'    : 'E',
+            \   'text'    : l:match[3]
+            \}
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('systemd', {
+            \   'name': 'systemd-analyze',
+            \   'executable': 'systemd-analyze',
+            \   'command': 'systemd-analyze verify %s ',
+            \   'output_stream': 'stderr',
+            \   'callback': 'ale_linters#systemd#systemd_analyze#Handle',
+            \   'lint_file': 1
+            \})

--- a/ale_linters/systemd/systemd_analyze.vim
+++ b/ale_linters/systemd/systemd_analyze.vim
@@ -2,24 +2,26 @@
 " Description: systemd-analyze unit for systemd files
 
 function! ale_linters#systemd#systemd_analyze#Handle(buffer, lines) abort
-   " Example output
-   " $ systemd-analyze
+   " Match lines like:
    " /home/bar/.config/systemd/user/synergys.socket:3: Unknown lvalue 'Bar' in section 'Unit'
-   " /home/bar/.config/systemd/user/synergys.socket:4: Unknown lvalue 'Accept' in section 'Unit'
-   " Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)
     let l:pattern = '^\v(.+):(\d+): (.+)$'
     let l:output = []
 
+    "Get current filename:
+    let l:buff_name = expand('#' . a:buffer . ':p')
+
     " Extract the header line first
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:item = {
-            \   'lnum'    : str2nr(l:match[2]),
-            \   'col'     : 1,
-            \   'end_col' : len(l:match[0]),
-            \   'type'    : 'E',
-            \   'text'    : l:match[3]
-            \}
-        call add(l:output, l:item)
+        if l:match[1] is? l:buff_name
+            let l:item = {
+                \   'lnum'    : str2nr(l:match[2]),
+                \   'col'     : 1,
+                \   'end_col' : len(l:match[0]),
+                \   'type'    : 'E',
+                \   'text'    : l:match[3]
+                \}
+            call add(l:output, l:item)
+        endif
     endfor
 
     return l:output

--- a/test/handler/test_systemd_analyze.vader
+++ b/test/handler/test_systemd_analyze.vader
@@ -1,0 +1,25 @@
+Before:
+  " Load the file which defines the linter.
+  runtime! ale_linters/systemd/systemd_analyze.vim
+
+After:
+  " Unload all linters again.
+  call ale#linter#Reset()
+
+Execute(Prepare Buffer):
+Execute(The output should be correct):
+" Test that the right loclist items are parsed from the handler.
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'type': 'W',
+  \     'text': "Unknown lvalue 'Foo' in section 'Unit'"
+  \   }
+  \ ],
+  \ ale_linters#systemd#systemd_analyze#Handle(bufnr(''), [
+  \ 'File /usr/lib/systemd/system/systemd-udevd.service:36 configures an IP firewall (IPAddressDeny=any), but the local system does not support BPF/cgroup based firewalling.',
+  \ 'Proceeding WITHOUT firewalling in effect! (This warning is only shown for the first loaded unit using IP firewalling.)',
+  \ "/etc/systemd/system/certbot.timer:6: Unknown lvalue 'RandomizeDelaySec' in section 'Timer'",
+  \ "/tmp/demo.service:3: Unknown lvalue 'Foo' in section 'Unit'"
+  \ ])


### PR DESCRIPTION
Adds support for systemd-analyze:
Since this util is shipped with systemd anyways, it might be useful to have.

This linter will mark whole lines, since they correspond bests with systemd files