### PR TITLE
Dynamic location list height

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,4 +778,7 @@ To set a default height for the error list, use the `g:ale_list_window_size` var
 ```vim
 " Show 5 lines of errors (default: 10)
 let g:ale_list_window_size = 5
+
+" Show all lines of errors. This matches window height to error line count.
+let g:ale_list_window_size = -1
 ```

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -123,7 +123,11 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
                 silent! execute l:open_type . 'copen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
             endif
         elseif g:ale_set_loclist
-            silent! execute l:open_type . 'lopen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+            if g:ale_list_window_size == -1
+                silent! execute l:open_type . 'lopen ' . str2nr(len(a:loclist))
+            else
+                silent! execute l:open_type . 'lopen ' . str2nr(ale#Var(a:buffer, 'list_window_size'))
+            endif
         endif
 
         " If focus changed, restore it (jump to the last window).

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1170,6 +1170,8 @@ g:ale_list_window_size                                 *g:ale_list_window_size*
   opened automatically for ALE problems. The default of `10` matches the Vim
   default height.
 
+  To have the to have the window height always match the number of error lines, use `-1`. There is no maximum. Only works with location list (not quickfix).
+
   See |g:ale_open_list| for information on automatically opening windows
   for quickfix or the loclist.
 

--- a/test/test_list_opening.vader
+++ b/test/test_list_opening.vader
@@ -260,3 +260,39 @@ Execute(The window shouldn't open on save when ale_open_list=0):
   call ale#list#SetLists(bufnr('%'), g:loclist)
   " Now the list should have opened.
   Assert !ale#list#IsQuickfixOpen()
+
+Execute(The quickfix window height should match the number of errors lines):
+  let g:ale_open_list = 1
+  let g:ale_list_window_size = -1
+
+  " Set the number of errors in the loclist to the default (4)
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+  " The list should have opened.
+  Assert ale#list#IsQuickfixOpen()
+  " The window height should match the number of errors in the loclist (4)
+  AssertEqual 4, GetQuickfixHeight()
+
+  " Set the number of errors in the loclist to 2
+  let g:loclist = [
+  \ {'bufnr': bufnr(''), 'lnum': 5, 'col': 6, 'text': 'a'},
+  \ {'bufnr': bufnr(''), 'lnum': 1, 'col': 12, 'text': 'b'},
+  \]
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+  " The list should still be open.
+  Assert ale#list#IsQuickfixOpen()
+  " The window height should now match the new number of errors in the loclist (2)
+  AssertEqual 2, GetQuickfixHeight()
+
+  " Set the number of errors in the loclist to 1
+  let g:loclist = [
+  \ {'bufnr': bufnr(''), 'lnum': 0, 'col': 0, 'text': 'z'},
+  \]
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+  " The list should still be open.
+  Assert ale#list#IsQuickfixOpen()
+  " The window height should now match the new number of errors in the loclist (1)
+  AssertEqual 1, GetQuickfixHeight()
+
+  call ale#list#SetLists(bufnr('%'), [])
+  " The window should close again when the loclist is empty.
+  Assert !ale#list#IsQuickfixOpen()


### PR DESCRIPTION
Allow `g:ale_list_window_size` to be set to `-1`. This changes the window height to be dynamic meaning it will always match the number of error lines in the loclist.

A similar change was proposed by @JZL some time ago in a [previous commit/PR](https://github.com/w0rp/ale/pull/1003/commits/ee4c53a3c5ed5b49c75da169cdb21b6ed1e20a5c) but it wasn't separated from other changes and was ultimately rejected.