### PR TITLE
Use cache for clj-kondo linter

### DIFF
--- a/ale_linters/clojure/clj_kondo.vim
+++ b/ale_linters/clojure/clj_kondo.vim
@@ -29,6 +29,6 @@ call ale#linter#Define('clojure', {
 \   'name': 'clj-kondo',
 \   'output_stream': 'stdout',
 \   'executable': 'clj-kondo',
-\   'command': 'clj-kondo --lint %t',
+\   'command': 'clj-kondo --cache --lint %t',
 \   'callback': 'ale_linters#clojure#clj_kondo#HandleCljKondoFormat',
 \})


### PR DESCRIPTION
This is a very small change, I'm not sure about how to test it if tests are necessary for the command executed for linting. Let me know if this is missing something.