### PR TITLE
Call rstcheck with --config option

### DIFF
--- a/ale_linters/rst/rstcheck.vim
+++ b/ale_linters/rst/rstcheck.vim
@@ -1,6 +1,12 @@
-" Author: John Nduli https://github.com/jnduli
+" Authors:
+"   John Nduli https://github.com/jnduli,
+"   Michael Goerz https://github.com/goerz
 " Description: Rstcheck for reStructuredText files
 "
+
+call ale#Set('rst_rstcheck_options', '')
+call ale#Set('rst_rstcheck_use_project_config', 1)
+
 
 function! ale_linters#rst#rstcheck#Handle(buffer, lines) abort
     " matches: 'bad_rst.rst:1: (SEVERE/4) Title overline & underline
@@ -23,8 +29,15 @@ function! ale_linters#rst#rstcheck#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#rst#rstcheck#GetCommand(buffer) abort
+    let l:dir = expand('#' . a:buffer . ':p:h')
+    let l:exec_args = ' ' . ale#Var(a:buffer, 'rst_rstcheck_options')
+    if ale#Var(a:buffer, 'rst_rstcheck_use_project_config')
+      let l:exec_args .= ' --config '. "'".l:dir."'"
+    endif
+
     return ale#path#BufferCdString(a:buffer)
     \   . 'rstcheck'
+    \   . l:exec_args
     \   . ' %t'
 endfunction
 

--- a/doc/ale-restructuredtext.txt
+++ b/doc/ale-restructuredtext.txt
@@ -3,6 +3,32 @@ ALE reStructuredText Integration                 *ale-restructuredtext-options*
 
 
 ===============================================================================
+rstcheck                                        *ale-restructuredtext-rstcheck*
+
+To use the rstcheck linter, install it according to the instruction at
+https://github.com/myint/rstcheck
+
+g:ale_rst_rstcheck_options                        *g:ale_rst_rstcheck_options*
+                                                  *b:ale_rst_rstcheck_options*
+  Type: |String|
+  Default: `''`
+
+  Additional options to pass to `rstcheck`. For example, `--debug` will print
+  the config file that `rstcheck` uses (see below).
+
+
+g:ale_rst_rstcheck_use_project_config  *g:ale_rst_rstcheck_use_project_config*
+                                       *b:ale_rst_rstcheck_use_project_config*
+  Type: |Number|
+  Default: `1`
+
+  If set to `1`, search for a `rstcheck` config file `.rstcheck.cfg` or
+  `setup.cfg` by traversing up from the location of the current buffer. This
+  requires `rstcheck` in a version > 3.3.1. If set to 0, no project config
+  file will be used.
+
+
+===============================================================================
 textlint                                        *ale-restructuredtext-textlint*
 
 To use textlint at reStructuredText, please install `textlint-plugin-rst`.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2096,6 +2096,7 @@ documented in additional help files.
     ols...................................|ale-reasonml-ols|
     refmt.................................|ale-reasonml-refmt|
   restructuredtext........................|ale-restructuredtext-options|
+    rstcheck..............................|ale-restructuredtext-rstcheck|
     textlint..............................|ale-restructuredtext-textlint|
     write-good............................|ale-restructuredtext-write-good|
   ruby....................................|ale-ruby-options|


### PR DESCRIPTION
The --config option is set to the original location of the rst file that
is being linted. This means that `rstcheck` will search for a config
file walking up from that location, instead of the location of the
temporary file that ALE generates.

Closes #2408. The resolution is based on recent changes in `rstcheck`,
cf. https://github.com/myint/rstcheck/issues/56.
There is a new option `g:ale_rst_rstcheck_use_project_config` that
enables this feature. This is so that anyone using an older
version <= 3.3.1 of `rstcheck`, which does not have the `--config`
options, is still able to run the linter. Since
https://github.com/myint/rstcheck/pull/57 has been merged,
any newer version of `rstcheck` should work out of the box.

The value `g:ale_rst_rstcheck_use_project_config` is 1 ("on") by
default, because I think people would generally expect their project
configuration to be taken into account in the default configuration.

A new option `g:ale_rst_rstcheck_options` is also provided. This
closes #2144. However, the main intended useage of this option is to
pass `--debug` to `rstcheck` (showing which config file is being used).

The documentation has been updated with a new
`ale-restructuredtext-rstcheck` section.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
