### PR TITLE
Fix syntax errors when using eruby with graphql-client gem

### DIFF
--- a/ale_linters/eruby/erb.vim
+++ b/ale_linters/eruby/erb.vim
@@ -11,7 +11,10 @@ function! ale_linters#eruby#erb#GetCommand(buffer) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " ERB, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter—the translated code is still evaluated.
-    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+    "
+    " The graphql-client's graphql view helper does something similar, so we
+    " replace that like it does internally
+    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}).gsub(%{<%graphql},%{<%#}), nil, %{-}).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {

--- a/ale_linters/eruby/erubi.vim
+++ b/ale_linters/eruby/erubi.vim
@@ -21,7 +21,10 @@ function! ale_linters#eruby#erubi#GetCommand(buffer, check_erubi_output) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " Erubi, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter---the translated code is still evaluated.
-    return 'ruby -r erubi/capture_end -e ' . ale#Escape('puts Erubi::CaptureEndEngine.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+    "
+    " The graphql-client's graphql view helper does something similar, so we
+    " replace that like it does internally
+    return 'ruby -r erubi/capture_end -e ' . ale#Escape('puts Erubi::CaptureEndEngine.new($stdin.read.gsub(%{<%=},%{<%}).gsub(%{<%graphql},%{<%#}), nil, %{-}).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {

--- a/ale_linters/eruby/erubis.vim
+++ b/ale_linters/eruby/erubis.vim
@@ -11,7 +11,10 @@ function! ale_linters#eruby#erubis#GetCommand(buffer) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " Erubis, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter - the translated code is still evaluated.
-    return 'ruby -r erubis -e ' . ale#Escape('puts Erubis::Eruby.new($stdin.read.gsub(%{<%=},%{<%})).src') . '< %t | ruby -c'
+    "
+    " The graphql-client's graphql view helper does something similar, so we
+    " replace that like it does internally
+    return 'ruby -r erubis -e ' . ale#Escape('puts Erubis::Eruby.new($stdin.read.gsub(%{<%=},%{<%}).gsub(%{<%graphql},%{<%#})).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {


### PR DESCRIPTION
[graphql-client](https://github.com/github/graphql-client) has this interesting feature where you can do inline
[graphql in ERB](https://github.com/github/graphql-client#rails-erb-integration):

> These <%graphql sections are simply ignored at runtime but make their definitions available through constants. The module namespacing is derived from the .erb's path plus the definition name.

The problem is this isn't actually valid ERB, similar to how Rails has
it's own idiosyncrasies. https://github.com/w0rp/ale/issues/580 covers when this came up for Rails

This adds a gsub similar to Rails, but for the graphql helper, like it
does internally: https://github.com/github/graphql-client/blob/116bb3ea2c2abac13ce9ed95a99d1cf98ccc201e/lib/graphql/client/erubis_enhancer.rb#L17

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
