### PR TITLE
Remove `/bin/ls` assumption from check-toc test.

### DIFF
--- a/test/script/check-toc
+++ b/test/script/check-toc
@@ -35,7 +35,7 @@ sed -n "$toc_start_line,$toc_end_line"p doc/ale.txt \
     > "$toc_file"
 
 # Get all of the doc files in a natural sorted order.
-doc_files="$(/bin/ls -1v doc | grep ^ale- | sed 's/^/doc\//' | paste -sd ' ' -)"
+doc_files="$(/usr/bin/env ls -1v doc | grep ^ale- | sed 's/^/doc\//' | paste -sd ' ' -)"
 
 # shellcheck disable=SC2086
 grep -h '\*ale-.*-options\|^[a-z].*\*ale-.*\*$' $doc_files \


### PR DESCRIPTION
On some systems, notably NixOS, there is no `/bin/ls` and thus this test can fail unnecessarily on those systems. This PR uses `/usr/bin/env ls` which resolves the issue.
