### PR TITLE
WIP: Lint on FocusGained/VimResume

### DIFF
--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -92,6 +92,11 @@ function! ale#events#FileChangedEvent(buffer) abort
     endif
 endfunction
 
+function! ale#events#FocusGained(buffer) abort
+    call setbufvar(a:buffer, 'force_changedtick', 1)
+    call ale#Queue(0, 'lint_file', a:buffer)
+endfunction
+
 function! ale#events#Init() abort
     " This value used to be a Boolean as a Number, and is now a String.
     let l:text_changed = '' . g:ale_lint_on_text_changed
@@ -125,6 +130,19 @@ function! ale#events#Init() abort
                 \   str2nr(expand('<abuf>')),
                 \   expand('<amatch>')
                 \)
+            endif
+
+            if g:ale_lint_on_focus_gained
+                if exists('##FocusGained')
+                    autocmd FocusGained * call ale#events#FocusGained(
+                    \   str2nr(expand('<abuf>'))
+                    \)
+                endif
+                if exists('##VimResume')
+                    autocmd VimResume * call ale#events#FocusGained(
+                    \   str2nr(expand('<abuf>'))
+                    \)
+                endif
             endif
 
             if g:ale_lint_on_insert_leave

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -492,8 +492,10 @@ function! ale#lsp#NotifyForChanges(conn_id, buffer) abort
 
     if !empty(l:conn) && has_key(l:conn.open_documents, a:buffer)
         let l:new_tick = getbufvar(a:buffer, 'changedtick')
+        let l:force = getbufvar(a:buffer, 'force_changedtick', 0)
 
-        if l:conn.open_documents[a:buffer] < l:new_tick
+        if l:conn.open_documents[a:buffer] < l:new_tick || l:force
+            call setbufvar(a:buffer, 'force_changedtick', 0)
             if l:conn.is_tsserver
                 let l:message = ale#lsp#tsserver_message#Change(a:buffer)
             else

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -87,6 +87,9 @@ let g:ale_lint_on_save = get(g:, 'ale_lint_on_save', 1)
 " This flag can be set to 1 to enable linting when the filetype is changed.
 let g:ale_lint_on_filetype_changed = get(g:, 'ale_lint_on_filetype_changed', 1)
 
+" This flag can be set to 1 to enable linting when vim gains focus.
+let g:ale_lint_on_focus_gained = get(g:, 'ale_lint_on_focus_gained', 1)
+
 " This Dictionary configures the default LSP roots for various linters.
 let g:ale_lsp_root = get(g:, 'ale_lsp_root', {})
 


### PR DESCRIPTION
This PR allows to configure ALE to lint when vim gains focus or is resumed after
being suspended (C-z and then `fg` command).

The motivation for this is that some linters do not watch all needed resources
(build artifacts) and thus they require to be nudged after those are changed.
The good way I found is to do that when you switch back to an editor.

Example workflow:

1. Work in vim, do some edits
2. Switch to terminal and run build process so it does some updates to build
   artifacts
3. Switch back to an editor. This is the point where I want to see updated
   diagnostics for the buffer but right now I have to save buffer manually so it
   triggers the lint (and didSave event for an LSP). With with PR vim sends
   didChange event to LSP / requests lints automatically when I switch to back
   to it.

Not that for this to work with tmux one must set
```
set -g focus-events on
```
in their `tmux.conf`.

Note also that I've added `b:force_changedtick` which forces to send LSP didChange event even if there were no changes.