### PR TITLE
Implement ability to disable rules for LanguageTool.

### DIFF
--- a/autoload/ale/handlers/languagetool.vim
+++ b/autoload/ale/handlers/languagetool.vim
@@ -3,14 +3,22 @@
 "
 call ale#Set('languagetool_executable', 'languagetool')
 
+function! ale#handlers#languagetool#ResetOptions() abort
+    call ale#Set('languagetool_disable_rules', '')
+    call ale#Set('languagetool_executable', 'languagetool')
+endfunction
+
 function! ale#handlers#languagetool#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'languagetool_executable')
 endfunction
 
 function! ale#handlers#languagetool#GetCommand(buffer) abort
     let l:executable = ale#handlers#languagetool#GetExecutable(a:buffer)
+    let l:disabled_rules = ale#Var(a:buffer, 'languagetool_disable_rules')
 
-    return ale#Escape(l:executable) . ' --autoDetect %s'
+    return ale#Escape(l:executable)
+    \   . (!empty(l:disabled_rules) ? ' -d ' . l:disabled_rules : '')
+    \   . ' --autoDetect %s'
 endfunction
 
 function! ale#handlers#languagetool#HandleOutput(buffer, lines) abort

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1846,7 +1846,16 @@ g:ale_languagetool_executable                   *g:ale_languagetool_executable*
 
   The executable to run for languagetool.
 
+g:ale_languagetool_disable_rules                *g:ale_languagetool_disable_rules*
+                                                *b:ale_languagetool_disable_rules*
+  Type: |String|
+  Default: `''`
 
+  Comma-separated list of LanguageTool rules that should be disabled.
+
+  For example:
+>
+  let g:ale_languagetool_disable_rules = 'DASH_RULE,EN_QUOTES'
 -------------------------------------------------------------------------------
 7.3. Options for write-good                            *ale-write-good-options*
 

--- a/test/command_callback/test_languagetool_command_callback.vader
+++ b/test/command_callback/test_languagetool_command_callback.vader
@@ -1,12 +1,26 @@
 Before:
     call ale#assert#SetUpLinterTest('text', 'languagetool')
 
+    Save g:ale_languagetool_executable
+    Save g:ale_languagetool_disable_rules
+
+    unlet! g:ale_languagetool_disable_rules
+    unlet! g:ale_languagetool_executable
+
+    call ale#handlers#languagetool#ResetOptions()
 After:
     call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
   AssertLinter 'languagetool', ale#Escape('languagetool')
   \ . ' --autoDetect %s'
+
+Execute(The disabled rules should be used in the command):
+  let g:ale_languagetool_disable_rules = 'DASH_RULE,EN_QUOTES'
+
+  AssertLinter
+  \ 'languagetool',
+  \ ale#Escape('languagetool') . ' -d ' . 'DASH_RULE,EN_QUOTES --autoDetect %s',
 
 Execute(Should be able to set a custom executable):
   let g:ale_languagetool_executable = 'foobar'


### PR DESCRIPTION
This adds the `g:ale_languagetool_disable_rules` to be able to pass a comma-separated list of rules to disable.

I've also added some clean up in the associated Vader file so the options are reset between testing runs. I'm not very familiar with Vader, but the tests weren't passing without this and I looked at the write-good tests as an example.

Also, sorry for the incorrect title of the PR initially; I was using `hub` and closed the editor by accident before I managed to edit it. :roll_eyes: 