### PR TITLE
Fix bug with detection of the PLT in Erlang Dialyzer

### DIFF
--- a/ale_linters/erlang/dialyzer.vim
+++ b/ale_linters/erlang/dialyzer.vim
@@ -15,10 +15,10 @@ endfunction
 function! ale_linters#erlang#dialyzer#FindPlt(buffer) abort
     let l:plt_file = ''
     let l:rebar3_profile = ale_linters#erlang#dialyzer#GetRebar3Profile(a:buffer)
-    let l:plt_file_directory = ale#path#FindNearestDirectory(a:buffer, '_build' . l:rebar3_profile)
+    let l:plt_file_directory = ale#path#FindNearestDirectory(a:buffer, '_build/' . l:rebar3_profile)
 
     if !empty(l:plt_file_directory)
-        let l:plt_file = split(globpath(l:plt_file_directory, '/*_plt'), '\n')
+        let l:plt_file = globpath(l:plt_file_directory, '*_plt', 0, 1)
     endif
 
     if !empty(l:plt_file)


### PR DESCRIPTION
Previously, it did not detect the PLT inside the `_build` directory and
would always default to the default PLT or the one from the `kerl` tool.