### PR TITLE
Add nixpkgs-fmt fixer.

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -335,6 +335,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['ada'],
 \       'description': 'Format Ada files with gnatpp.',
 \   },
+\   'nixpkgs-fmt': {
+\       'function': 'ale#fixers#nixpkgsfmt#Fix',
+\       'suggested_filetypes': ['nix'],
+\       'description': 'A formatter for Nix code',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/nixpkgsfmt.vim
+++ b/autoload/ale/fixers/nixpkgsfmt.vim
@@ -1,0 +1,12 @@
+call ale#Set('nix_nixpkgsfmt_executable', 'nixpkgs-fmt')
+call ale#Set('nix_nixpkgsfmt_options', '')
+
+function! ale#fixers#nixpkgsfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'nix_nixpkgsfmt_executable')
+    let l:options = ale#Var(a:buffer, 'nix_nixpkgsfmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \}
+endfunction

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -1,0 +1,24 @@
+===============================================================================
+ALE Nix Integration                                           *ale-nix-options*
+
+
+===============================================================================
+nixpkgs-fmt                                                 *ale-nix-nixpkgs-fmt*
+
+g:ale_nix_nixpkgsfmt_executable                *g:ale_nix_nixpkgsfmt_executable*
+                                               *b:ale_nix_nixpkgsfmt_executable*
+  Type: |String|
+  Default: `'nixpkgs-fmt'`
+
+  This variable sets executable used for nixpkgs-fmt.
+
+g:ale_nix_nixpkgsfmt_options                     *g:ale_nix_nixpkgsfmt_options*
+                                                 *b:ale_nix_nixpkgsfmt_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the nixpkgs-fmt fixer.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -281,6 +281,7 @@ Notes:
   * `nim check`!!
 * nix
   * `nix-instantiate`
+  * `nixpkgs-fmt`
 * nroff
   * `alex`!!
   * `proselint`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2191,6 +2191,8 @@ documented in additional help files.
     mmc...................................|ale-mercury-mmc|
   nasm....................................|ale-nasm-options|
     nasm..................................|ale-nasm-nasm|
+  nix.....................................|ale-nix-options|
+    nixpkgs-fmt...........................|ale-nix-nixpkgs-fmt|
   nroff...................................|ale-nroff-options|
     write-good............................|ale-nroff-write-good|
   objc....................................|ale-objc-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -290,6 +290,7 @@ formatting.
   * [nim check](https://nim-lang.org/docs/nimc.html) :floppy_disk:
 * nix
   * [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate)
+  * [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)
 * nroff
   * [alex](https://github.com/wooorm/alex) :floppy_disk:
   * [proselint](http://proselint.com/)

--- a/test/fixers/test_nixpkgsfmt_fixer_callback.vader
+++ b/test/fixers/test_nixpkgsfmt_fixer_callback.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_nix_nixpkgsfmt_executable
+  Save g:ale_nix_nixpkgsfmt_options
+
+After:
+  Restore
+
+Execute(The nixpkgs-fmt callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('nixpkgs-fmt')
+  \ },
+  \ ale#fixers#nixpkgsfmt#Fix(bufnr(''))
+
+Execute(The nixpkgs-fmt executable and options should be configurable):
+  let g:ale_nix_nixpkgsfmt_executable = '/path/to/nixpkgs-fmt'
+  let g:ale_nix_nixpkgsfmt_options = '-h'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/nixpkgs-fmt')
+  \     . ' -h',
+  \ },
+  \ ale#fixers#nixpkgsfmt#Fix(bufnr(''))


### PR DESCRIPTION
This commit adds a fixer for the Nix language, nixfmt (https://github.com/serokell/nixfmt).