### PR TITLE
clangcheck: Add -fno-color-diagnostics (closes #2188)

### DIFF
--- a/ale_linters/cpp/clangcheck.vim
+++ b/ale_linters/cpp/clangcheck.vim
@@ -20,7 +20,7 @@ function! ale_linters#cpp#clangcheck#GetCommand(buffer) abort
     " being generated. These are only added if no build directory can be
     " detected.
     return '%e -analyze %s'
-    \   . (empty(l:build_dir) ? ' -extra-arg -Xclang -extra-arg -analyzer-output=text' : '')
+    \   . (empty(l:build_dir) ? ' --extra-arg=-Xclang --extra-arg=-analyzer-output=text --extra-arg=-fno-color-diagnostics': '')
     \   . ale#Pad(l:user_options)
     \   . (!empty(l:build_dir) ? ' -p ' . ale#Escape(l:build_dir) : '')
 endfunction

--- a/test/command_callback/test_cpp_clangcheck_command_callbacks.vader
+++ b/test/command_callback/test_cpp_clangcheck_command_callbacks.vader
@@ -7,7 +7,7 @@ After:
 Execute(The executable should be configurable):
   AssertLinter 'clang-check',
   \ ale#Escape('clang-check')
-  \   . ' -analyze %s -extra-arg -Xclang -extra-arg -analyzer-output=text'
+  \   . ' -analyze %s --extra-arg=-Xclang --extra-arg=-analyzer-output=text --extra-arg=-fno-color-diagnostics'
 
   let b:ale_cpp_clangcheck_executable = 'foobar'
 
@@ -15,7 +15,7 @@ Execute(The executable should be configurable):
   " being generated.
   AssertLinter 'foobar',
   \ ale#Escape('foobar')
-  \   . ' -analyze %s -extra-arg -Xclang -extra-arg -analyzer-output=text'
+  \   . ' -analyze %s --extra-arg=-Xclang --extra-arg=-analyzer-output=text --extra-arg=-fno-color-diagnostics'
 
 Execute(The options should be configurable):
   let b:ale_cpp_clangcheck_options = '--something'
@@ -23,7 +23,7 @@ Execute(The options should be configurable):
   AssertLinter 'clang-check',
   \ ale#Escape('clang-check')
   \   . ' -analyze %s'
-  \   . ' -extra-arg -Xclang -extra-arg -analyzer-output=text'
+  \   . ' --extra-arg=-Xclang --extra-arg=-analyzer-output=text --extra-arg=-fno-color-diagnostics'
   \   . ' --something'
 
 Execute(The build directory should be used when set):


### PR DESCRIPTION
Also change to the modern `--extra-arg` syntax.

clang has supported `-fno-color-diagnostics` for at least ten years: https://github.com/llvm-mirror/clang/commit/a46c71abb1dc2f9758ad1abe3378534fe138e802

---

This works on my machine, but I don't use clang often so a second tester would be appreciated.