### PR TITLE
WIP: Implement API to query for document symbols

### DIFF
--- a/autoload/ale/document_symbol.vim
+++ b/autoload/ale/document_symbol.vim
@@ -1,0 +1,55 @@
+" Author: Andrey Popp <8mayday@gmail.com>
+" Description: Document Symbol support for LSP linters.
+
+let s:document_symbol_map = {}
+
+function s:HandleLSPResponse(conn_id, response) abort
+    if has_key(a:response, 'id')
+    \&& has_key(s:document_symbol_map, a:response.id)
+        let l:options = remove(s:document_symbol_map, a:response.id)
+        call call(l:options.callback, [a:response.result])
+    endif
+endfunction
+
+function! s:OnReady(buffer, state, callback, linter, lsp_details) abort
+    let l:id = a:lsp_details.connection_id
+
+    if !ale#lsp#HasCapability(l:id, 'document_symbol')
+        return
+    endif
+
+    if a:state.found_provider
+        return
+    endif
+    let a:state.found_provider = 1
+    let l:id = a:lsp_details.connection_id
+    call ale#lsp#RegisterCallback(
+        \l:id,
+        \function('s:HandleLSPResponse')
+        \)
+
+    let l:message = ale#lsp#message#DocumentSymbol(a:buffer)
+    let l:request_id = ale#lsp#Send(l:id, l:message)
+
+    let s:document_symbol_map[l:request_id] = {'callback': a:callback}
+endfunction
+
+function! s:List(linter, buffer, state, callback) abort
+    let l:Callback = function(
+    \    's:OnReady',
+    \    [a:buffer, a:state, a:callback]
+    \  )
+    call ale#lsp_linter#StartLSP(a:buffer, a:linter, l:Callback)
+endfunction
+
+function! ale#document_symbol#List(callback) abort
+    let l:buffer = bufnr('')
+
+    let l:state = {'found_provider': 0}
+
+    for l:linter in ale#linter#Get(getbufvar(l:buffer, '&filetype'))
+        if !empty(l:linter.lsp)
+            call s:List(l:linter, l:buffer, l:state, a:callback)
+        endif
+    endfor
+endfunction

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -38,6 +38,7 @@ function! ale#lsp#Register(executable_or_address, project, init_options) abort
         \   'capabilities': {
         \       'hover': 0,
         \       'references': 0,
+        \       'document_symbol': 0,
         \       'completion': 0,
         \       'completion_trigger_characters': [],
         \       'definition': 0,
@@ -197,6 +198,10 @@ function! s:UpdateCapabilities(conn, capabilities) abort
 
     if get(a:capabilities, 'referencesProvider') is v:true
         let a:conn.capabilities.references = 1
+    endif
+
+    if get(a:capabilities, 'documentSymbolProvider') is v:true
+        let a:conn.capabilities.document_symbol = 1
     endif
 
     if !empty(get(a:capabilities, 'completionProvider'))

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -34,7 +34,13 @@ function! ale#lsp#message#Initialize(root_path, initialization_options) abort
     return [0, 'initialize', {
     \   'processId': getpid(),
     \   'rootPath': a:root_path,
-    \   'capabilities': {},
+    \   'capabilities': {
+    \       'textDocument': {
+    \           'documentSymbol': {
+    \               'hierarchicalDocumentSymbolSupport': v:true
+    \           }
+    \       },
+    \   },
     \   'initializationOptions': a:initialization_options,
     \   'rootUri': ale#path#ToURI(a:root_path),
     \}]
@@ -155,6 +161,14 @@ function! ale#lsp#message#Hover(buffer, line, column) abort
     \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
+    \}]
+endfunction
+
+function! ale#lsp#message#DocumentSymbol(buffer) abort
+    return [0, 'textDocument/documentSymbol', {
+    \   'textDocument': {
+    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \   },
     \}]
 endfunction
 

--- a/autoload/ale/lsp/symbol_kind.vim
+++ b/autoload/ale/lsp/symbol_kind.vim
@@ -1,0 +1,62 @@
+" Author: Andrey Popp <8mayday@gmail.com>
+" Description: LSP SymbolKind utils
+
+let s:file = 1
+let s:module = 2
+let s:namespace = 3
+let s:package  = 4
+let s:class = 5
+let s:method = 6
+let s:property = 7
+let s:field = 8
+let s:constructor = 9
+let s:enum = 10
+let s:interface = 11
+let s:function = 12
+let s:variable = 13
+let s:constant = 14
+let s:string = 15
+let s:number = 16
+let s:boolean = 17
+let s:array = 18
+let s:object = 19
+let s:key = 20
+let s:null = 21
+let s:enummember = 22
+let s:struct = 23
+let s:event = 24
+let s:operator = 25
+let s:typeparameter = 26
+
+let s:to_string = {
+\    s:file: 'file',
+\    s:module: 'module',
+\    s:namespace: 'namespace',
+\    s:package:  'package',
+\    s:class: 'class',
+\    s:method: 'method',
+\    s:property: 'property',
+\    s:field: 'field',
+\    s:constructor: 'constructor',
+\    s:enum: 'enum',
+\    s:interface: 'interface',
+\    s:function: 'func',
+\    s:variable: 'variable',
+\    s:constant: 'constant',
+\    s:string: 'string',
+\    s:number: 'number',
+\    s:boolean: 'bool',
+\    s:array: 'array',
+\    s:object: 'object',
+\    s:key: 'key',
+\    s:null: 'null',
+\    s:enummember: 'enummember',
+\    s:struct: 'struct',
+\    s:event: 'event',
+\    s:operator: 'operator',
+\    s:typeparameter: 'typeparam',
+\}
+
+function! ale#lsp#symbol_kind#Show(kind) abort
+    return get(s:to_string, a:kind, v:null)
+endfunction


### PR DESCRIPTION
This only exposes a single function

```
ale#document_symbol#List(callback)
```

which queries first available LSP with `testDocument/documentSymbol`
request.

@w0rp Do you think ALE could expose just LSP methods and not UI? I have
PoC quality FZF bindings to that which I'm using. I can see how this can
be inline with exposing completion to deoplete (and other completoers).

TODO:

- [ ] Tests
- [ ] Docs
- [ ] Make sure callback is called even if no servers are available or
      no server support the request.
- [ ] Provide sync API