### PR TITLE
Add asyncomplete.vim Support

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -269,7 +269,7 @@ function! ale#completion#Show(result) abort
 endfunction
 
 function! ale#completion#GetAllTriggers() abort
-    return s:trigger_character_map
+    return deepcopy(s:trigger_character_map)
 endfunction
 
 function! s:CompletionStillValid(request_id) abort

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -262,6 +262,24 @@ function! ale#completion#Show(result) abort
         \   {-> ale#util#FeedKeys("\<Plug>(ale_show_completion_menu)")}
         \)
     endif
+
+    if l:source is# 'ale-callback'
+        call ale#completion#CallbackComplete()
+    endif
+endfunction
+
+function! ale#completion#CallbackComplete() abort
+    call b:asyncomplete_callback(b:ale_completion_result)
+endfunction
+
+function! ale#completion#GetAllTriggers() abort
+    return s:trigger_character_map
+endfunction
+
+function! ale#completion#RequestCallbackCompletions(callback) abort
+    let b:asyncomplete_callback = a:callback
+
+    call ale#completion#GetCompletions('ale-callback')
 endfunction
 
 function! s:CompletionStillValid(request_id) abort
@@ -275,6 +293,7 @@ function! s:CompletionStillValid(request_id) abort
     \   b:ale_completion_info.column == l:column
     \   || b:ale_completion_info.source is# 'deoplete'
     \   || b:ale_completion_info.source is# 'ale-omnifunc'
+    \   || b:ale_completion_info.source is# 'ale-callback'
     \)
 endfunction
 

--- a/autoload/asyncomplete/sources/ale.vim
+++ b/autoload/asyncomplete/sources/ale.vim
@@ -5,6 +5,7 @@ function! asyncomplete#sources#ale#get_source_options(...) abort
     \     'whitelist': ['*'],
     \     'triggers': asyncomplete#sources#ale#get_triggers(),
     \ }, a:0 >= 1 ? a:1 : {})
+
     return extend(l:default, {'refresh_pattern': '\k\+$'})
 endfunction
 

--- a/autoload/asyncomplete/sources/ale.vim
+++ b/autoload/asyncomplete/sources/ale.vim
@@ -15,10 +15,9 @@ function! asyncomplete#sources#ale#get_triggers() abort
     return l:triggers
 endfunction
 
-function! asyncomplete#sources#ale#completor(opts, ctx) abort
-    let l:kw = matchstr(a:ctx.typed, '\w\+$')
-    let l:kwlen = len(l:kw)
-    let l:startcol = a:ctx.col - l:kwlen
+function! asyncomplete#sources#ale#completor(options, context) abort
+    let l:keyword = matchstr(a:context.typed, '\w\+$')
+    let l:startcol = a:context.col - len(l:keyword)
 
     call ale#completion#GetCompletions('ale-callback', { 'callback': {completions ->
     \   asyncomplete#complete(a:options.name, a:context, l:startcol, completions)

--- a/autoload/asyncomplete/sources/ale.vim
+++ b/autoload/asyncomplete/sources/ale.vim
@@ -19,7 +19,7 @@ function! asyncomplete#sources#ale#completor(opts, ctx) abort
     let l:kwlen = len(l:kw)
     let l:startcol = a:ctx.col - l:kwlen
 
-    call ale#completion#RequestCallbackCompletions({completions ->
-    \   asyncomplete#complete(a:opts.name, a:ctx, l:startcol, completions)
-    \ })
+    call ale#completion#GetCompletions('ale-callback', { 'callback': {completions ->
+    \   asyncomplete#complete(a:options.name, a:context, l:startcol, completions)
+    \ }})
 endfunction

--- a/autoload/asyncomplete/sources/ale.vim
+++ b/autoload/asyncomplete/sources/ale.vim
@@ -1,10 +1,11 @@
 function! asyncomplete#sources#ale#get_source_options(...) abort
-    return extend(extend({
+    let l:default = extend({
     \     'name': 'ale',
     \     'completor': function('asyncomplete#sources#ale#completor'),
     \     'whitelist': ['*'],
     \     'triggers': asyncomplete#sources#ale#get_triggers(),
-    \ }, a:0 >= 1 ? a:1 : {}), {'refresh_pattern': '\k\+$'})
+    \ }, a:0 >= 1 ? a:1 : {})
+    return extend(l:default, {'refresh_pattern': '\k\+$'})
 endfunction
 
 function! asyncomplete#sources#ale#get_triggers() abort

