### PR TITLE
Adding support for LSP `window/showMessage` method

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -11,7 +11,7 @@ let g:ale_linters_ignore = get(g:, 'ale_linters_ignore', {})
 let g:ale_disable_lsp = get(g:, 'ale_disable_lsp', 0)
 
 " LSP window/showMessage format
-let g:ale_lsp_show_message_format = get(g:, 'ale_lsp_show_message_format', '%severity%:%linter%: %text%')
+let g:ale_lsp_show_message_format = get(g:, 'ale_lsp_show_message_format', '%severity%:%linter%: %s')
 " FIXME(suoto): Can use severity to display only errors by default.
 " Valid values mimic LSP definitions (error, warning and information; log is
 " never shown)

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -12,7 +12,6 @@ let g:ale_disable_lsp = get(g:, 'ale_disable_lsp', 0)
 
 " LSP window/showMessage format
 let g:ale_lsp_show_message_format = get(g:, 'ale_lsp_show_message_format', '%severity%:%linter%: %s')
-" FIXME(suoto): Can use severity to display only errors by default.
 " Valid values mimic LSP definitions (error, warning and information; log is
 " never shown)
 let g:ale_lsp_show_message_severity = get(g:, 'ale_lsp_show_message_severity', 'error')

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -12,6 +12,10 @@ let g:ale_disable_lsp = get(g:, 'ale_disable_lsp', 0)
 
 " LSP window/showMessage format
 let g:ale_lsp_show_message_format = get(g:, 'ale_lsp_show_message_format', '%severity%:%linter%: %text%')
+" FIXME(suoto): Can use severity to display only errors by default.
+" Valid values mimic LSP definitions (error, warning and information; log is
+" never shown)
+let g:ale_lsp_show_message_severity = get(g:, 'ale_lsp_show_message_severity', 'error')
 
 let s:lint_timer = -1
 let s:getcmdwintype_exists = exists('*getcmdwintype')

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -5,6 +5,7 @@
 " Strings used for severity in the echoed message
 let g:ale_echo_msg_error_str = get(g:, 'ale_echo_msg_error_str', 'Error')
 let g:ale_echo_msg_info_str = get(g:, 'ale_echo_msg_info_str', 'Info')
+let g:ale_echo_msg_log_str = get(g:, 'ale_echo_msg_log_str', 'Log')
 let g:ale_echo_msg_warning_str = get(g:, 'ale_echo_msg_warning_str', 'Warning')
 " Ignoring linters, for disabling some, or ignoring LSP diagnostics.
 let g:ale_linters_ignore = get(g:, 'ale_linters_ignore', {})

--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -10,6 +10,9 @@ let g:ale_echo_msg_warning_str = get(g:, 'ale_echo_msg_warning_str', 'Warning')
 let g:ale_linters_ignore = get(g:, 'ale_linters_ignore', {})
 let g:ale_disable_lsp = get(g:, 'ale_disable_lsp', 0)
 
