### PR TITLE
Allow use of quickfix window for ALEFindReferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,9 @@ let g:ale_keep_list_window_open = 1
 You can also set `let g:ale_list_vertical = 1` to open the windows vertically
 instead of the default horizontally.
 
+To present `ALEFindReferences` results in the quickfix window, use
+`let g:ale_use_quickfix_findref = 1`.
+
 <a name="faq-jsx-stylelint-eslint"></a>
 
 ### 5.xii. How can I check JSX files with both stylelint and eslint?

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -416,6 +416,9 @@ supported:
 
 |ALEFindReferences| - Find references for the word under the cursor.
 
+If |g:ale_use_quickfix_findref| is set to `1`, then found reference locations
+will be reported in the quickfix window.
+
 Options:
   `-relative`       Show file paths in the results relative to the working dir
 
@@ -1401,6 +1404,15 @@ g:ale_set_quickfix                                         *g:ale_set_quickfix*
   matches and commands like |:cfdo|, as ALE will replace the quickfix list
   pretty frequently. If you wish to use such tools, you should populate the
   loclist instead.
+
+
+g:ale_use_quickfix_findref                         *g:ale_use_quickfix_findref*
+
+  Type: |Number|
+  Default: `0`
+
+  When this option is set to `1`, the |quickfix| list will be populated with
+  locations found by |ALEFindReferences|.
 
 
 g:ale_set_signs                                               *g:ale_set_signs*


### PR DESCRIPTION
Fixes #1759.

Introduces new configuration `g:ale_use_quickfix_findref` which
defaults to 0.

Sort of a proof of concept - this is my first vimscript foray so I'm
sure the code is garbage.