### PR TITLE
Add setting for numhl highlights

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -83,31 +83,31 @@ execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 sign define ALEDummySign
 
 if has('nvim-0.3.2')
-  if !hlexists('ALEErrorSignLineNr')
-    highlight link ALEErrorSignLineNr CursorLineNr
-  endif
+    if !hlexists('ALEErrorSignLineNr')
+        highlight link ALEErrorSignLineNr CursorLineNr
+    endif
 
-  if !hlexists('ALEStyleErrorSignLineNr')
-    highlight link ALEStyleErrorSignLineNr CursorLineNr
-  endif
+    if !hlexists('ALEStyleErrorSignLineNr')
+        highlight link ALEStyleErrorSignLineNr CursorLineNr
+    endif
 
-  if !hlexists('ALEWarningSignLineNr')
-    highlight link ALEWarningSignLineNr CursorLineNr
-  endif
+    if !hlexists('ALEWarningSignLineNr')
+        highlight link ALEWarningSignLineNr CursorLineNr
+    endif
 
-  if !hlexists('ALEStyleWarningSignLineNr')
-    highlight link ALEStyleWarningSignLineNr CursorLineNr
-  endif
+    if !hlexists('ALEStyleWarningSignLineNr')
+        highlight link ALEStyleWarningSignLineNr CursorLineNr
+    endif
 
-  if !hlexists('ALEInfoSignLineNr')
-    highlight link ALEInfoSignLineNr CursorLineNr
-  endif
+    if !hlexists('ALEInfoSignLineNr')
+        highlight link ALEInfoSignLineNr CursorLineNr
+    endif
 
-  sign define ALEErrorSign numhl=ALEErrorSignLineNr
-  sign define ALEStyleErrorSign numhl=ALEStyleErrorSignLineNr
-  sign define ALEWarningSign numhl=ALEWarningSignLineNr
-  sign define ALEStyleWarningSign numhl=ALEStyleWarningSignLineNr
-  sign define ALEInfoSign numhl=ALEInfoSignLineNr
+    sign define ALEErrorSign numhl=ALEErrorSignLineNr
+    sign define ALEStyleErrorSign numhl=ALEStyleErrorSignLineNr
+    sign define ALEWarningSign numhl=ALEWarningSignLineNr
+    sign define ALEStyleWarningSign numhl=ALEStyleWarningSignLineNr
+    sign define ALEInfoSign numhl=ALEInfoSignLineNr
 endif
 
 function! ale#sign#GetSignName(sublist) abort

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -82,6 +82,34 @@ execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 \   . ' texthl=ALEInfoSign linehl=ALEInfoLine'
 sign define ALEDummySign
 
+if has('nvim-0.3.2')
+  if !hlexists('ALEErrorSignLineNr')
+    highlight link ALEErrorSignLineNr CursorLineNr
+  endif
+
+  if !hlexists('ALEStyleErrorSignLineNr')
+    highlight link ALEStyleErrorSignLineNr CursorLineNr
+  endif
+
+  if !hlexists('ALEWarningSignLineNr')
+    highlight link ALEWarningSignLineNr CursorLineNr
+  endif
+
+  if !hlexists('ALEStyleWarningSignLineNr')
+    highlight link ALEStyleWarningSignLineNr CursorLineNr
+  endif
+
+  if !hlexists('ALEInfoSignLineNr')
+    highlight link ALEInfoSignLineNr CursorLineNr
+  endif
+
+  sign define ALEErrorSign numhl=ALEErrorSignLineNr
+  sign define ALEStyleErrorSign numhl=ALEStyleErrorSignLineNr
+  sign define ALEWarningSign numhl=ALEWarningSignLineNr
+  sign define ALEStyleWarningSign numhl=ALEStyleWarningSignLineNr
+  sign define ALEInfoSign numhl=ALEInfoSignLineNr
+endif
+
 function! ale#sign#GetSignName(sublist) abort
     let l:priority = g:ale#util#style_warning_priority
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1775,7 +1775,7 @@ ALEStyleErrorSign                                           *ALEStyleErrorSign*
   The highlight for style error signs. See |g:ale_set_signs|.
 
 
-ALEStyleErrorSignLineNr                                    *ALEErrorSignLineNr*
+ALEStyleErrorSignLineNr                               *ALEStyleErrorSignLineNr*
 
   Default: `highlight link ALEStyleErrorSignLineNr CursorLineNr`
 
@@ -1798,7 +1798,7 @@ ALEStyleWarningSign                                       *ALEStyleWarningSign*
   The highlight for style warning signs. See |g:ale_set_signs|.
 
 
-ALEStyleWarningSignLineNr                                  *ALEErrorSignLineNr*
+ALEStyleWarningSignLineNr                           *ALEStyleWarningSignLineNr*
 
   Default: `highlight link ALEStyleWarningSignLineNr CursorLineNr`
 
@@ -1866,7 +1866,7 @@ ALEWarningSign                                                 *ALEWarningSign*
   The highlight for warning signs. See |g:ale_set_signs|.
 
 