+" LSP window/showMessage format
+let g:ale_lsp_show_message_format = get(g:, 'ale_lsp_show_message_format', '%severity%:%linter%: %text%')
+
 let s:lint_timer = -1
 let s:getcmdwintype_exists = exists('*getcmdwintype')
 

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -39,6 +39,7 @@ function! ale#lsp#window#formatString(format, args) abort
             throw 'Invalid argument ''' . l:key . '''. Arguments must follow ' .
             \ 'pattern [a-zA-Z][a-zA-Z0-9_]*'
         endif
+
         let l:string = substitute(l:string, '\V%' . l:key . '%', '\=l:value', 'g')
     endfor
 
@@ -52,6 +53,11 @@ function! ale#lsp#window#showMessage(linter_name, format, params) abort
     let l:message = a:params.message
     let l:type = a:params.type
 
+    if l:type is# s:LSP_MESSAGE_TYPE_LOG
+        " Discard log severity for now
+        return
+    endif
+
     " Common formatting arguments
     let l:format_args = {'linter': a:linter_name, 'text': l:message}
 
@@ -63,11 +69,6 @@ function! ale#lsp#window#showMessage(linter_name, format, params) abort
         let l:format_args['severity'] = g:ale_echo_msg_warning_str
         let l:Handler = funcref('s:echoWarning')
     elseif l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
-        let l:format_args['severity'] = g:ale_echo_msg_info_str
-        let l:Handler = funcref('s:echoInfo')
-    elseif l:type is# s:LSP_MESSAGE_TYPE_LOG
-        " TODO: If/when there's logging, we can handle it here. Until then,
-        " handle it as a regular info
         let l:format_args['severity'] = g:ale_echo_msg_info_str
         let l:Handler = funcref('s:echoInfo')
     endif

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -22,6 +22,10 @@ function! s:echoInfo(text) abort
     call ale#util#Execute('redraw | echomsg ''' . a:text . '''')
 endfunction
 
+function! s:isKeyValid(key) abort
+    return matchstr(a:key, '[a-zA-Z][a-zA-Z0-9_]*') is# a:key
+endfunction
+
 " This formats string 'a:format' by replacing a:args keys by their respective
 " values
 " - format: base format, where keys are surrounded by '%' (e.g, %linter%)
@@ -31,6 +35,10 @@ function! ale#lsp#window#formatString(format, args) abort
     let l:string = a:format
 
     for [l:key, l:value] in items(a:args)
+        if ! s:isKeyValid(l:key)
+            throw 'Invalid argument ''' . l:key . '''. Arguments must follow ' .
+            \ 'pattern [a-zA-Z][a-zA-Z0-9_]*'
+        endif
         let l:string = substitute(l:string, '\V%' . l:key . '%', '\=l:value', 'g')
     endfor
 

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -8,10 +8,6 @@ let s:LSP_MESSAGE_TYPE_WARNING = 2
 let s:LSP_MESSAGE_TYPE_INFORMATION = 3
 let s:LSP_MESSAGE_TYPE_LOG = 4
 
-" User configurable format
-let g:ale_lsp_show_message_format = '%severity%:%linter%: %s'
-
-"
 function! s:echoError(text) abort
     call ale#util#Execute(
     \ 'redraw | echohl ErrorMsg | echomsg ''' . a:text . ''' | echohl None')
@@ -26,35 +22,47 @@ function! s:echoInfo(text) abort
     call ale#util#Execute('redraw | echomsg ''' . a:text . '''')
 endfunction
 
-function! s:formatMessage(linter_name, severity, text) abort
-    let l:fmt_text = g:ale_lsp_show_message_format
-    " Replace special markers with certain information.
-    " \=l:variable is used to avoid escaping issues.
-    let l:fmt_text = substitute(l:fmt_text, '\V%severity%', '\=a:severity', 'g')
-    let l:fmt_text = substitute(l:fmt_text, '\V%linter%', '\=a:linter_name', 'g')
-    " Replace %s with the text.
-    let l:fmt_text = substitute(l:fmt_text, '\V%s', '\=a:text', 'g')
+" This formats string 'a:format' by replacing a:args keys by their respective
+" values
+" - format: base format, where keys are surrounded by '%' (e.g, %linter%)
+" - args: dict defining values for each key inside format. Don't add extra '%'
+"   to the keys, they'll be added automatically when replacing
+function! ale#lsp#window#formatString(format, args) abort
+    let l:string = a:format
 
-    return l:fmt_text
+    for [l:key, l:value] in items(a:args)
+        let l:string = substitute(l:string, '\V%' . l:key . '%', '\=l:value', 'g')
+    endfor
+
+    return l:string
 endfunction
 
-function! ale#lsp#window#showMessage(linter_name, response) abort
-    let l:message = a:response.params.message
-    let l:type = a:response.params.type
+" Handle window/showMessage response.
+" - details: dict containing linter name and format (g:ale_lsp_show_message_format)
+" - params: dict with the params for the call in the form of {type: number, message: string}
+function! ale#lsp#window#showMessage(linter_name, format, params) abort
+    let l:message = a:params.message
+    let l:type = a:params.type
 
+    " Common formatting arguments
+    let l:format_args = {'linter': a:linter_name, 'text': l:message}
+
+    " Severity will depend on the message type
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
-        let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_error_str, l:message)
-        call s:echoError(l:text)
+        let l:format_args['severity'] = g:ale_echo_msg_error_str
+        let l:Handler = funcref('s:echoError')
     elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
-        let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_warning_str, l:message)
-        call s:echoWarning(l:text)
-    else
-        let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_info_str, l:message)
-
-        if l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
-            call s:echoInfo(l:text)
-        else
-            call s:echoInfo(l:text)
-        endif
+        let l:format_args['severity'] = g:ale_echo_msg_warning_str
+        let l:Handler = funcref('s:echoWarning')
+    elseif l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
+        let l:format_args['severity'] = g:ale_echo_msg_info_str
+        let l:Handler = funcref('s:echoInfo')
+    elseif l:type is# s:LSP_MESSAGE_TYPE_LOG
+        " TODO: If/when there's logging, we can handle it here. Until then,
+        " handle it as a regular info
+        let l:format_args['severity'] = g:ale_echo_msg_info_str
+        let l:Handler = funcref('s:echoInfo')
     endif
+
+    call l:Handler(ale#lsp#window#formatString(a:format, l:format_args))
 endfunction

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -17,16 +17,6 @@ let s:CFG_TO_LSP_SEVERITY = {
 \   'log': s:LSP_MESSAGE_TYPE_LOG
 \}
 
-" Text is going to be echo'ed by ale#util#Execute, so any single quote the
-" text has must be reescaped
-function! s:escapeQuotes(text) abort
-    return substitute(a:text, '''', '''''', 'g')
-endfunction
-
-function! s:isKeyValid(key) abort
-    return matchstr(a:key, '[a-zA-Z][a-zA-Z0-9_]*') is# a:key
-endfunction
-
 " This formats string 'a:format' by replacing a:args keys by their respective
 " values
 " - format: base format, where keys are surrounded by '%' (e.g, %linter%)
@@ -36,11 +26,6 @@ function! ale#lsp#window#formatString(format, args) abort
     let l:string = a:format
 
     for [l:key, l:value] in items(a:args)
-        " if ! s:isKeyValid(l:key)
-        "     throw 'Invalid argument ''' . l:key . '''. Arguments must follow ' .
-        "     \ 'pattern [a-zA-Z][a-zA-Z0-9_]*'
-        " endif
-
         let l:string = substitute(l:string, '\V' . l:key, '\=l:value', 'g')
     endfor
 

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -1,0 +1,44 @@
+" Author: suoto <andre820@gmail.com>
+" Description: Handling of window LSP methods 
+
+" Constants for message type codes
+let s:LSP_MESSAGE_TYPE_ERROR = 1
+let s:LSP_MESSAGE_TYPE_WARNING = 2
+let s:LSP_MESSAGE_TYPE_INFORMATION = 3
+let s:LSP_MESSAGE_TYPE_LOG = 4
+
+function! s:showLSPErrorMessage(linter_name, message)
+    let l:text = '[' . g:ale_echo_msg_error_str . '@' . a:linter_name . '] ' . a:message
+    redraw | echohl ErrorMsg | echom l:text | echohl None
+endfunction
+
+function! s:showLSPWarningMessage(linter_name, message)
+    let l:text = '[' . g:ale_echo_msg_warning_str . '@' . a:linter_name . '] ' . a:message
+    redraw | echohl WarningMsg | echom l:text | echohl None
+endfunction
+
+function! s:showLSPInfoMessage(linter_name, message)
+    let l:text = '[' . g:ale_echo_msg_info_str . '@' . a:linter_name . '] ' . a:message
+    redraw | echom l:text
+endfunction
+
+function! ale#lsp#window#showMessage(linter_name, response) abort
+    let l:message = a:response.params.message
+    let l:type = a:response.params.type
+
+    let l:warning = 2
+    let l:info = 3
+    let l:log = 4
+
+    if l:type is# s:LSP_MESSAGE_TYPE_ERROR
+        call s:showLSPErrorMessage(a:linter_name, l:message)
+    elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
+        call s:showLSPWarningMessage(a:linter_name, l:message)
+    else
+        " 'info' and 'log' will be shown as info
+        call s:showLSPInfoMessage(a:linter_name, l:message)
+    endif
+
+endfunction
+
+

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -8,18 +8,24 @@ let s:LSP_MESSAGE_TYPE_WARNING = 2
 let s:LSP_MESSAGE_TYPE_INFORMATION = 3
 let s:LSP_MESSAGE_TYPE_LOG = 4
 
+" Text is going to be echo'ed by ale#util#Execute, so any single quote the
+" text has must be reescaped
+function! s:escapeQuotes(text) abort
+    return substitute(a:text, '''', '''''', 'g')
+endfunction
+
 function! s:echoError(text) abort
     call ale#util#Execute(
-    \ 'redraw | echohl ErrorMsg | echomsg ''' . a:text . ''' | echohl None')
+    \ 'redraw | echohl ErrorMsg | echomsg ''' . s:escapeQuotes(a:text) . ''' | echohl None')
 endfunction
 
 function! s:echoWarning(text) abort
     call ale#util#Execute(
-    \ 'redraw | echohl WarningMsg | echomsg ''' . a:text . ''' | echohl None')
+    \ 'redraw | echohl WarningMsg | echomsg ''' . s:escapeQuotes(a:text) . ''' | echohl None')
 endfunction
 
 function! s:echoInfo(text) abort
-    call ale#util#Execute('redraw | echomsg ''' . a:text . '''')
+    call ale#util#Execute('redraw | echomsg ''' . s:escapeQuotes(a:text) . '''')
 endfunction
 
 function! s:isKeyValid(key) abort

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -36,12 +36,12 @@ function! ale#lsp#window#formatString(format, args) abort
     let l:string = a:format
 
     for [l:key, l:value] in items(a:args)
-        if ! s:isKeyValid(l:key)
-            throw 'Invalid argument ''' . l:key . '''. Arguments must follow ' .
-            \ 'pattern [a-zA-Z][a-zA-Z0-9_]*'
-        endif
+        " if ! s:isKeyValid(l:key)
+        "     throw 'Invalid argument ''' . l:key . '''. Arguments must follow ' .
+        "     \ 'pattern [a-zA-Z][a-zA-Z0-9_]*'
+        " endif
 
-        let l:string = substitute(l:string, '\V%' . l:key . '%', '\=l:value', 'g')
+        let l:string = substitute(l:string, '\V' . l:key, '\=l:value', 'g')
     endfor
 
     return l:string
@@ -59,23 +59,24 @@ function! ale#lsp#window#HandleShowMessage(linter_name, format, params) abort
         return
     endif
 
-    " Check if the message is above the the configured threshold
-    let l:cfg_severity_threshold = get(s:CFG_TO_LSP_SEVERITY, get(g:, 'ale_lsp_show_message_severity', 'error'))
+    " Get the configured severity level threshold and check if the message
+    " should be displayed or not
+    let l:cfg_severity_threshold = s:CFG_TO_LSP_SEVERITY[tolower(get(g:, 'ale_lsp_show_message_severity', 'error'))]
 
     if l:type > l:cfg_severity_threshold
         return
     endif
 
     " Common formatting arguments
-    let l:format_args = {'linter': a:linter_name, 'text': l:message}
+    let l:format_args = {'%linter%': a:linter_name, '%s': l:message}
 
     " Severity will depend on the message type
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
-        let l:format_args['severity'] = g:ale_echo_msg_error_str
+        let l:format_args['%severity%'] = g:ale_echo_msg_error_str
     elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
-        let l:format_args['severity'] = g:ale_echo_msg_warning_str
+        let l:format_args['%severity%'] = g:ale_echo_msg_warning_str
     elseif l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
-        let l:format_args['severity'] = g:ale_echo_msg_info_str
+        let l:format_args['%severity%'] = g:ale_echo_msg_info_str
     endif
 
     call ale#util#ShowMessage(ale#lsp#window#formatString(a:format, l:format_args))

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -23,20 +23,6 @@ function! s:escapeQuotes(text) abort
     return substitute(a:text, '''', '''''', 'g')
 endfunction
 
-function! s:echoError(text) abort
-    call ale#util#Execute(
-    \ 'redraw | echohl ErrorMsg | echomsg ''' . s:escapeQuotes(a:text) . ''' | echohl None')
-endfunction
-
-function! s:echoWarning(text) abort
-    call ale#util#Execute(
-    \ 'redraw | echohl WarningMsg | echomsg ''' . s:escapeQuotes(a:text) . ''' | echohl None')
-endfunction
-
-function! s:echoInfo(text) abort
-    call ale#util#Execute('redraw | echomsg ''' . s:escapeQuotes(a:text) . '''')
-endfunction
-
 function! s:isKeyValid(key) abort
     return matchstr(a:key, '[a-zA-Z][a-zA-Z0-9_]*') is# a:key
 endfunction
@@ -86,14 +72,11 @@ function! ale#lsp#window#HandleShowMessage(linter_name, format, params) abort
     " Severity will depend on the message type
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
         let l:format_args['severity'] = g:ale_echo_msg_error_str
-        let l:Handler = funcref('s:echoError')
     elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
         let l:format_args['severity'] = g:ale_echo_msg_warning_str
-        let l:Handler = funcref('s:echoWarning')
     elseif l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
         let l:format_args['severity'] = g:ale_echo_msg_info_str
-        let l:Handler = funcref('s:echoInfo')
     endif
 
-    call l:Handler(ale#lsp#window#formatString(a:format, l:format_args))
+    call ale#util#ShowMessage(ale#lsp#window#formatString(a:format, l:format_args))
 endfunction

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -11,22 +11,22 @@ let s:LSP_MESSAGE_TYPE_LOG = 4
 " User configurable format
 let g:ale_lsp_show_message_format = '%severity%:%linter%: %s'
 
-" 
-function! s:echoError(text)
-  call ale#util#Execute(
-        \ 'redraw | echohl ErrorMsg | echomsg ''' . a:text . ''' | echohl None')
-endfunction
-
-function! s:echoWarning(text)
+"
+function! s:echoError(text) abort
     call ale#util#Execute(
-          \ 'redraw | echohl WarningMsg | echomsg ''' . a:text . ''' | echohl None')
+    \ 'redraw | echohl ErrorMsg | echomsg ''' . a:text . ''' | echohl None')
 endfunction
 
-function! s:echoInfo(text)
+function! s:echoWarning(text) abort
+    call ale#util#Execute(
+    \ 'redraw | echohl WarningMsg | echomsg ''' . a:text . ''' | echohl None')
+endfunction
+
+function! s:echoInfo(text) abort
     call ale#util#Execute('redraw | echomsg ''' . a:text . '''')
 endfunction
 
-function! s:formatMessage(linter_name, severity, text)
+function! s:formatMessage(linter_name, severity, text) abort
     let l:fmt_text = g:ale_lsp_show_message_format
     " Replace special markers with certain information.
     " \=l:variable is used to avoid escaping issues.
@@ -34,6 +34,7 @@ function! s:formatMessage(linter_name, severity, text)
     let l:fmt_text = substitute(l:fmt_text, '\V%linter%', '\=a:linter_name', 'g')
     " Replace %s with the text.
     let l:fmt_text = substitute(l:fmt_text, '\V%s', '\=a:text', 'g')
+
     return l:fmt_text
 endfunction
 
@@ -42,18 +43,18 @@ function! ale#lsp#window#showMessage(linter_name, response) abort
     let l:type = a:response.params.type
 
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
-      let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_error_str, l:message)
-      call s:echoError(l:text)
+        let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_error_str, l:message)
+        call s:echoError(l:text)
     elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
-      let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_warning_str, l:message)
-      call s:echoWarning(l:text)
+        let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_warning_str, l:message)
+        call s:echoWarning(l:text)
     else
-      let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_info_str, l:message)
-      if l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
-        call s:echoInfo(l:text)
-      else
-        call s:echoInfo(l:text)
-      endif
-    endif
+        let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_info_str, l:message)
 
+        if l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
+            call s:echoInfo(l:text)
+        else
+            call s:echoInfo(l:text)
+        endif
+    endif
 endfunction

--- a/autoload/ale/lsp/window.vim
+++ b/autoload/ale/lsp/window.vim
@@ -1,5 +1,6 @@
 " Author: suoto <andre820@gmail.com>
-" Description: Handling of window LSP methods 
+" Description: Handling of window/* LSP methods, although right now only
+" handles window/showMessage
 
 " Constants for message type codes
 let s:LSP_MESSAGE_TYPE_ERROR = 1
@@ -7,38 +8,52 @@ let s:LSP_MESSAGE_TYPE_WARNING = 2
 let s:LSP_MESSAGE_TYPE_INFORMATION = 3
 let s:LSP_MESSAGE_TYPE_LOG = 4
 
-function! s:showLSPErrorMessage(linter_name, message)
-    let l:text = '[' . g:ale_echo_msg_error_str . '@' . a:linter_name . '] ' . a:message
-    redraw | echohl ErrorMsg | echom l:text | echohl None
+" User configurable format
+let g:ale_lsp_show_message_format = '%severity%:%linter%: %s'
+
+" 
+function! s:echoError(text)
+  call ale#util#Execute(
+        \ 'redraw | echohl ErrorMsg | echomsg ''' . a:text . ''' | echohl None')
 endfunction
 
-function! s:showLSPWarningMessage(linter_name, message)
-    let l:text = '[' . g:ale_echo_msg_warning_str . '@' . a:linter_name . '] ' . a:message
-    redraw | echohl WarningMsg | echom l:text | echohl None
+function! s:echoWarning(text)
+    call ale#util#Execute(
+          \ 'redraw | echohl WarningMsg | echomsg ''' . a:text . ''' | echohl None')
 endfunction
 
-function! s:showLSPInfoMessage(linter_name, message)
-    let l:text = '[' . g:ale_echo_msg_info_str . '@' . a:linter_name . '] ' . a:message
-    redraw | echom l:text
+function! s:echoInfo(text)
+    call ale#util#Execute('redraw | echomsg ''' . a:text . '''')
+endfunction
+
+function! s:formatMessage(linter_name, severity, text)
+    let l:fmt_text = g:ale_lsp_show_message_format
+    " Replace special markers with certain information.
+    " \=l:variable is used to avoid escaping issues.
+    let l:fmt_text = substitute(l:fmt_text, '\V%severity%', '\=a:severity', 'g')
+    let l:fmt_text = substitute(l:fmt_text, '\V%linter%', '\=a:linter_name', 'g')
+    " Replace %s with the text.
+    let l:fmt_text = substitute(l:fmt_text, '\V%s', '\=a:text', 'g')
+    return l:fmt_text
 endfunction
 
 function! ale#lsp#window#showMessage(linter_name, response) abort
     let l:message = a:response.params.message
     let l:type = a:response.params.type
 
-    let l:warning = 2
-    let l:info = 3
-    let l:log = 4
-
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
-        call s:showLSPErrorMessage(a:linter_name, l:message)
+      let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_error_str, l:message)
+      call s:echoError(l:text)
     elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
-        call s:showLSPWarningMessage(a:linter_name, l:message)
+      let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_warning_str, l:message)
+      call s:echoWarning(l:text)
     else
-        " 'info' and 'log' will be shown as info
-        call s:showLSPInfoMessage(a:linter_name, l:message)
+      let l:text = s:formatMessage(a:linter_name, g:ale_echo_msg_info_str, l:message)
+      if l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
+        call s:echoInfo(l:text)
+      else
+        call s:echoInfo(l:text)
+      endif
     endif
 
 endfunction
-
-

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -131,7 +131,10 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
     elseif l:method is# 'textDocument/publishDiagnostics'
         call s:HandleLSPDiagnostics(a:conn_id, a:response)
     elseif l:method is# 'window/showMessage'
-        call ale#lsp#window#showMessage(s:lsp_linter_map[a:conn_id], a:response)
+        call ale#lsp#window#showMessage(
+        \ s:lsp_linter_map[a:conn_id],
+        \ g:ale_lsp_show_message_format,
+        \ a:response.params)
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'semanticDiag'
         call s:HandleTSServerDiagnostics(a:response, 'semantic')

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -131,7 +131,7 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
     elseif l:method is# 'textDocument/publishDiagnostics'
         call s:HandleLSPDiagnostics(a:conn_id, a:response)
     elseif l:method is# 'window/showMessage'
-        call ale#lsp#window#showMessage(
+        call ale#lsp#window#HandleShowMessage(
         \   s:lsp_linter_map[a:conn_id],
         \   g:ale_lsp_show_message_format,
         \   a:response.params

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -132,9 +132,10 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         call s:HandleLSPDiagnostics(a:conn_id, a:response)
     elseif l:method is# 'window/showMessage'
         call ale#lsp#window#showMessage(
-        \ s:lsp_linter_map[a:conn_id],
-        \ g:ale_lsp_show_message_format,
-        \ a:response.params)
+        \   s:lsp_linter_map[a:conn_id],
+        \   g:ale_lsp_show_message_format,
+        \   a:response.params
+        \)
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'semanticDiag'
         call s:HandleTSServerDiagnostics(a:response, 'semantic')

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -131,7 +131,7 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
     elseif l:method is# 'textDocument/publishDiagnostics'
         call s:HandleLSPDiagnostics(a:conn_id, a:response)
     elseif l:method is# 'window/showMessage'
-        call ale#lsp#window#HandleShowMessage(
+        call ale#lsp_window#HandleShowMessage(
         \   s:lsp_linter_map[a:conn_id],
         \   g:ale_lsp_show_message_format,
         \   a:response.params

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -11,6 +11,12 @@ endif
 " A Dictionary to track one-shot handlers for custom LSP requests
 let s:custom_handlers_map = get(s:, 'custom_handlers_map', {})
 
+" Constants for message type codes
+let s:LSP_MESSAGE_TYPE_ERROR = 1
+let s:LSP_MESSAGE_TYPE_WARNING = 2
+let s:LSP_MESSAGE_TYPE_INFORMATION = 3
+let s:LSP_MESSAGE_TYPE_LOG = 4
+
 " Check if diagnostics for a particular linter should be ignored.
 function! s:ShouldIgnore(buffer, linter_name) abort
     " Ignore all diagnostics if LSP integration is disabled.
@@ -48,6 +54,41 @@ function! s:HandleLSPDiagnostics(conn_id, response) abort
     let l:loclist = ale#lsp#response#ReadDiagnostics(a:response)
 
     call ale#engine#HandleLoclist(l:linter_name, l:buffer, l:loclist, 0)
+endfunction
+
+function! s:showLSPErrorMessage(linter_name, message)
+    let l:text = '[' . g:ale_echo_msg_error_str . '@' . a:linter_name . '] ' . a:message
+    redraw | echohl ErrorMsg | echom l:text | echohl None
+endfunction
+
+function! s:showLSPWarningMessage(linter_name, message)
+    let l:text = '[' . g:ale_echo_msg_warning_str . '@' . a:linter_name . '] ' . a:message
+    redraw | echohl WarningMsg | echom l:text | echohl None
+endfunction
+
+function! s:showLSPInfoMessage(linter_name, message)
+    let l:text = '[' . g:ale_echo_msg_info_str . '@' . a:linter_name . '] ' . a:message
+    redraw | echom l:text
+endfunction
+
+function! s:HandleLSPShowMessage(conn_id, response) abort
+    let l:linter_name = s:lsp_linter_map[a:conn_id]
+    let l:message = a:response.params.message
+    let l:type = a:response.params.type
+
+    let l:warning = 2
+    let l:info = 3
+    let l:log = 4
+
+    if l:type is# s:LSP_MESSAGE_TYPE_ERROR
+        call s:showLSPErrorMessage(l:linter_name, l:message)
+    elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
+        call s:showLSPWarningMessage(l:linter_name, l:message)
+    else
+        " 'info' and 'log' will be shown as info
+        call s:showLSPInfoMessage(l:linter_name, l:message)
+    endif
+
 endfunction
 
 function! s:HandleTSServerDiagnostics(response, error_type) abort
@@ -130,6 +171,8 @@ function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
         call s:HandleLSPErrorMessage(l:linter_name, a:response)
     elseif l:method is# 'textDocument/publishDiagnostics'
         call s:HandleLSPDiagnostics(a:conn_id, a:response)
+    elseif l:method is# 'window/showMessage'
+        call s:HandleLSPShowMessage(a:conn_id, a:response)
     elseif get(a:response, 'type', '') is# 'event'
     \&& get(a:response, 'event', '') is# 'semanticDiag'
         call s:HandleTSServerDiagnostics(a:response, 'semantic')

--- a/autoload/ale/lsp_window.vim
+++ b/autoload/ale/lsp_window.vim
@@ -27,14 +27,12 @@ function! ale#lsp_window#HandleShowMessage(linter_name, format, params) abort
     let l:message = a:params.message
     let l:type = a:params.type
 
-    " Discard log severity for now
-    if l:type is# s:LSP_MESSAGE_TYPE_LOG
-        return
-    endif
-
     " Get the configured severity level threshold and check if the message
     " should be displayed or not
-    let l:cfg_severity_threshold = s:CFG_TO_LSP_SEVERITY[tolower(get(g:, 'ale_lsp_show_message_severity', 'error'))]
+    let l:configured_severity = tolower(get(g:, 'ale_lsp_show_message_severity', 'error'))
+    " If the user has confgured with a value we can't find on the conversion
+    " dict, fall back to warning
+    let l:cfg_severity_threshold = get(s:CFG_TO_LSP_SEVERITY, l:configured_severity, s:LSP_MESSAGE_TYPE_WARNING)
 
     if l:type > l:cfg_severity_threshold
         return

--- a/autoload/ale/lsp_window.vim
+++ b/autoload/ale/lsp_window.vim
@@ -43,15 +43,18 @@ function! ale#lsp_window#HandleShowMessage(linter_name, format, params) abort
     " Severity will depend on the message type
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
         let l:severity = g:ale_echo_msg_error_str
-    elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
-        let l:severity = g:ale_echo_msg_warning_str
     elseif l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
         let l:severity = g:ale_echo_msg_info_str
+    elseif l:type is# s:LSP_MESSAGE_TYPE_LOG
+        let l:severity = g:ale_echo_msg_log_str
+    else
+        " Default to warning just in case
+        let l:severity = g:ale_echo_msg_warning_str
     endif
 
     let l:string = substitute(a:format, '\V%severity%', l:severity, 'g')
     let l:string = substitute(l:string, '\V%linter%', a:linter_name, 'g')
-    let l:string = substitute(l:string, '\V%s', l:message, 'g')
+    let l:string = substitute(l:string, '\V%s\>', l:message, 'g')
 
     call ale#util#ShowMessage(l:string)
 endfunction

--- a/autoload/ale/lsp_window.vim
+++ b/autoload/ale/lsp_window.vim
@@ -3,6 +3,7 @@
 " handles window/showMessage
 
 " Constants for message type codes
+let s:LSP_MESSAGE_TYPE_DISABLED = 0
 let s:LSP_MESSAGE_TYPE_ERROR = 1
 let s:LSP_MESSAGE_TYPE_WARNING = 2
 let s:LSP_MESSAGE_TYPE_INFORMATION = 3
@@ -11,31 +12,18 @@ let s:LSP_MESSAGE_TYPE_LOG = 4
 " Translate strings from the user config to a number so we can check
 " severities
 let s:CFG_TO_LSP_SEVERITY = {
+\   'disabled': s:LSP_MESSAGE_TYPE_DISABLED,
 \   'error': s:LSP_MESSAGE_TYPE_ERROR,
 \   'warning': s:LSP_MESSAGE_TYPE_WARNING,
 \   'information': s:LSP_MESSAGE_TYPE_INFORMATION,
+\   'info': s:LSP_MESSAGE_TYPE_INFORMATION,
 \   'log': s:LSP_MESSAGE_TYPE_LOG
 \}
-
-" This formats string 'a:format' by replacing a:args keys by their respective
-" values
-" - format: base format, where keys are surrounded by '%' (e.g, %linter%)
-" - args: dict defining values for each key inside format. Don't add extra '%'
-"   to the keys, they'll be added automatically when replacing
-function! ale#lsp#window#formatString(format, args) abort
-    let l:string = a:format
-
-    for [l:key, l:value] in items(a:args)
-        let l:string = substitute(l:string, '\V' . l:key, '\=l:value', 'g')
-    endfor
-
-    return l:string
-endfunction
 
 " Handle window/showMessage response.
 " - details: dict containing linter name and format (g:ale_lsp_show_message_format)
 " - params: dict with the params for the call in the form of {type: number, message: string}
-function! ale#lsp#window#HandleShowMessage(linter_name, format, params) abort
+function! ale#lsp_window#HandleShowMessage(linter_name, format, params) abort
     let l:message = a:params.message
     let l:type = a:params.type
 
@@ -52,17 +40,18 @@ function! ale#lsp#window#HandleShowMessage(linter_name, format, params) abort
         return
     endif
 
-    " Common formatting arguments
-    let l:format_args = {'%linter%': a:linter_name, '%s': l:message}
-
     " Severity will depend on the message type
     if l:type is# s:LSP_MESSAGE_TYPE_ERROR
-        let l:format_args['%severity%'] = g:ale_echo_msg_error_str
+        let l:severity = g:ale_echo_msg_error_str
     elseif l:type is# s:LSP_MESSAGE_TYPE_WARNING
-        let l:format_args['%severity%'] = g:ale_echo_msg_warning_str
+        let l:severity = g:ale_echo_msg_warning_str
     elseif l:type is# s:LSP_MESSAGE_TYPE_INFORMATION
-        let l:format_args['%severity%'] = g:ale_echo_msg_info_str
+        let l:severity = g:ale_echo_msg_info_str
     endif
 
-    call ale#util#ShowMessage(ale#lsp#window#formatString(a:format, l:format_args))
+    let l:string = substitute(a:format, '\V%severity%', l:severity, 'g')
+    let l:string = substitute(l:string, '\V%linter%', a:linter_name, 'g')
+    let l:string = substitute(l:string, '\V%s', l:message, 'g')
+
+    call ale#util#ShowMessage(l:string)
 endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1181,6 +1181,43 @@ b:ale_loclist_msg_format                             *b:ale_loclist_msg_format*
 
   The strings for configuring `%severity%` are also used for this option.
 
+
+g:ale_lsp_show_message_format                           *g:ale_lsp_show_message_format*
+
+  Type: |String|
+  Default: `'%severity%:%linter%: %s'`
+
+  This variable defines the format that messages received from an LSP will
+  have. The following sequences of characters will be replaced.
+
+    `%s`           - replaced with the message text
+    `%linter%`     - replaced with the name of the linter
+    `%severity%`   - replaced with the severity of the message
+
+  To configure the strings used on the `%severity%` field, see |g:ale_echo_msg_format|.
+
+  The echo message format can also be configured separately for each buffer,
+  so different formats can be used for different languages. (Say in ftplugin
+  files.)
+
+
+g:ale_lsp_show_message_severity                         *g:ale_lsp_show_message_severity*
+
+  Type: |String|
+  Default: `'error'`
+
+  This variable defines the minimum severity level an LSP message needs to be
+  displayed. Messages below this level are discarded; please note that
+  messages with `Log` severity level are always discarded.
+
+  Possible values follow the LSP spec `MessageType` definition:
+
+  `'error'`       - Displays only errors.
+  `'warning'`     - Displays errors and warnings.
+  `'information'` - Displays errors, warnings and infos
+  `'log'`         - Same as `'information'`
+
+
 g:ale_lsp_root                                                 *g:ale_lsp_root*
 b:ale_lsp_root                                                 *b:ale_lsp_root*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -734,6 +734,15 @@ g:ale_echo_msg_info_str                               *g:ale_echo_msg_info_str*
   The string used for `%severity%` for info. See |g:ale_echo_msg_format|
 
 
+g:ale_echo_msg_log_str                               *g:ale_echo_msg_log_str*
+
+  Type: |String|
+  Default: `'Log'`
+
+  The string used for `%severity%` for log, used only for handling LSP show
+  message requests. See |g:ale_lsp_show_message_format|
+
+
 g:ale_echo_msg_warning_str                         *g:ale_echo_msg_warning_str*
 
   Type: |String|
@@ -1188,17 +1197,20 @@ g:ale_lsp_show_message_format                           *g:ale_lsp_show_message_
   Default: `'%severity%:%linter%: %s'`
 
   This variable defines the format that messages received from an LSP will
-  have. The following sequences of characters will be replaced.
+  have when echoed. The following sequences of characters will be replaced.
 
     `%s`           - replaced with the message text
     `%linter%`     - replaced with the name of the linter
     `%severity%`   - replaced with the severity of the message
 
-  To configure the strings used on the `%severity%` field, see |g:ale_echo_msg_format|.
+  The strings for `%severity%` levels "error", "info" and "warning" are shared
+  with |g:ale_echo_msg_format|. Severity "log" is unique to
+  |g:ale_lsp_show_message_format| and it can be configured via
 
-  The echo message format can also be configured separately for each buffer,
-  so different formats can be used for different languages. (Say in ftplugin
-  files.)
+    |g:ale_echo_msg_log_str|     - Defaults to `'Log'`
+
+  Please note that |g:ale_lsp_show_message_format| *can not* be configured
+  separately for each buffer like |g:ale_echo_msg_format| can.
 
 
 g:ale_lsp_show_message_severity                         *g:ale_lsp_show_message_severity*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -734,7 +734,7 @@ g:ale_echo_msg_info_str                               *g:ale_echo_msg_info_str*
   The string used for `%severity%` for info. See |g:ale_echo_msg_format|
 
 
-g:ale_echo_msg_log_str                               *g:ale_echo_msg_log_str*
+g:ale_echo_msg_log_str                                 *g:ale_echo_msg_log_str*
 
   Type: |String|
   Default: `'Log'`

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -62,3 +62,41 @@ Execute(ale#lsp#window#showMessage() should handle severity Log):
   \ ['redraw | echomsg ''Info:some_linter: just log this'''],
   \ g:expr_list
 
