### PR TITLE
Fix cflags parsing (#2510, #2265)

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -89,7 +89,7 @@ function! ale#c#ParseCFlags(path_prefix, cflag_line) abort
                 let l:option_index = l:option_index + 1
             endif
             " Fix relative paths if needed
-            if stridx(l:arg, s:sep) != 0
+            if stridx(l:arg, s:sep) != 0 && stridx(l:arg, '/') != 0
                 let l:rel_path = substitute(l:arg, '"', '', 'g')
                 let l:rel_path = substitute(l:rel_path, '''', '', 'g')
                 let l:arg = ale#Escape(a:path_prefix . s:sep . l:rel_path)

--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -76,6 +76,7 @@ function! ale#c#ParseCFlags(path_prefix, cflag_line) abort
         let l:option = l:split_lines[l:option_index]
         let l:option_index = l:option_index + 1
 
+        " Include options, that may need relative path fix
         if stridx(l:option, '-I') == 0 ||
                     \ stridx(l:option, '-iquote') == 0 ||
                     \ stridx(l:option, '-isystem') == 0 ||
@@ -95,17 +96,23 @@ function! ale#c#ParseCFlags(path_prefix, cflag_line) abort
             endif
             call add(l:cflags_list, l:option)
             call add(l:cflags_list, l:arg)
+
+        " Options with arg that can be grouped with the option or separate
         elseif stridx(l:option, '-D') == 0 || stridx(l:option, '-B') == 0
             call add(l:cflags_list, l:option)
             if l:option is# '-D' || l:option is# '-B'
                 call add(l:cflags_list, l:split_lines[l:option_index])
                 let l:option_index = l:option_index + 1
             endif
+
+        " Options that have an argument (always separate)
         elseif l:option is# '-iprefix' || stridx(l:option, '-iwithprefix') == 0 ||
                     \ l:option is# '-isysroot' || l:option is# '-imultilib'
             call add(l:cflags_list, l:option)
             call add(l:cflags_list, l:split_lines[l:option_index])
             let l:option_index = l:option_index + 1
+
+        " Options without argument
         elseif (stridx(l:option, '-W') == 0 && stridx(l:option, '-Wa,') != 0 && stridx(l:option, '-Wl,') != 0 && stridx(l:option, '-Wp,') != 0) ||
 					\ l:option is '-w' || stridx(l:option, '-pedantic') == 0 ||
 					\ l:option is# '-ansi' || stridx(l:option, '-std=') == 0 ||

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -321,3 +321,37 @@ Execute(ParseCFlags should handle parenthesis and quotes):
   \     . '-Dtest2=''(` `)'' file2.o '
   \     . '-Dtest3=`(" ")` file3.o '
   \ )
+
+Execute(CFlags we want to pass):
+  AssertEqual
+  \ '-I ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/inc'))
+  \ . ' -I ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/include'))
+  \ . ' -iquote ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incquote'))
+  \ . ' -isystem ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incsystem'))
+  \ . ' -idirafter ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incafter'))
+  \ . ' -Dmacro=value -D macro2 -Bbdir -B bdir2'
+  \ . ' -iprefix prefix -iwithprefix prefix2 -iwithprefixbefore prefix3'
+  \ . ' -isysroot sysroot --sysroot=test --no-sysroot-suffix -imultilib multidir'
+  \ . ' -Wsome-warning -std=c89 -pedantic -pedantic-errors -ansi'
+  \ . ' -foption -O2 -C -CC -trigraphs -nostdinc -nostdinc++'
+  \ . ' -iplugindir=dir -march=native -w',
+  \ ale#c#ParseCFlags(
+  \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
+  \   'gcc'
+  \ . ' -Iinc -I include -iquote incquote -isystem incsystem -idirafter incafter'
+  \ . ' -Dmacro=value -D macro2 -Bbdir -B bdir2'
+  \ . ' -iprefix prefix -iwithprefix prefix2 -iwithprefixbefore prefix3'
+  \ . ' -isysroot sysroot --sysroot=test --no-sysroot-suffix -imultilib multidir'
+  \ . ' -Wsome-warning -std=c89 -pedantic -pedantic-errors -ansi'
+  \ . ' -foption -O2 -C -CC -trigraphs -nostdinc -nostdinc++'
+  \ . ' -iplugindir=dir -march=native -w'
+  \ )
+
+Execute(CFlags we dont want to pass):
+  AssertEqual
+  \ '',
+  \ ale#c#ParseCFlags(
+  \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
+  \   'gcc -Wl,option -Wa,option -Wp,option filename.c somelib.a '
+  \ . '-fdump-file=name -fdiagnostics-arg -fno-show-column'
+  \ )

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -14,25 +14,14 @@ Execute(The CFlags parser should be able to parse include directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'),
+  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')),
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c'])
-
-  AssertEqual
-  \ '-isystem ' . '/usr/include/dir',
-  \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -isystem /usr/include/dir -c file.c'])
-
-Execute(ParseCFlags should ignore -c and -o):
-  call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
-
-  AssertEqual
-  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'),
-  \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c -o a.out'])
 
 Execute(The CFlags parser should be able to parse macro directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -DTEST=1',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=1 -c file.c'])
 
@@ -40,7 +29,7 @@ Execute(The CFlags parser should be able to parse macro directives with spaces):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -DTEST=$(( 2 * 4 ))',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=$(( 2 * 4 )) -c file.c'])
 
@@ -48,14 +37,14 @@ Execute(The CFlags parser should be able to parse shell directives with spaces):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   .  ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=`date +%s` -c file.c'])
 
 Execute(ParseCFlags should be able to parse flags with relative paths):
   AssertEqual
-  \ '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
+  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -67,8 +56,8 @@ Execute(ParseCFlags should be able to parse flags with relative paths):
 Execute(ParseCFlags should be able to parse -Dgoal):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -77,16 +66,29 @@ Execute(ParseCFlags should be able to parse -Dgoal):
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
 
-Execute(ParseCFlags should handle paths with spaces in double quotes):
+Execute(ParseCFlags should ignore -T and other arguments):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/"dir with spaces"')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Isubdir '
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir --sysroot=subdir '
+  \     .  '-I'. ale#path#Simplify('kernel/include')
+  \     .  ' -DTEST=`date +%s` -c file.c'
+  \ )
+
+Execute(ParseCFlags should handle paths with spaces in double quotes):
+  AssertEqual
+  \ '-Dgoal=9'
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' -DTEST=`date +%s`',
+  \ ale#c#ParseCFlags(
+  \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
   \     . '-I"dir with spaces"' . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
@@ -94,28 +96,29 @@ Execute(ParseCFlags should handle paths with spaces in double quotes):
 Execute(ParseCFlags should handle paths with spaces in single quotes):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. "/test_c_projects/makefile_project/'dir with spaces'")
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Isubdir '
-  \     . "-I'dir with spaces'" . ' -I'. ale#path#Simplify('kernel/include')
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
+  \     . '-I''dir with spaces''' . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
 
 Execute(ParseCFlags should handle paths with minuses):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Isubdir '
-  \     . ' -Idir-with-dash'
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
+  \     . '-I''dir with spaces''' . ' -Idir-with-dash'
   \     . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
@@ -123,14 +126,17 @@ Execute(ParseCFlags should handle paths with minuses):
 Execute(ParseCFlags should handle -D with minuses):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -Dmacro-with-dash'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Isubdir '
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
   \     . '-Dmacro-with-dash '
+  \     . '-I''dir with spaces''' . ' -Idir-with-dash'
   \     . ' -I'. ale#path#Simplify('kernel/include')
   \     . ' -DTEST=`date +%s` -c file.c'
   \ )
@@ -138,11 +144,16 @@ Execute(ParseCFlags should handle -D with minuses):
 Execute(ParseCFlags should handle flags at the end of the line):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')
-  \   . ' ' . '-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'),
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' -Dmacro-with-dash'
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 -Isubdir '
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
+  \     . '-Dmacro-with-dash '
+  \     . '-I''dir with spaces''' . ' -Idir-with-dash'
   \     . ' -I'. ale#path#Simplify('kernel/include')
   \ )
 
