### PR TITLE
WIP: Add support for textDocument/codeLens

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -109,7 +109,10 @@ function! s:Lint(buffer, should_lint_file, timer_id) abort
     \   || (a:should_lint_file && filereadable(expand('#' . a:buffer . ':p')))
 
     call ale#engine#RunLinters(a:buffer, l:linters, l:lint_file)
-    call ale#code_lens#Request(a:buffer)
+
+    if get(g:, 'ale_code_lens_enabled', 0)
+        call ale#code_lens#Request(a:buffer)
+    endif
 endfunction
 
 " (delay, [linting_flag, buffer_number])

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -109,6 +109,7 @@ function! s:Lint(buffer, should_lint_file, timer_id) abort
     \   || (a:should_lint_file && filereadable(expand('#' . a:buffer . ':p')))
 
     call ale#engine#RunLinters(a:buffer, l:linters, l:lint_file)
+    call ale#code_lens#Request(a:buffer)
 endfunction
 
 " (delay, [linting_flag, buffer_number])

--- a/autoload/ale/code_lens.vim
+++ b/autoload/ale/code_lens.vim
@@ -17,10 +17,10 @@ endfunction
 " TODO: maybe check with exists instead?
 let s:supported = exists('*nvim_buf_set_virtual_text')
 
-let s:enabled = 0
+let g:ale_code_lens_enabled = 0
 
 function! ale#code_lens#Toggle() abort
-    if s:enabled
+    if g:ale_code_lens_enabled
         call ale#code_lens#Disable()
     else
         call ale#code_lens#Enable()
@@ -28,23 +28,21 @@ function! ale#code_lens#Toggle() abort
 endfunction
 
 function! ale#code_lens#Enable() abort
-    let s:enabled = 1
+    let g:ale_code_lens_enabled = 1
     " We try to request code lens for the current buffer.
     call ale#code_lens#Request(bufnr('%'))
 endfunction
 
 function! ale#code_lens#Disable() abort
-    let s:enabled = 0
+    let g:ale_code_lens_enabled = 0
     call ale#code_lens#Clear(bufnr('%'))
 endfunction
 
-let s:enabled_buf_var = 'ale_code_lens_enabled'
-
 function! ale#code_lens#ToggleBuffer(buffer) abort
     " Get the new value for the code_lens.
-    let l:enabled = !getbufvar(a:buffer, s:enabled_buf_var, 1)
+    let l:enabled = !getbufvar(a:buffer, 'ale_code_lens_enabled', 1)
 
-    call setbufvar(a:buffer, s:enabled_buf_var, l:enabled)
+    call setbufvar(a:buffer, 'ale_code_lens_enabled', l:enabled)
 
     if l:enabled
         call ale#code_lens#Request(a:buffer)
@@ -55,36 +53,34 @@ endfunction
 
 function! ale#code_lens#EnableBuffer(buffer) abort
     " ALE is enabled by default for all buffers.
-    if !getbufvar(a:buffer, s:enabled_buf_var, 1)
+    if !getbufvar(a:buffer, 'ale_code_lens_enabled', 1)
         call ale#code_lens#ToggleBuffer(a:buffer)
     endif
 endfunction
 
 function! ale#code_lens#DisableBuffer(buffer) abort
-    if getbufvar(a:buffer, s:enabled_buf_var, 1)
+    if getbufvar(a:buffer, 'ale_code_lens_enabled', 1)
         call ale#code_lens#ToggleBuffer(a:buffer)
     endif
 endfunction
 
 function! ale#code_lens#IsEnabled(buffer) abort
     return s:supported
-         \ && s:enabled
-         \ && getbufvar(a:buffer, s:enabled_buf_var, 1)
+         \ && g:ale_code_lens_enabled
+         \ && getbufvar(a:buffer, 'ale_code_lens_enabled', 1)
 endfunction
 
-let s:ale_code_lens_ns_var = 'ale_code_lens_ns'
-
 function! s:GetNamespace(buffer) abort
-    if getbufvar(a:buffer, s:ale_code_lens_ns_var, -1) == -1
+    if getbufvar(a:buffer, 'ale_code_lens_ns', -1) == -1
         " NOTE: This will highlights nothing but will allocate new id
         call setbufvar(
         \ a:buffer,
-        \ s:ale_code_lens_ns_var,
+        \ 'ale_code_lens_ns',
         \ nvim_buf_add_highlight(a:buffer, 0, '', 0, 0, -1)
         \)
     endif
 