--- a/autoload/asyncomplete/sources/ale.vim
+++ b/autoload/asyncomplete/sources/ale.vim
@@ -1,0 +1,25 @@
+function! asyncomplete#sources#ale#get_source_options(...) abort
+    return extend(extend({
+    \     'name': 'ale',
+    \     'completor': function('asyncomplete#sources#ale#completor'),
+    \     'whitelist': ['*'],
+    \     'triggers': asyncomplete#sources#ale#get_triggers(),
+    \ }, a:0 >= 1 ? a:1 : {}), {'refresh_pattern': '\k\+$'})
+endfunction
+
+function! asyncomplete#sources#ale#get_triggers() abort
+    let l:triggers = ale#completion#GetAllTriggers()
+    let l:triggers['*'] = l:triggers['<default>']
+
+    return l:triggers
+endfunction
+
+function! asyncomplete#sources#ale#completor(opts, ctx) abort
+    let l:kw = matchstr(a:ctx.typed, '\w\+$')
+    let l:kwlen = len(l:kw)
+    let l:startcol = a:ctx.col - l:kwlen
+
+    call ale#completion#RequestCallbackCompletions({completions ->
+    \   asyncomplete#complete(a:opts.name, a:ctx, l:startcol, completions)
+    \ })
+endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -341,6 +341,17 @@ completion source for Deoplete is named `'ale'`, and should enabled
 automatically if Deoplete is enabled and configured correctly. Deoplete
 integration should not be combined with ALE's own implementation.
 
+                                                 *ale-asyncomplete-integration*
+
+ALE additionally integrates with asyncomplete.vim for offering automatic
+completion data. ALE's asyncomplete source requires registration and should
+use the defaults provided by the|asyncomplete#sources#ale#get_source_options| function >
+
+  " Use ALE's function for asyncomplete defaults
+  au User asyncomplete_setup call asyncomplete#register_source(asyncomplete#sources#ale#get_source_options({
+      \ 'priority': 10, " Provide your own overrides here
+      \ }))
+>
 ALE also offers its own completion implementation, which does not require any
 other plugins. Suggestions will be made while you type after completion is
 enabled. ALE's own completion implementation can be enabled by setting

--- a/test/completion/test_completion_events.vader
+++ b/test/completion/test_completion_events.vader
@@ -333,6 +333,27 @@ Execute(b:ale_completion_info should be set up correctly for other sources):
   \ b:ale_completion_info
   Assert !exists('b:ale_completion_result')
 
+Execute(b:ale_completion_info should be set up correctly when requesting completions via callback):
+  let b:ale_completion_result = []
+  call setpos('.', [bufnr(''), 3, 14, 0])
+  function! Callback() abort
+    echo 'Called'
+  endfunction
+  call ale#completion#RequestCallbackCompletions(funcref('Callback'))
+
+  AssertEqual
+  \ {
+  \   'request_id': 0,
+  \   'conn_id': 0,
+  \   'column': 14,
+  \   'line_length': 14,
+  \   'line': 3,
+  \   'prefix': 'ab',
+  \   'source': 'ale-callback',
+  \ },
+  \ b:ale_completion_info
+  Assert !exists('b:ale_completion_result')
+
 Execute(The correct keybinds should be configured):
   redir => g:output
     silent map <Plug>(ale_show_completion_menu)

--- a/test/completion/test_completion_events.vader
+++ b/test/completion/test_completion_events.vader
@@ -61,7 +61,10 @@ After:
   unlet! b:ale_complete_done_time
 
   delfunction CheckCompletionCalled
-  delfunction CompleteCallback
+
+  if exists('*CompleteCallback')
+    delfunction CompleteCallback
+  endif
 
   " Stop any timers we left behind.
   " This stops the tests from failing randomly.
@@ -337,10 +340,13 @@ Execute(b:ale_completion_info should be set up correctly for other sources):
 Execute(b:ale_completion_info should be set up correctly when requesting completions via callback):
   let b:ale_completion_result = []
   call setpos('.', [bufnr(''), 3, 14, 0])
+
   function! CompleteCallback() abort
     echo 'Called'
   endfunction
-  call ale#completion#RequestCallbackCompletions(funcref('CompleteCallback'))
+
+
+  call ale#completion#GetCompletions('ale-callback', {'callback': funcref('CompleteCallback')})
 
   AssertEqual
   \ {

--- a/test/completion/test_completion_events.vader
+++ b/test/completion/test_completion_events.vader
@@ -61,6 +61,7 @@ After:
   unlet! b:ale_complete_done_time
 
   delfunction CheckCompletionCalled
+  delfunction CompleteCallback
 
   " Stop any timers we left behind.
   " This stops the tests from failing randomly.
@@ -336,10 +337,10 @@ Execute(b:ale_completion_info should be set up correctly for other sources):
 Execute(b:ale_completion_info should be set up correctly when requesting completions via callback):
   let b:ale_completion_result = []
   call setpos('.', [bufnr(''), 3, 14, 0])
-  function! Callback() abort
+  function! CompleteCallback() abort
     echo 'Called'
   endfunction
-  call ale#completion#RequestCallbackCompletions(funcref('Callback'))
+  call ale#completion#RequestCallbackCompletions(funcref('CompleteCallback'))
 
   AssertEqual
   \ {


### PR DESCRIPTION
This PR adds support for `asyncomplete.vim`

There may be another, better approach here but it basically works by creating an API for `ALE` to provide completions to other tooling via a callback. This theoretically opens up support for other tools like `ncm2` to also add support for `ALE` in the future with `asyncomplete.vim` being a test case for this approach.

This is _probably_ a rather naive approach and I'm super open to modifying this based on any feedback you might have.

Ref: https://github.com/prabirshrestha/asyncomplete.vim/issues/150