### PR TITLE
Use Neovim API for highlights when available

### DIFF
--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -32,6 +32,15 @@ if s:has_nvim_highlight
     let s:ns_id = nvim_create_namespace('ale_highlight')
 endif
 
+" Wrappers are necessary to test this functionality by faking the calls in tests.
+function! ale#highlight#nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start, col_end) abort
+    call nvim_buf_add_highlight(a:buffer, a:ns_id, a:hl_group, a:line, a:col_start, a:col_end)
+endfunction
+
+function! ale#highlight#nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) abort
+    call nvim_buf_clear_namespace(a:buffer, a:ns_id, a:line_start, a:line_end)
+endfunction
+
 function! ale#highlight#CreatePositions(line, col, end_line, end_col) abort
     if a:line >= a:end_line
         " For single lines, just return the one position.
@@ -58,7 +67,7 @@ endfunction
 
 function! ale#highlight#RemoveHighlights() abort
     if s:has_nvim_highlight
-        call nvim_buf_clear_namespace(bufnr(''), s:ns_id, 0, -1)
+        call ale#highlight#nvim_buf_clear_namespace(bufnr(''), s:ns_id, 0, -1)
     else
         for l:match in getmatches()
             if l:match.group =~? '\v^ALE(Style)?(Error|Warning|Info)(Line)?$'
@@ -82,13 +91,13 @@ function! s:matchaddpos(group, pos_list) abort
 
             if type(l:pos) == v:t_number || len(l:pos) == 1
                 let l:col_start = 0
-                let l:col_end = -1
+                let l:col_end = s:MAX_COL_SIZE
             else
                 let l:col_start = l:pos[1] - 1
                 let l:col_end = l:col_start + get(l:pos, 2, 1)
             endif
 
-            call nvim_buf_add_highlight(
+            call ale#highlight#nvim_buf_add_highlight(
             \   bufnr(''),
             \   s:ns_id,
             \   a:group,

--- a/test/test_highlight_placement.vader
+++ b/test/test_highlight_placement.vader
@@ -8,6 +8,8 @@ Before:
   Save g:ale_set_quickfix
   Save g:ale_set_signs
 
+  runtime autoload/ale/highlight.vim
+
   let g:ale_run_synchronously = 1
   unlet! g:ale_run_synchronously_callbacks
   let g:ale_set_highlights = 1
@@ -42,16 +44,54 @@ Before:
     \]
   endfunction
 
+  let g:has_nvim_highlight = exists('*nvim_buf_add_highlight') && exists('*nvim_buf_clear_namespace')
+  let g:nvim_highlight_matches = {}
+
+  function! ale#highlight#nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) abort
+    if a:line_end != -1
+      throw 'nvim api behavior not supported'
+    endif
+
+    let l:matches = get(g:nvim_highlight_matches, a:buffer, [])
+    call filter(
+    \ l:matches,
+    \ {_, val -> val.pos1[0] < (a:line_start + 1) },
+    \)
+  endfunction
+
+  function! ale#highlight#nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start, col_end) abort
+    if a:col_end == -1
+      throw 'nvim api behavior not supported'
+    endif
+
+    let l:matches = get(g:nvim_highlight_matches, a:buffer, [])
+    let g:nvim_highlight_matches[a:buffer] = l:matches
+
+    let l:new_match = {
+    \ 'group': a:hl_group,
+    \ 'priority': 10,
+    \ 'pos1': [a:line + 1, a:col_start + 1, a:col_end - a:col_start],
+    \}
+
+    call add(l:matches, l:new_match)
+    " sort by line number to emulate getmatches faithfully
+    call sort(l:matches, {m1, m2 -> m1.pos1[0] - m2.pos1[0]})
+  endfunction
+
   " We don't care what the IDs are, just that we have some matches.
   " The IDs are generated.
   function! GetMatchesWithoutIDs() abort
-    let l:list = getmatches()
+    if g:has_nvim_highlight
+      return get(g:nvim_highlight_matches, bufnr(''), [])
+    else
+      let l:list = getmatches()
 
-    for l:item in l:list
-      call remove(l:item, 'id')
-    endfor
+      for l:item in l:list
+        call remove(l:item, 'id')
+      endfor
 
-    return l:list
+      return l:list
+    endif
   endfunction
 
   call ale#linter#Define('testft', {
@@ -68,12 +108,16 @@ After:
   unlet! g:ale_run_synchronously_callbacks
   unlet! g:items
   unlet! b:ale_enabled
+  unlet! g:has_nvim_highlight
+  unlet! g:nvim_highlight_matches
 
   delfunction GenerateResults
   call ale#linter#Reset()
   call clearmatches()
   sign unplace *
   highlight clear SomeOtherGroup
+
+  runtime autoload/ale/highlight.vim
 
 Given testft(A Javscript file with warnings/errors):
   foo


### PR DESCRIPTION
Fixes #1274.

I tried to keep the changes as simple as possible by just defining a wrapper around `nvim_buf_add_highlight` that emulates the `matchaddpos` interface.

I'm having trouble testing this. I wrapped the function calls in autoload functions to be able to mock them. But the original function still seems to be used in some of the tests. I don't understand the exact sequence of `runtime`, `let`, `unlet`, etc that I'm supposed to be running for these mocks to work. Is there an explanation of this pattern somewhere that I could read? Thanks!