### PR TITLE
mdl: Use JSON output instead of parsing text

### DIFF
--- a/ale_linters/markdown/mdl.vim
+++ b/ale_linters/markdown/mdl.vim
@@ -17,18 +17,17 @@ function! ale_linters#markdown#mdl#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'markdown_mdl_options')
 
     return ale#Escape(l:executable) . l:exec_args
-    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' -j' . (!empty(l:options) ? ' ' . l:options : '')
 endfunction
 
 function! ale_linters#markdown#mdl#Handle(buffer, lines) abort
-    " matches: '(stdin):173: MD004 Unordered list style'
-    let l:pattern = ':\(\d*\): \(.*\)$'
     let l:output = []
 
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+    for l:error in ale#util#FuzzyJSONDecode(a:lines, [])
         call add(l:output, {
-        \   'lnum': l:match[1] + 0,
-        \   'text': l:match[2],
+        \   'lnum': l:error['line'],
+        \   'code': l:error['rule']  . '/' . join(l:error['aliases'], '/'),
+        \   'text': l:error['description'],
         \   'type': 'W',
         \})
     endfor

--- a/test/command_callback/test_markdown_mdl_command_callback.vader
+++ b/test/command_callback/test_markdown_mdl_command_callback.vader
@@ -5,15 +5,15 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'mdl', ale#Escape('mdl')
+  AssertLinter 'mdl', ale#Escape('mdl') . ' -j'
 
 Execute(The executable and options should be configurable):
   let g:ale_markdown_mdl_executable = 'foo bar'
   let g:ale_markdown_mdl_options = '--wat'
 
-  AssertLinter 'foo bar', ale#Escape('foo bar') . ' --wat'
+  AssertLinter 'foo bar', ale#Escape('foo bar') . ' -j --wat'
 
 Execute(Setting bundle appends 'exec mdl'):
   let g:ale_markdown_mdl_executable = 'path to/bundle'
 
-  AssertLinter 'path to/bundle', ale#Escape('path to/bundle') . ' exec mdl'
+  AssertLinter 'path to/bundle', ale#Escape('path to/bundle') . ' exec mdl -j'

--- a/test/handler/test_mdl_handler.vader
+++ b/test/handler/test_mdl_handler.vader
@@ -1,0 +1,25 @@
+Before:
+  runtime ale_linters/markdown/mdl.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The mdl handler should parse output correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'code': 'MD002/first-header-h1',
+  \     'text': 'First header should be a top level header',
+  \     'type': 'W'
+  \   },
+  \   {
+  \     'lnum': 18,
+  \     'code': 'MD033/no-inline-html',
+  \     'text': 'Inline HTML',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale_linters#markdown#mdl#Handle(0, [
+  \     '[{"filename":"README.md","line":1,"rule":"MD002","aliases":["first-header-h1"],"description":"First header should be a top level header"},{"filename":"README.md","line":18,"rule":"MD033","aliases":["no-inline-html"],"description":"Inline HTML"}]'
+  \ ])


### PR DESCRIPTION
Also add test coverage for the mdl handler.

---

`-j` was added to mdl in June, 2018 with https://github.com/markdownlint/markdownlint/pull/206. Since mdl is generally distributed via RubyGems or maybe Homebrew (it is not packaged in Debian, Ubuntu, or Arch), I think it's reasonable to expect users to have a version less than 13 months old.