### PR TITLE
Edit ale-cs-csc docs to remove typos

### DIFF
--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -11,22 +11,21 @@ csc                                                                *ale-cs-csc*
 
   The |ale-cs-csc| linter checks for semantic errors when files are opened or
   saved.
-  
+
   See |ale-lint-file-linters| for more information on linters which do not
   check for problems while you type.
 
-  The csc linter uses the mono csc compiler providing full c# 7 and newer 
-  support to generate a temporary module target file (/t:module). The module
-  includes including all '*.cs' files  contained in the directory tree rooted
-  at the path defined by the |g:ale_cs_csc_source| or |b:ale_cs_csc_source|
-  variabl and all sub directories.
-  
+  The csc linter uses the mono csc compiler, providing full C# 7 and newer
+  support, to generate a temporary module target file (/t:module). The module
+  includes all '*.cs' files contained in the directory tree rooted at the path
+  defined by the |g:ale_cs_csc_source| or |b:ale_cs_csc_source| variable and
+  all sub directories.
+
   It will in future replace the |ale-cs-mcs| and |ale-cs-mcsc| linters as both
-  utilizer the mcsc compiler which according to mono porject ist further
-  developed and as of writint these lines only receives maintenance updates.
-  The down is that the csc compiler does not support the -sytax option any more
-  and therefore |ale-cs-csc| linter doese not offer any as you type syntax
-  checking like the |ale-cs-mcsc| linter doesn't.
+  utilize the mcsc compiler which, according to the mono project, is no longer
+  actively developed, and only receives maintenance updates. However, because
+  the csc compiler does not support the -syntax option, this linter does not
+  offer any as-you-type syntax checking, similar to the |ale-cs-mcsc| linter.
 
   The paths to search for additional assembly files can be specified using the
   |g:ale_cs_csc_assembly_path| or |b:ale_cs_csc_assembly_path| variables.


### PR DESCRIPTION
Edits the ale-cs-csc docs to remove typos, misspellings, and run-on sentences.