### PR TITLE
Add support for ink-language-server

### DIFF
--- a/ale_linters/ink/ls.vim
+++ b/ale_linters/ink/ls.vim
@@ -1,0 +1,35 @@
+" Author: Andreww Hayworth <ahayworth@gmail.com>
+" Description: Integrate ALE with ink-language-server
+
+call ale#Set('ink_ls_executable', 'ink-language-server')
+call ale#Set('ink_ls_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('ink_ls_initialization_options', {})
+
+function! ale_linters#ink#ls#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'ink_ls', [
+    \   'ink-language-server',
+    \   'node_modules/.bin/ink-language-server',
+    \])
+endfunction
+
+function! ale_linters#ink#ls#GetCommand(buffer) abort
+    let l:executable = ale_linters#ink#ls#GetExecutable(a:buffer)
+
+    return ale#Escape(l:executable) . ' --stdio'
+endfunction
+
+function! ale_linters#ink#ls#FindProjectRoot(buffer) abort
+    let l:main_file = get(ale#Var(a:buffer, 'ink_ls_initialization_options'), 'mainStoryPath', 'main.ink')
+    let l:config = ale#path#ResolveLocalPath(a:buffer, l:main_file, expand('#' . a:buffer . ':p'))
+
+    return ale#path#Dirname(l:config)
+endfunction
+
+call ale#linter#Define('ink', {
+\   'name': 'ink-language-server',
+\   'lsp': 'stdio',
+\   'executable': function('ale_linters#ink#ls#GetExecutable'),
+\   'command': function('ale_linters#ink#ls#GetCommand'),
+\   'project_root': function('ale_linters#ink#ls#FindProjectRoot'),
+\   'initialization_options': {b -> ale#Var(b, 'ink_ls_initialization_options')},
+\})

--- a/doc/ale-ink.txt
+++ b/doc/ale-ink.txt
@@ -1,0 +1,40 @@
+===============================================================================
+ALE Ink Integration                                           *ale-ink-options*
+
+
+===============================================================================
+ink-language-server                                   *ale-ink-language-server*
+
+Ink Language Server
+  (https://github.com/ephraim/ink-language-server)
+
+g:ale_ink_ls_executable                               g:ale_ink_ls_executable
+                                                      b:ale_ink_ls_executable
+  Type: |String|
+  Default: `'ink-language-server'`
+
+  Ink language server executable.
+
+g:ale_ink_ls_initialization_options
+                                          g:ale_ink_ls_initialization_options
+                                          b:ale_ink_ls_initialization_options
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary containing configuration settings that will be passed to the
+  language server at startup. For certain platforms and certain story
+  structures, the defaults will suffice. However, many projects will need to
+  change these settings - see the ink-language-server website for more
+  information.
+
+  An example of setting non-default options:
+		{
+		\  'ink': {
+		\    'mainStoryPath': 'init.ink',
+		\    'inklecateExecutablePath': '/usr/local/bin/inklecate',
+		\    'runThroughMono': v:false
+		\  }
+		\}
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -198,6 +198,8 @@ Notes:
   * `write-good`
 * Idris
   * `idris`
+* Ink
+  * `ink-language-server`
 * ISPC
   * `ispc`!!
 * Java

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2123,6 +2123,8 @@ documented in additional help files.
     write-good............................|ale-html-write-good|
   idris...................................|ale-idris-options|
     idris.................................|ale-idris-idris|
+  ink.....................................|ale-ink-options|
+    ink-language-server...................|ale-ink-language-server|
   ispc....................................|ale-ispc-options|
     ispc..................................|ale-ispc-ispc|
   java....................................|ale-java-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -207,6 +207,8 @@ formatting.
   * [write-good](https://github.com/btford/write-good)
 * Idris
   * [idris](http://www.idris-lang.org/)
+* Ink
+  * [ink-language-server](https://github.com/ephread/ink-language-server)
 * ISPC
   * [ispc](https://ispc.github.io/) :floppy_disk:
 * Java

--- a/test/command_callback/test_ink_ls_command_callbacks.vader
+++ b/test/command_callback/test_ink_ls_command_callbacks.vader
@@ -1,0 +1,22 @@
+Before:
+  call ale#assert#SetUpLinterTest('ink', 'ls')
+  set ft=ink
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(should set correct defaults):
+  AssertLinter 'ink-language-server', ale#Escape('ink-language-server') . ' --stdio'
+
+Execute(should set correct LSP values):
+  call ale#test#SetFilename('ink_paths/story/main.ink')
+
+  AssertLSPLanguage 'ink'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject ale#path#Simplify(g:dir . '/ink_paths/story')
+
+Execute(should accept configuration settings):
+  AssertLSPConfig {}
+  let b:ale_ink_ls_initialization_options = {'ink': {'runThroughMono': v:true}}
+  AssertLSPOptions {'ink': {'runThroughMono': v:true}}


### PR DESCRIPTION
Add support for ink-language-server

This commit add support for ink-language-server, which it does by
largely copying and pasting from the pure-language-server PR that was
merged recently.

The most interesting things to note are:
- ink-language-server is distributed upstream via npm, which is why we
  search through node_modules
- With some coaxing, it can be installed globally - which is why we
  search for a global binary.
- Ink is a funky language, and users will likely need to add
  initialization options.
- I am not incredibly familiar with vimscript; and I may not have done
  some of the buffer searching correctly.

<hr>

NB: Some of the formatting tests failed for me on both master, and my feature branch. Given that they fail both places, I've decided to make this PR anyways. But, if something in this commit did break tests, I'm happy to fix them of course.