### PR TITLE
Fix broken ouptut of eslint when there are depricated rules

### DIFF
--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -44,7 +44,7 @@ function! ale#handlers#eslint#GetCommand(buffer) abort
 
     return ale#node#Executable(a:buffer, l:executable)
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' -f json --stdin --stdin-filename %s'
+    \   . ' -f json --stdin --stdin-filename %s 2> /dev/null'
 endfunction
 
 function! s:AddHintsForTypeScriptParsingErrors(output) abort

--- a/test/test_eslint_executable_detection.vader
+++ b/test/test_eslint_executable_detection.vader
@@ -64,6 +64,6 @@ Execute(eslint.js executables should be run with node on Windows):
   else
     AssertEqual
     \ ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
-    \   . ' -f json --stdin --stdin-filename %s',
+    \   . ' -f json --stdin --stdin-filename %s 2> /dev/null',
     \ ale#handlers#eslint#GetCommand(bufnr(''))
   endif


### PR DESCRIPTION
When there is DeprecationWarning in the output of eslint, then plugin won't work. For example I stumbled upon on this rule `parserOptions.ecmaFeatures.experimentalObjectRestSpread` that caused broken linting experience:

```
(node:25580) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "airbnb-base")
```