@@ -156,14 +167,14 @@ Execute(ParseCompileCommandsFlags should parse some basic flags):
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
-  \ '-I/usr/include/xmms2',
+  \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
   \ ale#c#ParseCompileCommandsFlags(bufnr(''), { "xmms2-mpris.c": [
   \   {
-  \     'directory': '/foo/bar/xmms2-mpris',
-  \     'command': '/usr/bin/cc  -I' . '/usr/include/xmms2'
+  \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
+  \     'command': '/usr/bin/cc  -I' . ale#path#Simplify('/usr/include/xmms2')
   \       . '    -o CMakeFiles/xmms2-mpris.dir/src/xmms2-mpris.c.o'
-  \       . '   -c ' . '/foo/bar/xmms2-mpris/src/xmms2-mpris.c',
-  \     'file': '/foo/bar/xmms2-mpris/src/xmms2-mpris.c',
+  \       . '   -c ' . ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'),
+  \     'file': ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'),
   \   },
   \ ] }, {})
 
@@ -183,14 +194,14 @@ Execute(ParseCompileCommandsFlags should fall back to files in the same director
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
-  \ '-I/usr/include/xmms2',
+  \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
   \ ale#c#ParseCompileCommandsFlags(bufnr(''), {}, { "src": [
   \   {
-  \     'directory': '/foo/bar/xmms2-mpris',
-  \     'command': '/usr/bin/cc  -I' . '/usr/include/xmms2'
+  \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
+  \     'command': '/usr/bin/cc  -I' . ale#path#Simplify('/usr/include/xmms2')
   \       . '    -o CMakeFiles/xmms2-mpris.dir/src/xmms2-mpris.c.o'
-  \       . '   -c ' . '/foo/bar/xmms2-mpris/src/xmms2-mpris.c',
-  \     'file': (has('win32') ? 'C:' : '') . '/foo/bar/xmms2-mpris/src/xmms2-other.c',
+  \       . '   -c ' . ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'),
+  \     'file': ale#path#Simplify((has('win32') ? 'C:' : '') . '/foo/bar/xmms2-mpris/src/xmms2-other.c'),
   \   },
   \ ] })
 
