### PR TITLE
Set --assume-filename for clangformat fixer

### DIFF
--- a/autoload/ale/fixers/clangformat.vim
+++ b/autoload/ale/fixers/clangformat.vim
@@ -13,10 +13,15 @@ function! ale#fixers#clangformat#GetExecutable(buffer) abort
 endfunction
 
 function! ale#fixers#clangformat#Fix(buffer) abort
+    let l:executable = ale#Escape(ale#fixers#clangformat#GetExecutable(a:buffer))
+    let l:filename = ale#Escape(bufname(a:buffer))
     let l:options = ale#Var(a:buffer, 'c_clangformat_options')
 
-    return {
-    \   'command': ale#Escape(ale#fixers#clangformat#GetExecutable(a:buffer))
-    \       . ' ' . l:options,
-    \}
+    let l:command = l:executable . ' --assume-filename=' . l:filename
+
+    if l:options isnot# ''
+        let l:command .= ' ' . l:options
+    endif
+
+    return {'command': l:command}
 endfunction

--- a/test/fixers/test_clangformat_fixer_callback.vader
+++ b/test/fixers/test_clangformat_fixer_callback.vader
@@ -20,7 +20,7 @@ Execute(The clang-format callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_c_clangformat_executable)
-  \       . ' '
+  \     . ' --assume-filename=' . ale#Escape(bufname(bufnr('')))
   \ },
   \ ale#fixers#clangformat#Fix(bufnr(''))
 
@@ -31,6 +31,7 @@ Execute(The clangformat callback should include any additional options):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_c_clangformat_executable)
+  \     . ' --assume-filename=' . ale#Escape(bufname(bufnr('')))
   \     . ' --some-option',
   \ },
   \ ale#fixers#clangformat#Fix(bufnr(''))


### PR DESCRIPTION
Here is a short addition to the `clangformat` fixer to supply the `--assume-filename` argument with the name of the file in the current buffer.

Resolves the issue that I mentioned in https://github.com/w0rp/ale/issues/2645