-    return getbufvar(a:buffer, s:ale_code_lens_ns_var)
+    return getbufvar(a:buffer, 'ale_code_lens_ns')
 endfunction
 
 function! ale#code_lens#Show(buffer, items) abort

--- a/autoload/ale/code_lens.vim
+++ b/autoload/ale/code_lens.vim
@@ -1,0 +1,185 @@
+let s:code_lens_map = {}
+
+" Used to get the code lens map in tests.
+function! ale#code_lens#GetMap() abort
+    return deepcopy(s:code_lens_map)
+endfunction
+
+" Used to set the code lens map in tests.
+function! ale#code_lens#SetMap(map) abort
+    let s:code_lens_map = a:map
+endfunction
+
+function! ale#code_lens#ClearLSPData() abort
+    let s:code_lens_map = {}
+endfunction
+
+" TODO: maybe check with exists instead?
+let s:supported = exists('*nvim_buf_set_virtual_text')
+
+let s:enabled = 0
+
+function! ale#code_lens#Toggle() abort
+    if s:enabled
+        call ale#code_lens#Disable()
+    else
+        call ale#code_lens#Enable()
+    endif
+endfunction
+
+function! ale#code_lens#Enable() abort
+    let s:enabled = 1
+    " We try to request code lens for the current buffer.
+    call ale#code_lens#Request(bufnr('%'))
+endfunction
+
+function! ale#code_lens#Disable() abort
+    let s:enabled = 0
+    call ale#code_lens#Clear(bufnr('%'))
+endfunction
+
+let s:enabled_buf_var = 'ale_code_lens_enabled'
+
+function! ale#code_lens#ToggleBuffer(buffer) abort
+    " Get the new value for the code_lens.
+    let l:enabled = !getbufvar(a:buffer, s:enabled_buf_var, 1)
+
+    call setbufvar(a:buffer, s:enabled_buf_var, l:enabled)
+
+    if l:enabled
+        call ale#code_lens#Request(a:buffer)
+    else
+        call ale#code_lens#Clear(a:buffer)
+    endif
+endfunction
+
+function! ale#code_lens#EnableBuffer(buffer) abort
+    " ALE is enabled by default for all buffers.
+    if !getbufvar(a:buffer, s:enabled_buf_var, 1)
+        call ale#code_lens#ToggleBuffer(a:buffer)
+    endif
+endfunction
+
+function! ale#code_lens#DisableBuffer(buffer) abort
+    if getbufvar(a:buffer, s:enabled_buf_var, 1)
+        call ale#code_lens#ToggleBuffer(a:buffer)
+    endif
+endfunction
+
+function! ale#code_lens#IsEnabled(buffer) abort
+    return s:supported
+         \ && s:enabled
+         \ && getbufvar(a:buffer, s:enabled_buf_var, 1)
+endfunction
+
+let s:ale_code_lens_ns_var = 'ale_code_lens_ns'
+
+function! s:GetNamespace(buffer) abort
+    if getbufvar(a:buffer, s:ale_code_lens_ns_var, -1) == -1
+        " NOTE: This will highlights nothing but will allocate new id
+        call setbufvar(
+        \ a:buffer,
+        \ s:ale_code_lens_ns_var,
+        \ nvim_buf_add_highlight(a:buffer, 0, '', 0, 0, -1)
+        \)
+    endif
+
+    return getbufvar(a:buffer, s:ale_code_lens_ns_var)
+endfunction
+
+function! ale#code_lens#Show(buffer, items) abort
+    let l:namespace = s:GetNamespace(a:buffer)
+    for item in a:items
+        let text = '  ' . substitute(l:item.title, '\n', ' ', 'g')
+        call nvim_buf_set_virtual_text(
+        \ a:buffer, l:namespace,
+        \ item.range.start.line, [[text, 'Comment']], {}
+        \)
+    endfor
+endfunction
+
+function! ale#code_lens#Clear(buffer) abort
+    let l:namespace = s:GetNamespace(a:buffer)
+    call nvim_buf_clear_namespace(a:buffer, l:namespace, 0, -1)
+endfunction
+
+function! ale#code_lens#HandleLSPResponse(buffer, conn_id, response) abort
+    if has_key(a:response, 'id')
+    \&& has_key(s:code_lens_map, a:response.id)
+        let l:options = remove(s:code_lens_map, a:response.id)
+
+        let l:result = get(a:response, 'result', v:null)
+        let l:item_list = []
+
+        if type(l:result) is v:t_list
+            " Each item looks like this:
+            "{
+            "  'range': {
+            "    'start': { 'line': 7, 'character': 2 },
+            "    'end': { 'line': 7, 'character': 12 }
+            "  },
+            "  'command': { 'title': 'int', 'command': '' }
+            "}
+            for l:response_item in l:result
+                call add(l:item_list, {
+                \ 'range': l:response_item.range,
+                \ 'title': l:response_item.command.title,
+                \})
+            endfor
+        endif
+
+        if !empty(l:item_list)
+            call ale#code_lens#Show(a:buffer, l:item_list)
+        else
+        endif
+    endif
+endfunction
+
+function! s:OnReady(linter, lsp_details, ...) abort
+    let l:buffer = a:lsp_details.buffer
+
+    " If we already made a request, stop here.
+    if getbufvar(l:buffer, 'ale_code_lens_request_made', 0)
+        return
+    endif
+
+    let l:id = a:lsp_details.connection_id
+
+    let l:Callback = function('ale#code_lens#HandleLSPResponse', [l:buffer])
+    call ale#lsp#RegisterCallback(l:id, l:Callback)
+
+    let l:message = ale#lsp#message#CodeLens(l:buffer)
+    let l:request_id = ale#lsp#Send(l:id, l:message)
+
+    call setbufvar(l:buffer, 'ale_code_lens_request_made', 1)
+    let s:code_lens_map[l:request_id] = {
+    \   'buffer': l:buffer,
+    \}
+endfunction
+
+function! s:Request(linter, buffer) abort
+    let l:lsp_details = ale#lsp_linter#StartLSP(a:buffer, a:linter)
+
+    if !empty(l:lsp_details)
+        call ale#lsp#WaitForCapability(
+        \   l:lsp_details.connection_id,
+        \   'code_lens',
+        \   function('s:OnReady', [a:linter, l:lsp_details]),
+        \)
+    endif
+endfunction
+
+function! ale#code_lens#Request(buffer) abort
+    if !ale#code_lens#IsEnabled(a:buffer)
+        return
+    endif
+
+    " Set a flag so we only make one request.
+    call setbufvar(a:buffer, 'ale_code_lens_request_made', 0)
+
+    for l:linter in ale#linter#Get(getbufvar(a:buffer, '&filetype'))
+        if !empty(l:linter.lsp) && l:linter.lsp isnot# 'tsserver'
+            call s:Request(l:linter, a:buffer)
+        endif
+    endfor
+endfunction

