### PR TITLE
Ruby/Brakeman: only lint current file

### DIFF
--- a/ale_linters/ruby/brakeman.vim
+++ b/ale_linters/ruby/brakeman.vim
@@ -3,7 +3,6 @@
 
 call ale#Set('ruby_brakeman_options', '')
 call ale#Set('ruby_brakeman_executable', 'brakeman')
-call ale#Set('ruby_brakeman_options', '')
 
 function! ale_linters#ruby#brakeman#Handle(buffer, lines) abort
     let l:output = []
@@ -40,6 +39,7 @@ function! ale_linters#ruby#brakeman#GetCommand(buffer) abort
     \    . ' -f json -q '
     \    . ale#Var(a:buffer, 'ruby_brakeman_options')
     \    . ' -p ' . ale#Escape(l:rails_root)
+    \    . ' --only-files ' . expand('#' . a:buffer . '...')
 endfunction
 
 call ale#linter#Define('ruby', {

--- a/test/command_callback/test_brakeman_command_callback.vader
+++ b/test/command_callback/test_brakeman_command_callback.vader
@@ -15,6 +15,8 @@ Execute(The brakeman command callback should find a valid Rails app root):
   AssertLinter 'brakeman', ale#Escape('brakeman')
   \ . ' -f json -q  -p '
   \ . ale#Escape(ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app'))
+  \ . ' --only-files '
+  \ . ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app/db/test.rb')
 
 Execute(The brakeman command callback should include configured options):
   call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/db/test.rb')
@@ -24,6 +26,17 @@ Execute(The brakeman command callback should include configured options):
   AssertLinter 'brakeman', ale#Escape('brakeman')
   \ . ' -f json -q --combobulate -p '
   \ . ale#Escape(ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app'))
+  \ . ' --only-files '
+  \ . ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app/db/test.rb')
+
+Execute(The brakeman command callback should use the relative path of the buffer):
+  call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/db/test.rb')
+
+  AssertLinter 'brakeman', ale#Escape('brakeman')
+  \ . ' -f json -q  -p '
+  \ . ale#Escape(ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app'))
+  \ . ' --only-files '
+  \ . ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app/db/test.rb')
 
 Execute(Setting bundle appends 'exec brakeman'):
   call ale#test#SetFilename('../ruby_fixtures/valid_rails_app/db/test.rb')
@@ -35,3 +48,5 @@ Execute(Setting bundle appends 'exec brakeman'):
   \ . ' exec brakeman'
   \ . ' -f json -q --combobulate -p '
   \ . ale#Escape(ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app'))
+  \ . ' --only-files '
+  \ . ale#path#Simplify(g:dir . '/../ruby_fixtures/valid_rails_app/db/test.rb')


### PR DESCRIPTION
When the Brakeman linter was added, Brakeman didn't yet have the ability
to only check a single file. This results in ALE filling the location
list with violations from elsewhere in the project that aren't relevant
to the current buffer.

This change uses the `--only-files` argument to scope the Brakeman check
to the file of the current buffer. Note that this change will cause some
controller/view interactions to be missed, as Brakeman won't consider
violations that require scanning the current buffer's file in the
context of other files in the project (such as XSS with a model fetched
in a controller but output unescaped in a view), but it cuts down
significantly on unactionable noise.

Brakeman docs:
https://brakemanscanner.org/docs/options/