-ALEWarningSignLineNr                                       *ALEErrorSignLineNr*
+ALEWarningSignLineNr                                     *ALEWarningSignLineNr*
 
   Default: `highlight link ALEWarningSignLineNr CursorLineNr`
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1426,6 +1426,15 @@ g:ale_set_signs                                               *g:ale_set_signs*
   |ALEWarningLine| - All items with `'type': 'W'`
   |ALEInfoLine|    - All items with `'type': 'I'`
 
+  With Neovim 0.3.2 or higher, ALE uses `numhl` option to highlight 'number'
+  column. It uses the following highlight groups.
+
+  |ALEErrorSignLineNr|        - Items with `'type': 'E'`
+  |ALEWarningSignLineNr|      - Items with `'type': 'W'`
+  |ALEInfoSignLineNr|         - Items with `'type': 'I'`
+  |ALEStyleErrorSignLineNr|   - Items with `'type': 'E'` and `'sub_type': 'style'`
+  |ALEStyleWarningSignLineNr| - Items with `'type': 'W'` and `'sub_type': 'style'`
+
   The markers for the highlights can be customized with the following options:
 
   |g:ale_sign_error|
@@ -1710,6 +1719,15 @@ ALEErrorSign                                                     *ALEErrorSign*
   The highlight for error signs. See |g:ale_set_signs|.
 
 
+ALEErrorSignLineNr                                         *ALEErrorSignLineNr*
+
+  Default: `highlight link ALEErrorSignLineNr CursorLineNr`
+
+  The highlight for error signs. See |g:ale_set_signs|.
+
+  NOTE: This highlight is only available on Neovim 0.3.2 or higher.
+
+
 ALEInfo                                                              *ALEInfo.*
                                                             *ALEInfo-highlight*
   Default: `highlight link ALEInfo ALEWarning`
@@ -1734,6 +1752,15 @@ ALEInfoLine                                                       *ALEInfoLine*
   See |g:ale_set_signs| and |g:ale_set_highlights|.
 
 
+ALEInfoSignLineNr                                           *ALEInfoSignLineNr*
+
+  Default: `highlight link ALEInfoSignLineNr CursorLineNr`
+
+  The highlight for error signs. See |g:ale_set_signs|.
+
+  NOTE: This highlight is only available on Neovim 0.3.2 or higher.
+
+
 ALEStyleError                                                   *ALEStyleError*
 
   Default: `highlight link ALEStyleError ALEError`
@@ -1748,6 +1775,15 @@ ALEStyleErrorSign                                           *ALEStyleErrorSign*
   The highlight for style error signs. See |g:ale_set_signs|.
 
 
+ALEStyleErrorSignLineNr                                    *ALEErrorSignLineNr*
+
+  Default: `highlight link ALEStyleErrorSignLineNr CursorLineNr`
+
+  The highlight for error signs. See |g:ale_set_signs|.
+
+  NOTE: This highlight is only available on Neovim 0.3.2 or higher.
+
+
 ALEStyleWarning                                               *ALEStyleWarning*
 
   Default: `highlight link ALEStyleWarning ALEError`
@@ -1760,6 +1796,15 @@ ALEStyleWarningSign                                       *ALEStyleWarningSign*
   Default: `highlight link ALEStyleWarningSign ALEWarningSign`
 
   The highlight for style warning signs. See |g:ale_set_signs|.
+
+
+ALEStyleWarningSignLineNr                                  *ALEErrorSignLineNr*
+
+  Default: `highlight link ALEStyleWarningSignLineNr CursorLineNr`
+
+  The highlight for error signs. See |g:ale_set_signs|.
+
+  NOTE: This highlight is only available on Neovim 0.3.2 or higher.
 
 
 ALEVirtualTextError                                       *ALEVirtualTextError*
@@ -1819,6 +1864,15 @@ ALEWarningSign                                                 *ALEWarningSign*
   Default: `highlight link ALEWarningSign todo`
 
   The highlight for warning signs. See |g:ale_set_signs|.
+
+
+ALEWarningSignLineNr                                       *ALEErrorSignLineNr*
+
+  Default: `highlight link ALEWarningSignLineNr CursorLineNr`
+
+  The highlight for error signs. See |g:ale_set_signs|.
+
+  NOTE: This highlight is only available on Neovim 0.3.2 or higher.
 
 
 ===============================================================================


### PR DESCRIPTION
Neovim has `numhl` option for signs. This PR adds highlights for this.

https://github.com/neovim/neovim/commit/bddcbbb5716a005001da3bacb4c1df4ae05e51bc
related: https://github.com/airblade/vim-gitgutter/pull/632

<img width="271" alt="スクリーンショット 0001-07-10 10 51 02" src="https://user-images.githubusercontent.com/1239245/60934299-ac722500-a300-11e9-9149-b9a8eb67131c.png">

* Added new highlights `ALE(Error|StyleError|Warning|StyleWarning|Info)LineNr`.
  * All are linked to `CursorLineNr`.

### TODO

I will adds these later!

* tests
  - This diff has no logic to tests
* README
  - It seems need not to describe this in README.
* [x] doc