--- a/autoload/ale/code_lens.vim
+++ b/autoload/ale/code_lens.vim
@@ -89,7 +89,7 @@ function! ale#code_lens#Show(buffer, items) abort
         let text = '  ' . substitute(l:item.title, '\n', ' ', 'g')
         call nvim_buf_set_virtual_text(
         \ a:buffer, l:namespace,
-        \ item.range.start.line, [[text, 'Comment']], {}
+        \ item.line, [[text, 'Comment']], {}
         \)
     endfor
 endfunction
@@ -99,7 +99,7 @@ function! ale#code_lens#Clear(buffer) abort
     call nvim_buf_clear_namespace(a:buffer, l:namespace, 0, -1)
 endfunction
 
-function! ale#code_lens#HandleLSPResponse(buffer, conn_id, response) abort
+function! ale#code_lens#HandleLSPResponse(conn_id, response) abort
     if has_key(a:response, 'id')
     \&& has_key(s:code_lens_map, a:response.id)
         let l:options = remove(s:code_lens_map, a:response.id)
@@ -118,14 +118,14 @@ function! ale#code_lens#HandleLSPResponse(buffer, conn_id, response) abort
             "}
             for l:response_item in l:result
                 call add(l:item_list, {
-                \ 'range': l:response_item.range,
+                \ 'line': l:response_item.range.start.line,
                 \ 'title': l:response_item.command.title,
                 \})
             endfor
         endif
 
         if !empty(l:item_list)
