### PR TITLE
Add gnatpp fixer for Ada

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -315,6 +315,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['python'],
 \       'description': 'Sort Python imports with reorder-python-imports.',
 \   },
+\   'gnatpp': {
+\       'function': 'ale#fixers#gnatpp#Fix',
+\       'suggested_filetypes': ['ada'],
+\       'description': 'Format Ada files with gnatpp.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/gnatpp.vim
+++ b/autoload/ale/fixers/gnatpp.vim
@@ -1,0 +1,17 @@
+" Author: tim <tim@inept.tech>
+" Description: Fix files with gnatpp.
+
+call ale#Set('ada_gnatpp_executable', 'gnatpp')
+call ale#Set('ada_gnatpp_options', '')
+
+function! ale#fixers#gnatpp#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ada_gnatpp_executable')
+    let l:options = ale#Var(a:buffer, 'ada_gnatpp_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (!empty(l:options) ? ' ' . l:options : '')
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-ada.txt
+++ b/doc/ale-ada.txt
@@ -22,4 +22,15 @@ g:ale_ada_gcc_options                                   *g:ale_ada_gcc_options*
 
 
 ===============================================================================
+gnatpp                                                         *ale-ada-gnatpp*
+
+g:ale_ada_gnatpp_options                             *g:ale_ada_gnatpp_options*
+                                                     *b:ale_ada_gnatpp_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass extra options to the gnatpp fixer.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -14,6 +14,7 @@ Notes:
 
 * Ada
   * `gcc`
+  * `gnatpp`
 * Ansible
   * `ansible-lint`
 * API Blueprint

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1927,6 +1927,7 @@ documented in additional help files.
 
   ada.....................................|ale-ada-options|
     gcc...................................|ale-ada-gcc|
+    gnatpp................................|ale-ada-gnatpp|
   ansible.................................|ale-ansible-options|
     ansible-lint..........................|ale-ansible-ansible-lint|
   asciidoc................................|ale-asciidoc-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -23,6 +23,7 @@ formatting.
 
 * Ada
   * [gcc](https://gcc.gnu.org)
+  * [gnatpp](https://docs.adacore.com/gnat_ugn-docs/html/gnat_ugn/gnat_ugn/gnat_utility_programs.html#the-gnat-pretty-printer-gnatpp) :floppy_disk:
 * Ansible
   * [ansible-lint](https://github.com/willthames/ansible-lint)
 * API Blueprint

--- a/test/fixers/test_gnatpp_fixer_callback.vader
+++ b/test/fixers/test_gnatpp_fixer_callback.vader
@@ -1,0 +1,28 @@
+Before:
+  call ale#assert#SetUpFixerTest('ada', 'gnatpp')
+
+After:
+  " Reset fixers, variables, etc.
+  "
+  " Vader's 'Restore' command will be called here.
+  call ale#assert#TearDownFixerTest()
+
+Execute(The default command should be correct):
+  call ale#test#SetFilename('../ada_files/testfile.adb')
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape(g:ale_ada_gnatpp_executable) .' %t',
+  \   'read_temporary_file': 1,
+  \ }
+
+Execute(The version check should be correct):
+  call ale#test#SetFilename('../ada_files/testfile.adb')
+  let g:ale_ada_gnatpp_options = '--no-alignment'
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape(g:ale_ada_gnatpp_executable)
+  \     . ' --no-alignment %t',
+  \   'read_temporary_file': 1,
+  \ }


### PR DESCRIPTION
Adds the [`gnatpp`](https://docs.adacore.com/gnat_ugn-docs/html/gnat_ugn/gnat_ugn/gnat_utility_programs.html#the-gnat-pretty-printer-gnatpp) fixer for Ada. Only added simple tests based on what I saw in `:h ale-dev` and other fixers' tests. The tests pass on Linux at the very least.