### PR TITLE
force bash use en_US.UTF-8 lang

### DIFF
--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -27,7 +27,7 @@ function! ale_linters#sh#shell#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#sh#shell#GetCommand(buffer) abort
-    return ale_linters#sh#shell#GetExecutable(a:buffer) . ' -n %t'
+    return 'export LANG=en_US.UTF-8;' . ale_linters#sh#shell#GetExecutable(a:buffer) . ' -n %t'
 endfunction
 
 function! ale_linters#sh#shell#Handle(buffer, lines) abort


### PR DESCRIPTION
fix https://github.com/dense-analysis/ale/issues/2687
if system lang is zh_CN.UTF-8,bash will output chinese and ale will not show any warning or error sign.
maybe other linters also have this problem.
in this linter force  bash to use en_US.UTF-8 will fix this problem