-            call ale#code_lens#Show(a:buffer, l:item_list)
+            call ale#code_lens#Show(l:options.buffer, l:item_list)
         else
         endif
     endif
@@ -141,7 +141,7 @@ function! s:OnReady(linter, lsp_details, ...) abort
 
     let l:id = a:lsp_details.connection_id
 
-    let l:Callback = function('ale#code_lens#HandleLSPResponse', [l:buffer])
+    let l:Callback = function('ale#code_lens#HandleLSPResponse')
     call ale#lsp#RegisterCallback(l:id, l:Callback)
 
     let l:message = ale#lsp#message#CodeLens(l:buffer)

--- a/autoload/ale/debugging.vim
+++ b/autoload/ale/debugging.vim
@@ -4,6 +4,7 @@
 let s:global_variable_list = [
 \    'ale_cache_executable_check_failures',
 \    'ale_change_sign_column_color',
+\    'ale_code_lens_enabled',
 \    'ale_command_wrapper',
 \    'ale_completion_delay',
 \    'ale_completion_enabled',

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -45,6 +45,7 @@ function! ale#lsp#Register(executable_or_address, project, init_options) abort
         \       'definition': 0,
         \       'typeDefinition': 0,
         \       'symbol_search': 0,
+        \       'code_lens': 0,
         \   },
         \}
     endif
@@ -215,6 +216,10 @@ function! s:UpdateCapabilities(conn, capabilities) abort
     if get(a:capabilities, 'workspaceSymbolProvider') is v:true
         let a:conn.capabilities.symbol_search = 1
     endif
+
+    if type(get(a:capabilities, 'codeLensProvider')) is v:t_dict
+        let a:conn.capabilities.code_lens = 1
+    endif
 endfunction
 
 " Update a connection's configuration dictionary and notify LSP servers
@@ -317,6 +322,8 @@ function! ale#lsp#MarkConnectionAsTsserver(conn_id) abort
     let l:conn.capabilities.completion_trigger_characters = ['.']
     let l:conn.capabilities.definition = 1
     let l:conn.capabilities.symbol_search = 1
+    " TODO: need to check if tsserver provides that
+    let l:conn.capabilities.code_lens = 0
 endfunction
 
 " Start a program for LSP servers.

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -149,6 +149,14 @@ function! ale#lsp#message#Symbol(query) abort
     \}]
 endfunction
 
+function! ale#lsp#message#CodeLens(buffer) abort
+    return [0, 'textDocument/codeLens', {
+    \   'textDocument': {
+    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \   },
+    \}]
+endfunction
+
 function! ale#lsp#message#Hover(buffer, line, column) abort
     return [0, 'textDocument/hover', {
     \   'textDocument': {

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -201,6 +201,14 @@ command! -bar ALEGoToTypeDefinitionInTab :call ale#definition#GoToType({'open_in
 command! -bar ALEGoToTypeDefinitionInSplit :call ale#definition#GoToType({'open_in': 'horizontal-split'})
 command! -bar ALEGoToTypeDefinitionInVSplit :call ale#definition#GoToType({'open_in': 'vertical-split'})
 
+" CodeLens toggles for LSP
+command! -bar ALECodeLensToggle  :call ale#code_lens#Toggle()
+command! -bar ALECodeLensEnable  :call ale#code_lens#Enable()
+command! -bar ALECodeLensDisable :call ale#code_lens#Disable()
+command! -bar ALECodeLensToggleBuffer  :call ale#code_lens#ToggleBuffer(bufnr(''))
+command! -bar ALECodeLensEnableBuffer  :call ale#code_lens#EnableBuffer(bufnr(''))
+command! -bar ALECodeLensDisableBuffer :call ale#code_lens#DisableBuffer(bufnr(''))
+
 " Find references for tsserver and LSP
 command! -bar -nargs=* ALEFindReferences :call ale#references#Find(<f-args>)
 


### PR DESCRIPTION
This adds implementation of `textDocument/codeLens` request.

The result is rendered through neovim's virtualtext API and thus it's only usable with neovim.

![codelens](https://user-images.githubusercontent.com/30594/53448910-9d619900-3a29-11e9-9288-5e8e7719bd46.gif)

TODO:
- [ ] Tests (I know!)
- [x] Commands to enable/disable/toggle (also per buffer variants)
