### PR TITLE
Support 'python -m mypy'

### DIFF
--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -37,8 +37,9 @@ function! ale_linters#python#mypy#GetCommand(buffer) abort
     " we can know with certainty the base path for the 'filename' keys below.
     return ale#path#CdString(l:dir)
     \   . ale#Escape(l:executable) . l:exec_args
-    \   . ' --show-column-numbers '
+    \   . ' '
     \   . ale#Var(a:buffer, 'python_mypy_options')
+    \   . ' --show-column-numbers'
     \   . ' --shadow-file %s %t %s'
 endfunction
 


### PR DESCRIPTION
## Issue

If we above make setting as below,

```
let g:ale_python_mypy_executable = 'python' 
let g:ale_python_mypy_args = '-m mypy'
```

it could not work well because the constructed command is `python --show-column-numbers -m mypy {user options} ...`.

I got like below.

```
$ python --show-column-numbers -m mypy foo.py
unknown option --show-column-numbers
usage: C:\Software\Python\python-3.7.2\python.exe [option] ... [-c cmd | -m mod | file | -] [arg] ...
Try `python -h' for more information.
```

with
OS : Windows10
Vim : 8.1
python : 3.7.2

I tested fixed code works well with above global options (sorry, I couldn't come up with the test for this situation) .
