### PR TITLE
Move ale#handlers#ruby#EscapeExecutable to ale#ruby#EscapeExecutable

### DIFF
--- a/ale_linters/eruby/ruumba.vim
+++ b/ale_linters/eruby/ruumba.vim
@@ -8,7 +8,7 @@ call ale#Set('eruby_ruumba_options', '')
 function! ale_linters#eruby#ruumba#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'eruby_ruumba_executable')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'ruumba')
+    return ale#ruby#EscapeExecutable(l:executable, 'ruumba')
     \   . ' --format json --force-exclusion '
     \   . ale#Var(a:buffer, 'eruby_ruumba_options')
     \   . ' --stdin ' . ale#Escape(expand('#' . a:buffer . ':p'))

--- a/ale_linters/ruby/brakeman.vim
+++ b/ale_linters/ruby/brakeman.vim
@@ -36,7 +36,7 @@ function! ale_linters#ruby#brakeman#GetCommand(buffer) abort
 
     let l:executable = ale#Var(a:buffer, 'ruby_brakeman_executable')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'brakeman')
+    return ale#ruby#EscapeExecutable(l:executable, 'brakeman')
     \    . ' -f json -q '
     \    . ale#Var(a:buffer, 'ruby_brakeman_options')
     \    . ' -p ' . ale#Escape(l:rails_root)

--- a/ale_linters/ruby/rails_best_practices.vim
+++ b/ale_linters/ruby/rails_best_practices.vim
@@ -33,7 +33,7 @@ function! ale_linters#ruby#rails_best_practices#GetCommand(buffer) abort
     let l:output_file = has('win32') ? '%t ' : '/dev/stdout '
     let l:cat_file = has('win32') ? '; type %t' : ''
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'rails_best_practices')
+    return ale#ruby#EscapeExecutable(l:executable, 'rails_best_practices')
     \    . ' --silent -f json --output-file ' . l:output_file
     \    . ale#Var(a:buffer, 'ruby_rails_best_practices_options')
     \    . ale#Escape(l:rails_root)

--- a/ale_linters/ruby/reek.vim
+++ b/ale_linters/ruby/reek.vim
@@ -14,7 +14,7 @@ function! ale_linters#ruby#reek#GetCommand(buffer, version) abort
     \   ? ' --stdin-filename %s'
     \   : ''
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'reek')
+    return ale#ruby#EscapeExecutable(l:executable, 'reek')
     \   . ' -f json --no-progress --no-color --force-exclusion'
     \   . l:display_name_args
 endfunction

--- a/ale_linters/ruby/rubocop.vim
+++ b/ale_linters/ruby/rubocop.vim
@@ -7,7 +7,7 @@ call ale#Set('ruby_rubocop_options', '')
 function! ale_linters#ruby#rubocop#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_rubocop_executable')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'rubocop')
+    return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
     \   . ' --format json --force-exclusion '
     \   . ale#Var(a:buffer, 'ruby_rubocop_options')
     \   . ' --stdin ' . ale#Escape(expand('#' . a:buffer . ':p'))

--- a/ale_linters/ruby/sorbet.vim
+++ b/ale_linters/ruby/sorbet.vim
@@ -5,7 +5,7 @@ function! ale_linters#ruby#sorbet#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_sorbet_executable')
     let l:options = ale#Var(a:buffer, 'ruby_sorbet_options')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'srb')
+    return ale#ruby#EscapeExecutable(l:executable, 'srb')
     \   . ' tc'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' --lsp --disable-watchman'

--- a/ale_linters/ruby/standardrb.vim
+++ b/ale_linters/ruby/standardrb.vim
@@ -8,7 +8,7 @@ call ale#Set('ruby_standardrb_options', '')
 function! ale_linters#ruby#standardrb#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_standardrb_executable')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'standardrb')
+    return ale#ruby#EscapeExecutable(l:executable, 'standardrb')
     \   . ' --format json --force-exclusion '
     \   . ale#Var(a:buffer, 'ruby_standardrb_options')
     \   . ' --stdin ' . ale#Escape(expand('#' . a:buffer . ':p'))

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -6,7 +6,7 @@ function! ale#fixers#rubocop#GetCommand(buffer) abort
     let l:config = ale#path#FindNearestFile(a:buffer, '.rubocop.yml')
     let l:options = ale#Var(a:buffer, 'ruby_rubocop_options')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'rubocop')
+    return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' --auto-correct --force-exclusion %t'

--- a/autoload/ale/fixers/sorbet.vim
+++ b/autoload/ale/fixers/sorbet.vim
@@ -5,7 +5,7 @@ function! ale#fixers#sorbet#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_sorbet_executable')
     let l:options = ale#Var(a:buffer, 'ruby_sorbet_options')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'srb')
+    return ale#ruby#EscapeExecutable(l:executable, 'srb')
     \   . ' tc'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' --autocorrect --file %t'

--- a/autoload/ale/fixers/standardrb.vim
+++ b/autoload/ale/fixers/standardrb.vim
@@ -9,7 +9,7 @@ function! ale#fixers#standardrb#GetCommand(buffer) abort
     let l:config = ale#path#FindNearestFile(a:buffer, '.standard.yml')
     let l:options = ale#Var(a:buffer, 'ruby_standardrb_options')
 
-    return ale#handlers#ruby#EscapeExecutable(l:executable, 'standardrb')
+    return ale#ruby#EscapeExecutable(l:executable, 'standardrb')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' --fix --force-exclusion %t'

--- a/autoload/ale/handlers/ruby.vim
+++ b/autoload/ale/handlers/ruby.vim
@@ -36,11 +36,3 @@ endfunction
 function! ale#handlers#ruby#HandleSyntaxErrors(buffer, lines) abort
     return s:HandleSyntaxError(a:buffer, a:lines)
 endfunction
-
-function! ale#handlers#ruby#EscapeExecutable(executable, bundle_exec) abort
-    let l:exec_args = a:executable =~? 'bundle'
-    \   ? ' exec ' . a:bundle_exec
-    \   : ''
-
-    return ale#Escape(a:executable) . l:exec_args
-endfunction

--- a/autoload/ale/ruby.vim
+++ b/autoload/ale/ruby.vim
@@ -74,3 +74,10 @@ function! ale#ruby#HandleRubocopOutput(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale#ruby#EscapeExecutable(executable, bundle_exec) abort
+    let l:exec_args = a:executable =~? 'bundle'
+    \   ? ' exec ' . a:bundle_exec
+    \   : ''
+
+    return ale#Escape(a:executable) . l:exec_args
+endfunction


### PR DESCRIPTION
This function is generally applicable to Ruby tools, not just handling linter output.