### PR TITLE
Fix crystal-lang non file-tied message handling

### DIFF
--- a/ale_linters/crystal/crystal.vim
+++ b/ale_linters/crystal/crystal.vim
@@ -5,6 +5,10 @@ function! ale_linters#crystal#crystal#Handle(buffer, lines) abort
     let l:output = []
 
     for l:error in ale#util#FuzzyJSONDecode(a:lines, [])
+        if !has_key(l:error, 'file')
+            continue
+        endif
+
         call add(l:output, {
         \   'lnum': l:error.line + 0,
         \   'col': l:error.column + 0,

--- a/test/handler/test_crystal_handler.vader
+++ b/test/handler/test_crystal_handler.vader
@@ -16,3 +16,13 @@ Execute(The crystal handler should parse lines correctly and add the column if i
   \ ale_linters#crystal#crystal#Handle(255, [
   \ '[{"file":"/tmp/test.cr","line":2,"column":1,"size":null,"message":"unexpected token: EOF"}]'
   \ ])
+
+Execute(The crystal handler should not fail when a missing file is required):
+  AssertEqual
+  \ [ { 'lnum':1, 'col': 1, 'text': 'while requiring "./nonexistent.cr"' } ],
+  \ ale_linters#crystal#crystal#Handle(255,
+  \ json_encode([
+  \ { "file":"/tmp/file.cr","line":1,"column":1,"size":0,"message":"while requiring \"./nonexistent.cr\"" },
+  \ { "message": "can't find file './nonexistent.cr' relative to '/tmp'" },
+  \ ])
+  \ )


### PR DESCRIPTION
Some messages of the crystal compiler are not tied to a file.
This causes a 'Key not present in Dictionnary' error (E716).
For the record, the json output on ```require "./nonexistent.cr"```
is the following :
```json
  [
  { "file":"/tmp/file.cr", "line":1, "column":1, "size":0,
    "message":"while requiring \"./nonexistent.cr\"" },
  { "message":"can't find file './nonexistent.cr' relative to '/tmp'" }
  ]
```
The second message does not have line/column attributes.