+
+Execute(ale#lsp#window#formatString should format strings properly):
+  " Replacement at the beginning
+  AssertEqual
+  \ 'one two three',
+  \ ale#lsp#window#formatString('%foo% two three', {'foo': 'one'})
+
+  " Replacement at the end
+  AssertEqual
+  \ 'one two three',
+  \ ale#lsp#window#formatString('one two %arg%', {'arg': 'three'})
+
+  " Replacement in the middle
+  AssertEqual
+  \ 'one two three',
+  \ ale#lsp#window#formatString('one %two% three', {'two': 'two'})
+
+
+Execute(ale#lsp#window#formatString should fail for invalid replacement):
+  AssertThrows call ale#lsp#window#formatString('', {'colon:error': 'value'})
+  AssertEqual 'Invalid argument ''colon:error''. Arguments must follow ' . 
+  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
+
+  AssertThrows call ale#lsp#window#formatString('', {'0leadingzero': 'value'})
+  AssertEqual 'Invalid argument ''0leadingzero''. Arguments must follow ' .
+  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
+
+  AssertThrows call ale#lsp#window#formatString('', {'_leadingunderscore': 'value'})
+  AssertEqual 'Invalid argument ''_leadingunderscore''. Arguments must follow ' .
+  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
+
+  AssertThrows call ale#lsp#window#formatString('', {'123': 'value'})
+  AssertEqual 'Invalid argument ''123''. Arguments must follow ' .
+  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
+
+  AssertThrows call ale#lsp#window#formatString('', {'%percent%': 'value'})
+  AssertEqual 'Invalid argument ''%percent%''. Arguments must follow ' .
+  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -1,7 +1,7 @@
 Before:
   let g:expr_list = []
   let g:linter_name = 'some_linter'
-  let g:format = '%severity%:%linter%: %text%'
+  let g:format = '%severity%:%linter%: %s'
   " Get the default value to restore it
   let g:default_severity = g:ale_lsp_show_message_severity
   let g:ale_lsp_show_message_severity = 'information'
@@ -63,31 +63,10 @@ Execute(ale#lsp#window#HandleShowMessage() should escape quotes on messages):
 
 Execute(ale#lsp#window#formatString should format strings properly):
   " Replacement at the beginning
-  AssertEqual 'one two three', ale#lsp#window#formatString('%foo% two three', {'foo': 'one'})
+  AssertEqual 'one two three', ale#lsp#window#formatString('%foo% two three', {'%foo%': 'one'})
 
   " Replacement at the end
-  AssertEqual 'one two three', ale#lsp#window#formatString('one two %arg%', {'arg': 'three'})
+  AssertEqual 'one two three', ale#lsp#window#formatString('one two %arg', {'%arg': 'three'})
 
   " Replacement in the middle
-  AssertEqual 'one two three', ale#lsp#window#formatString('one %two% three', {'two': 'two'})
-
-Execute(ale#lsp#window#formatString should fail for invalid replacement):
-  AssertThrows call ale#lsp#window#formatString('', {'colon:error': 'value'})
-  AssertEqual 'Invalid argument ''colon:error''. Arguments must follow ' . 
-  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
-
-  AssertThrows call ale#lsp#window#formatString('', {'0leadingzero': 'value'})
-  AssertEqual 'Invalid argument ''0leadingzero''. Arguments must follow ' .
-  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
-
-  AssertThrows call ale#lsp#window#formatString('', {'_leadingunderscore': 'value'})
-  AssertEqual 'Invalid argument ''_leadingunderscore''. Arguments must follow ' .
-  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
-
-  AssertThrows call ale#lsp#window#formatString('', {'123': 'value'})
-  AssertEqual 'Invalid argument ''123''. Arguments must follow ' .
-  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
-
-  AssertThrows call ale#lsp#window#formatString('', {'%percent%': 'value'})
-  AssertEqual 'Invalid argument ''%percent%''. Arguments must follow ' .
-  \ 'pattern [a-zA-Z][a-zA-Z0-9_]*', g:vader_exception
+  AssertEqual 'one 2 three', ale#lsp#window#formatString('one two three', {'two': '2'})

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -17,56 +17,54 @@ After:
   let g:ale_lsp_show_message_severity = g:default_severity
   unlet! g:default_severity
 
-Execute(ale#lsp#window#HandleShowMessage() should only show errors when configured severity is error):
+Execute(ale#lsp_window#HandleShowMessage() should only show errors when configured severity is error):
   let g:ale_lsp_show_message_severity = 'error'
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual ['Error:some_linter: an error'], g:expr_list
 
-Execute(ale#lsp#window#HandleShowMessage() should only show errors and warnings when configured severity is warning):
+Execute(ale#lsp_window#HandleShowMessage() should only show errors and warnings when configured severity is warning):
   let g:ale_lsp_show_message_severity = 'warning'
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual ['Error:some_linter: an error', 'Warning:some_linter: a warning'], g:expr_list
 
-Execute(ale#lsp#window#HandleShowMessage() should only show errors, warnings and infos when configured severity is information):
+Execute(ale#lsp_window#HandleShowMessage() should only show errors, warnings and infos when configured severity is information):
   let g:ale_lsp_show_message_severity = 'information'
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual [
   \ 'Error:some_linter: an error',
   \ 'Warning:some_linter: a warning',
   \ 'Info:some_linter: an info'],
   \ g:expr_list
 
-Execute(ale#lsp#window#HandleShowMessage() should not show severity log regardless of the config):
+Execute(ale#lsp_window#HandleShowMessage() should not show severity log regardless of the config):
   let g:ale_lsp_show_message_severity = 'log'
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual [
   \ 'Error:some_linter: an error',
   \ 'Warning:some_linter: a warning',
   \ 'Info:some_linter: an info'],
   \ g:expr_list
 
-Execute(ale#lsp#window#HandleShowMessage() should escape quotes on messages):
-  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':"this is an 'info'"})
+Execute(ale#lsp_window#HandleShowMessage() should not show anything if severity is configured as disabled):
+  let g:ale_lsp_show_message_severity = 'disabled'
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual [], g:expr_list
+
+Execute(ale#lsp_window#HandleShowMessage() should escape quotes on messages):
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':"this is an 'info'"})
   AssertEqual ['Info:some_linter: this is an ''info'''], g:expr_list
-
-Execute(ale#lsp#window#formatString should format strings properly):
-  " Replacement at the beginning
-  AssertEqual 'one two three', ale#lsp#window#formatString('%foo% two three', {'%foo%': 'one'})
-
-  " Replacement at the end
-  AssertEqual 'one two three', ale#lsp#window#formatString('one two %arg', {'%arg': 'three'})
-
-  " Replacement in the middle
-  AssertEqual 'one 2 three', ale#lsp#window#formatString('one two three', {'two': '2'})

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -1,5 +1,8 @@
 Before:
   let g:expr_list = []
+  let g:linter_name = 'some_linter'
+  let g:format = '%severity%:%linter%: %text%'
+
 
   function! ale#util#Execute(expr) abort
     call add(g:expr_list, a:expr)
@@ -8,11 +11,15 @@ Before:
 
 After:
   unlet! g:expr_list
+  unlet! g:linter_name
+  unlet! g:format
+
 
 Execute(ale#lsp#window#showMessage() should handle severity Error):
   call ale#lsp#window#showMessage(
-  \ 'some_linter',
-  \ {'params': {'type':1,'message':'an error'}})
+  \  g:linter_name,
+  \  g:format,
+  \  {'type':1,'message':'an error'})
 
   AssertEqual
   \ ['redraw | ' .
@@ -23,22 +30,35 @@ Execute(ale#lsp#window#showMessage() should handle severity Error):
 
 Execute(ale#lsp#window#showMessage() should handle severity Warning):
   call ale#lsp#window#showMessage(
-  \ 'some_linter',
-  \ {'params': {'type':2,'message':'a warning'}})
+  \  g:linter_name,
+  \  g:format,
+  \  {'type':2,'message':'a warning'})
 
   AssertEqual
   \ ['redraw | ' .
-  \  'echohl WarningMsg | '. 
+  \  'echohl WarningMsg | '.
   \  'echomsg ''Warning:some_linter: a warning'' | ' .
   \  'echohl None'],
   \ g:expr_list
 
 Execute(ale#lsp#window#showMessage() should handle severity Info):
   call ale#lsp#window#showMessage(
-  \ 'some_linter',
-  \ {'params': {'type':3,'message':'an info'}})
+  \  g:linter_name,
+  \  g:format,
+  \  {'type':3,'message':'an info'})
 
   AssertEqual
   \ ['redraw | echomsg ''Info:some_linter: an info'''],
+  \ g:expr_list
+
+
+Execute(ale#lsp#window#showMessage() should handle severity Log):
+  call ale#lsp#window#showMessage(
+  \  g:linter_name,
+  \  g:format,
+  \  {'type':4,'message':'just log this'})
+
+  AssertEqual
+  \ ['redraw | echomsg ''Info:some_linter: just log this'''],
   \ g:expr_list
 

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -2,6 +2,9 @@ Before:
   let g:expr_list = []
   let g:linter_name = 'some_linter'
   let g:format = '%severity%:%linter%: %text%'
+  " Get the default value to restore it
+  let g:default_severity = g:ale_lsp_show_message_severity
+  let g:ale_lsp_show_message_severity = 'information'
 
 
   function! ale#util#Execute(expr) abort
@@ -15,8 +18,8 @@ After:
   unlet! g:format
 
 
-Execute(ale#lsp#window#showMessage() should handle severity Error):
-  call ale#lsp#window#showMessage(
+Execute(ale#lsp#window#HandleShowMessage() should handle severity Error):
+  call ale#lsp#window#HandleShowMessage(
   \  g:linter_name,
   \  g:format,
   \  {'type':1,'message':'an error'})
@@ -29,8 +32,8 @@ Execute(ale#lsp#window#showMessage() should handle severity Error):
   \ g:expr_list
 
 
-Execute(ale#lsp#window#showMessage() should handle severity Warning):
-  call ale#lsp#window#showMessage(
+Execute(ale#lsp#window#HandleShowMessage() should handle severity Warning):
+  call ale#lsp#window#HandleShowMessage(
   \  g:linter_name,
   \  g:format,
   \  {'type':2,'message':'a warning'})
@@ -43,8 +46,8 @@ Execute(ale#lsp#window#showMessage() should handle severity Warning):
   \ g:expr_list
 
 
-Execute(ale#lsp#window#showMessage() should handle severity Info):
-  call ale#lsp#window#showMessage(
+Execute(ale#lsp#window#HandleShowMessage() should handle severity Info):
+  call ale#lsp#window#HandleShowMessage(
   \  g:linter_name,
   \  g:format,
   \  {'type':3,'message':'an info'})
@@ -54,8 +57,8 @@ Execute(ale#lsp#window#showMessage() should handle severity Info):
   \ g:expr_list
 
 
-Execute(ale#lsp#window#showMessage() should handle severity Log):
-  call ale#lsp#window#showMessage(
+Execute(ale#lsp#window#HandleShowMessage() should handle severity Log):
+  call ale#lsp#window#HandleShowMessage(
   \  g:linter_name,
   \  g:format,
   \  {'type':4,'message':'just log this'})
@@ -63,8 +66,8 @@ Execute(ale#lsp#window#showMessage() should handle severity Log):
   AssertEqual [], g:expr_list
 
 
-Execute(ale#lsp#window#showMessage() should escape quotes on messages):
-  call ale#lsp#window#showMessage(
+Execute(ale#lsp#window#HandleShowMessage() should escape quotes on messages):
+  call ale#lsp#window#HandleShowMessage(
   \  g:linter_name,
   \  g:format,
   \  {'type':3,'message':"this is an 'info'"})

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -45,8 +45,8 @@ Execute(ale#lsp_window#HandleShowMessage() should only show errors, warnings and
   \ 'Info:some_linter: an info'],
   \ g:expr_list
 
-Execute(ale#lsp_window#HandleShowMessage() should not show severity log regardless of the config):
-  let g:ale_lsp_show_message_severity = 'log'
+Execute(ale#lsp_window#HandleShowMessage() should only show errors, warnings and infos when severity is set to "info"):
+  let g:ale_lsp_show_message_severity = 'info'
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
@@ -57,6 +57,19 @@ Execute(ale#lsp_window#HandleShowMessage() should not show severity log regardle
   \ 'Info:some_linter: an info'],
   \ g:expr_list
 
+Execute(ale#lsp_window#HandleShowMessage() should show all messages is severity is set to "log"):
+  let g:ale_lsp_show_message_severity = 'log'
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual [
+  \ 'Error:some_linter: an error',
+  \ 'Warning:some_linter: a warning',
+  \ 'Info:some_linter: an info',
+  \ 'Log:some_linter: a log'],
+  \ g:expr_list
+
 Execute(ale#lsp_window#HandleShowMessage() should not show anything if severity is configured as disabled):
   let g:ale_lsp_show_message_severity = 'disabled'
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
@@ -64,6 +77,17 @@ Execute(ale#lsp_window#HandleShowMessage() should not show anything if severity 
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual [], g:expr_list
+
+Execute(ale#lsp_window#HandleShowMessage() should use "warning" when severity is set to an invalid value):
+  let g:ale_lsp_show_message_severity = 'foo'
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual [
+  \ 'Error:some_linter: an error',
+  \ 'Warning:some_linter: a warning'],
+  \ g:expr_list
 
 Execute(ale#lsp_window#HandleShowMessage() should escape quotes on messages):
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':"this is an 'info'"})

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -28,6 +28,7 @@ Execute(ale#lsp#window#showMessage() should handle severity Error):
   \  'echohl None'],
   \ g:expr_list
 
+
 Execute(ale#lsp#window#showMessage() should handle severity Warning):
   call ale#lsp#window#showMessage(
   \  g:linter_name,
@@ -40,6 +41,7 @@ Execute(ale#lsp#window#showMessage() should handle severity Warning):
   \  'echomsg ''Warning:some_linter: a warning'' | ' .
   \  'echohl None'],
   \ g:expr_list
+
 
 Execute(ale#lsp#window#showMessage() should handle severity Info):
   call ale#lsp#window#showMessage(
@@ -58,9 +60,7 @@ Execute(ale#lsp#window#showMessage() should handle severity Log):
   \  g:format,
   \  {'type':4,'message':'just log this'})
 
-  AssertEqual
-  \ ['redraw | echomsg ''Info:some_linter: just log this'''],
-  \ g:expr_list
+  AssertEqual [], g:expr_list
 
 
 Execute(ale#lsp#window#formatString should format strings properly):

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -11,34 +11,34 @@ After:
 
 Execute(ale#lsp#window#showMessage() should handle severity Error):
   call ale#lsp#window#showMessage(
-      \ 'some_linter',
-      \ {'params': {'type':1,'message':'an error'}})
+  \ 'some_linter',
+  \ {'params': {'type':1,'message':'an error'}})
 
   AssertEqual
-    \ ['redraw | ' .
-    \  'echohl ErrorMsg | ' .
-    \  'echomsg ''Error:some_linter: an error'' | ' .
-    \  'echohl None'],
-    \ g:expr_list
+  \ ['redraw | ' .
+  \  'echohl ErrorMsg | ' .
+  \  'echomsg ''Error:some_linter: an error'' | ' .
+  \  'echohl None'],
+  \ g:expr_list
 
 Execute(ale#lsp#window#showMessage() should handle severity Warning):
   call ale#lsp#window#showMessage(
-      \ 'some_linter',
-      \ {'params': {'type':2,'message':'a warning'}})
+  \ 'some_linter',
+  \ {'params': {'type':2,'message':'a warning'}})
 
   AssertEqual
-    \ ['redraw | ' .
-    \  'echohl WarningMsg | '. 
-    \  'echomsg ''Warning:some_linter: a warning'' | ' .
-    \  'echohl None'],
-    \ g:expr_list
+  \ ['redraw | ' .
+  \  'echohl WarningMsg | '. 
+  \  'echomsg ''Warning:some_linter: a warning'' | ' .
+  \  'echohl None'],
+  \ g:expr_list
 
 Execute(ale#lsp#window#showMessage() should handle severity Info):
   call ale#lsp#window#showMessage(
-      \ 'some_linter',
-      \ {'params': {'type':3,'message':'an info'}})
+  \ 'some_linter',
+  \ {'params': {'type':3,'message':'an info'}})
 
   AssertEqual
-    \ ['redraw | echomsg ''Info:some_linter: an info'''],
-    \ g:expr_list
+  \ ['redraw | echomsg ''Info:some_linter: an info'''],
+  \ g:expr_list
 

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -6,93 +6,70 @@ Before:
   let g:default_severity = g:ale_lsp_show_message_severity
   let g:ale_lsp_show_message_severity = 'information'
 
-
-  function! ale#util#Execute(expr) abort
+  function! ale#util#ShowMessage(expr) abort
     call add(g:expr_list, a:expr)
   endfunction
-
 
 After:
   unlet! g:expr_list
   unlet! g:linter_name
   unlet! g:format
+  let g:ale_lsp_show_message_severity = g:default_severity
+  unlet! g:default_severity
 
+Execute(ale#lsp#window#HandleShowMessage() should only show errors when configured severity is error):
+  let g:ale_lsp_show_message_severity = 'error'
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual ['Error:some_linter: an error'], g:expr_list
 
-Execute(ale#lsp#window#HandleShowMessage() should handle severity Error):
-  call ale#lsp#window#HandleShowMessage(
-  \  g:linter_name,
-  \  g:format,
-  \  {'type':1,'message':'an error'})
+Execute(ale#lsp#window#HandleShowMessage() should only show errors and warnings when configured severity is warning):
+  let g:ale_lsp_show_message_severity = 'warning'
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual ['Error:some_linter: an error', 'Warning:some_linter: a warning'], g:expr_list
 
-  AssertEqual
-  \ ['redraw | ' .
-  \  'echohl ErrorMsg | ' .
-  \  'echomsg ''Error:some_linter: an error'' | ' .
-  \  'echohl None'],
+Execute(ale#lsp#window#HandleShowMessage() should only show errors, warnings and infos when configured severity is information):
+  let g:ale_lsp_show_message_severity = 'information'
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual [
+  \ 'Error:some_linter: an error',
+  \ 'Warning:some_linter: a warning',
+  \ 'Info:some_linter: an info'],
   \ g:expr_list
 
-
-Execute(ale#lsp#window#HandleShowMessage() should handle severity Warning):
-  call ale#lsp#window#HandleShowMessage(
-  \  g:linter_name,
-  \  g:format,
-  \  {'type':2,'message':'a warning'})
-
-  AssertEqual
-  \ ['redraw | ' .
-  \  'echohl WarningMsg | '.
-  \  'echomsg ''Warning:some_linter: a warning'' | ' .
-  \  'echohl None'],
+Execute(ale#lsp#window#HandleShowMessage() should not show severity log regardless of the config):
+  let g:ale_lsp_show_message_severity = 'log'
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':'an info'})
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
+  AssertEqual [
+  \ 'Error:some_linter: an error',
+  \ 'Warning:some_linter: a warning',
+  \ 'Info:some_linter: an info'],
   \ g:expr_list
-
-
-Execute(ale#lsp#window#HandleShowMessage() should handle severity Info):
-  call ale#lsp#window#HandleShowMessage(
-  \  g:linter_name,
-  \  g:format,
-  \  {'type':3,'message':'an info'})
-
-  AssertEqual
-  \ ['redraw | echomsg ''Info:some_linter: an info'''],
-  \ g:expr_list
-
-
-Execute(ale#lsp#window#HandleShowMessage() should handle severity Log):
-  call ale#lsp#window#HandleShowMessage(
-  \  g:linter_name,
-  \  g:format,
-  \  {'type':4,'message':'just log this'})
-
-  AssertEqual [], g:expr_list
-
 
 Execute(ale#lsp#window#HandleShowMessage() should escape quotes on messages):
-  call ale#lsp#window#HandleShowMessage(
-  \  g:linter_name,
-  \  g:format,
-  \  {'type':3,'message':"this is an 'info'"})
-
-  AssertEqual
-  \ ['redraw | echomsg ''Info:some_linter: this is an ''''info'''''''],
-  \ g:expr_list
-
+  call ale#lsp#window#HandleShowMessage(g:linter_name, g:format, {'type':3,'message':"this is an 'info'"})
+  AssertEqual ['Info:some_linter: this is an ''info'''], g:expr_list
 
 Execute(ale#lsp#window#formatString should format strings properly):
   " Replacement at the beginning
-  AssertEqual
-  \ 'one two three',
-  \ ale#lsp#window#formatString('%foo% two three', {'foo': 'one'})
+  AssertEqual 'one two three', ale#lsp#window#formatString('%foo% two three', {'foo': 'one'})
 
   " Replacement at the end
-  AssertEqual
-  \ 'one two three',
-  \ ale#lsp#window#formatString('one two %arg%', {'arg': 'three'})
+  AssertEqual 'one two three', ale#lsp#window#formatString('one two %arg%', {'arg': 'three'})
 
   " Replacement in the middle
-  AssertEqual
-  \ 'one two three',
-  \ ale#lsp#window#formatString('one %two% three', {'two': 'two'})
-
+  AssertEqual 'one two three', ale#lsp#window#formatString('one %two% three', {'two': 'two'})
 
 Execute(ale#lsp#window#formatString should fail for invalid replacement):
   AssertThrows call ale#lsp#window#formatString('', {'colon:error': 'value'})

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -1,0 +1,44 @@
+Before:
+  let g:expr_list = []
+
+  function! ale#util#Execute(expr) abort
+    call add(g:expr_list, a:expr)
+  endfunction
+
+
+After:
+  unlet! g:expr_list
+
+Execute(ale#lsp#window#showMessage() should handle severity Error):
+  call ale#lsp#window#showMessage(
+      \ 'some_linter',
+      \ {'params': {'type':1,'message':'an error'}})
+
+  AssertEqual
+    \ ['redraw | ' .
+    \  'echohl ErrorMsg | ' .
+    \  'echomsg ''Error:some_linter: an error'' | ' .
+    \  'echohl None'],
+    \ g:expr_list
+
+Execute(ale#lsp#window#showMessage() should handle severity Warning):
+  call ale#lsp#window#showMessage(
+      \ 'some_linter',
+      \ {'params': {'type':2,'message':'a warning'}})
+
+  AssertEqual
+    \ ['redraw | ' .
+    \  'echohl WarningMsg | '. 
+    \  'echomsg ''Warning:some_linter: a warning'' | ' .
+    \  'echohl None'],
+    \ g:expr_list
+
+Execute(ale#lsp#window#showMessage() should handle severity Info):
+  call ale#lsp#window#showMessage(
+      \ 'some_linter',
+      \ {'params': {'type':3,'message':'an info'}})
+
+  AssertEqual
+    \ ['redraw | echomsg ''Info:some_linter: an info'''],
+    \ g:expr_list
+

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -17,7 +17,7 @@ After:
   let g:ale_lsp_show_message_severity = g:default_severity
   unlet! g:default_severity
 
-Execute(ale#lsp_window#HandleShowMessage() should only show errors when configured severity is error):
+Execute(ale#lsp_window#HandleShowMessage() should only show errors when severity is set to "error"):
   let g:ale_lsp_show_message_severity = 'error'
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
@@ -25,7 +25,7 @@ Execute(ale#lsp_window#HandleShowMessage() should only show errors when configur
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual ['Error:some_linter: an error'], g:expr_list
 
-Execute(ale#lsp_window#HandleShowMessage() should only show errors and warnings when configured severity is warning):
+Execute(ale#lsp_window#HandleShowMessage() should only show errors and warnings when severity is set to "warning"):
   let g:ale_lsp_show_message_severity = 'warning'
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})
@@ -33,7 +33,7 @@ Execute(ale#lsp_window#HandleShowMessage() should only show errors and warnings 
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':4,'message':'a log'})
   AssertEqual ['Error:some_linter: an error', 'Warning:some_linter: a warning'], g:expr_list
 
-Execute(ale#lsp_window#HandleShowMessage() should only show errors, warnings and infos when configured severity is information):
+Execute(ale#lsp_window#HandleShowMessage() should only show errors, warnings and infos when severity is set to "information"):
   let g:ale_lsp_show_message_severity = 'information'
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':1,'message':'an error'})
   call ale#lsp_window#HandleShowMessage(g:linter_name, g:format, {'type':2,'message':'a warning'})

--- a/test/lsp/test_handling_window_requests.vader
+++ b/test/lsp/test_handling_window_requests.vader
@@ -63,6 +63,17 @@ Execute(ale#lsp#window#showMessage() should handle severity Log):
   AssertEqual [], g:expr_list
 
 
+Execute(ale#lsp#window#showMessage() should escape quotes on messages):
+  call ale#lsp#window#showMessage(
+  \  g:linter_name,
+  \  g:format,
+  \  {'type':3,'message':"this is an 'info'"})
+
+  AssertEqual
+  \ ['redraw | echomsg ''Info:some_linter: this is an ''''info'''''''],
+  \ g:expr_list
+
+
 Execute(ale#lsp#window#formatString should format strings properly):
   " Replacement at the beginning
   AssertEqual


### PR DESCRIPTION
Text received via this methods is added to the message stream.

Implementation notes:

* Use variable `g:ale_lsp_show_message_format` to tweak the format; default is `'%severity%:%linter%: %text%'` (this value includes all options implemented)
* `window/showMessage` can have severity "log", which seems the same as `window/logMessage`. Since I could not find a logging mechanism, I chose to ignore them. An alternative would be to log like Info, but that might lead to flooding the UI
* I've hard coded the highlights for error and warning severities to `ErrorMsg` and `WarningMsg` respectively, please advise if there's an ALE specific highlight group that's better suited