@@ -280,14 +291,30 @@ Execute(ParseCompileCommandsFlags should not take commands from .c files for .h 
   \   },
   \   {
   \   },
+
+Execute(ParseCFlags should not merge flags):
+  AssertEqual
+  \ '-Dgoal=9'
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
+  \ ale#c#ParseCFlags(
+  \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
+  \     . 'subdir/somedep1.o ' . 'subdir/somedep2.o '
+  \     . '-I''dir with spaces''' . ' -Idir-with-dash '
+  \     . 'subdir/somedep3.o ' . 'subdir/somedep4.o '
+  \     . ' -I'. ale#path#Simplify('kernel/include') . ' '
+  \     . 'subdir/somedep5.o ' . 'subdir/somedep6.o '
   \ )
 
 Execute(ParseCFlags should handle parenthesis and quotes):
   AssertEqual
-  \ '-Dgoal=9 -Dtest1="('' '')" file1.o -Dtest2=''(` `)'' file2.o -Dtest3=`(" ")` file3.o',
+  \ '-Dgoal=9 -Dtest1="('' '')" -Dtest2=''(` `)'' -Dtest3=`(" ")`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
-  \   'gcc -Dgoal=9 '
+  \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla '
   \     . '-Dtest1="('' '')" file1.o '
   \     . '-Dtest2=''(` `)'' file2.o '
   \     . '-Dtest3=`(" ")` file3.o '

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -14,14 +14,14 @@ Execute(The CFlags parser should be able to parse include directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')),
+  \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')),
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c'])
 
 Execute(The CFlags parser should be able to parse macro directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -DTEST=1',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=1 -c file.c'])
 
@@ -29,7 +29,7 @@ Execute(The CFlags parser should be able to parse macro directives with spaces):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -DTEST=$(( 2 * 4 ))',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=$(( 2 * 4 )) -c file.c'])
 
@@ -37,14 +37,14 @@ Execute(The CFlags parser should be able to parse shell directives with spaces):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   .  ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -DTEST=`date +%s` -c file.c'])
 
 Execute(ParseCFlags should be able to parse flags with relative paths):
   AssertEqual
-  \ ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -56,8 +56,8 @@ Execute(ParseCFlags should be able to parse flags with relative paths):
 Execute(ParseCFlags should be able to parse -Dgoal):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -69,8 +69,9 @@ Execute(ParseCFlags should be able to parse -Dgoal):
 Execute(ParseCFlags should ignore -T and other arguments):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '--sysroot=subdir'
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -82,9 +83,9 @@ Execute(ParseCFlags should ignore -T and other arguments):
 Execute(ParseCFlags should handle paths with spaces in double quotes):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -96,9 +97,9 @@ Execute(ParseCFlags should handle paths with spaces in double quotes):
 Execute(ParseCFlags should handle paths with spaces in single quotes):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -110,10 +111,10 @@ Execute(ParseCFlags should handle paths with spaces in single quotes):
 Execute(ParseCFlags should handle paths with minuses):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -126,11 +127,11 @@ Execute(ParseCFlags should handle paths with minuses):
 Execute(ParseCFlags should handle -D with minuses):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -Dmacro-with-dash'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include'))
   \   . ' -DTEST=`date +%s`',
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
@@ -144,11 +145,11 @@ Execute(ParseCFlags should handle -D with minuses):
 Execute(ParseCFlags should handle flags at the end of the line):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
   \   . ' -Dmacro-with-dash'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
   \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '
@@ -167,7 +168,7 @@ Execute(ParseCompileCommandsFlags should parse some basic flags):
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
-  \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
+  \ '-I ' . ale#path#Simplify('/usr/include/xmms2'),
   \ ale#c#ParseCompileCommandsFlags(bufnr(''), { "xmms2-mpris.c": [
   \   {
   \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
@@ -194,7 +195,7 @@ Execute(ParseCompileCommandsFlags should fall back to files in the same director
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.c'))
 
   AssertEqual
-  \ '-I' . ale#path#Simplify('/usr/include/xmms2'),
+  \ '-I ' . ale#path#Simplify('/usr/include/xmms2'),
   \ ale#c#ParseCompileCommandsFlags(bufnr(''), {}, { "src": [
   \   {
   \     'directory': ale#path#Simplify('/foo/bar/xmms2-mpris'),
@@ -209,7 +210,7 @@ Execute(ParseCompileCommandsFlags should take commands from matching .c files fo
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.h'))
 
   AssertEqual
-  \ '-I/usr/include/xmms2',
+  \ '-I /usr/include/xmms2',
   \ ale#c#ParseCompileCommandsFlags(
   \   bufnr(''),
   \   {
@@ -231,7 +232,7 @@ Execute(ParseCompileCommandsFlags should take commands from matching .cpp files 
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.hpp'))
 
   AssertEqual
-  \ '-I/usr/include/xmms2',
+  \ '-I /usr/include/xmms2',
   \ ale#c#ParseCompileCommandsFlags(
   \   bufnr(''),
   \   {
@@ -253,7 +254,7 @@ Execute(ParseCompileCommandsFlags should take commands from matching .cpp files 
   silent noautocmd execute 'file! ' . fnameescape(ale#path#Simplify('/foo/bar/xmms2-mpris/src/xmms2-mpris.h'))
 
   AssertEqual
-  \ '-I/usr/include/xmms2',
+  \ '-I /usr/include/xmms2',
   \ ale#c#ParseCompileCommandsFlags(
   \   bufnr(''),
   \   {
@@ -291,14 +292,15 @@ Execute(ParseCompileCommandsFlags should not take commands from .c files for .h 
   \   },
   \   {
   \   },
+  \ )
 
 Execute(ParseCFlags should not merge flags):
   AssertEqual
   \ '-Dgoal=9'
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
-  \   . ' ' . ale#Escape('-I' . ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir with spaces'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/dir-with-dash'))
+  \   . ' ' . '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/kernel/include')),
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
   \   'gcc -Dgoal=9 -Tlinkerfile.ld blabla -Isubdir '

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -17,6 +17,17 @@ Execute(The CFlags parser should be able to parse include directives):
   \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')),
   \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c'])
 
+  AssertEqual
+  \ '-isystem ' . '/usr/include/dir',
+  \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -isystem /usr/include/dir -c file.c'])
+
+Execute(ParseCFlags should ignore -c and -o):
+  call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
+
+  AssertEqual
+  \ '-I' . ' ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/subdir')),
+  \ ale#c#ParseCFlagsFromMakeOutput(bufnr(''), ['gcc -Isubdir -c file.c -o a.out'])
+
 Execute(The CFlags parser should be able to parse macro directives):
   call ale#test#SetFilename('test_c_projects/makefile_project/subdir/file.c')
 


### PR DESCRIPTION
This PR fixes the cflags parsing problem I had in #2510: some filenames were passed as arguments. I believe it should fix #2265 as well.

1) The splitting is now done in ale#c#ShellSplit, which is intended to split the command line closely to how a shell would do.
2) Flags are selected following a whitelist of arguments. I went through GCC's man page to select which flags made sense to be parsed. I believe the others either don't need to be passed for syntax checking or cannot be passed (because of output files or non-wanted behaviour).
3) Added two tests for flags we want or don't want to be passed.

Ping for testing: @0mco @davidvandebunte @ranebrown