### PR TITLE
Black fixer should include --pyi for files with .pyi extension

### DIFF
--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -29,6 +29,10 @@ function! ale#fixers#black#Fix(buffer) abort
 
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
+    if (expand('#' . a:buffer . ':e') ==? 'pyi')
+        let l:options .= '--pyi'
+    endif
+
     return {
     \   'command': l:cd_string . ale#Escape(l:executable) . l:exec_args
     \       . (!empty(l:options) ? ' ' . l:options : '')

--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -29,7 +29,7 @@ function! ale#fixers#black#Fix(buffer) abort
 
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
-    if (expand('#' . a:buffer . ':e') ==? 'pyi')
+    if (expand('#' . a:buffer . ':e') is? 'pyi')
         let l:options .= '--pyi'
     endif
 

--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -29,7 +29,7 @@ function! ale#fixers#black#Fix(buffer) abort
 
     let l:options = ale#Var(a:buffer, 'python_black_options')
 
-    if (expand('#' . a:buffer . ':e') is? 'pyi')
+    if expand('#' . a:buffer . ':e') is? 'pyi'
         let l:options .= '--pyi'
     endif
 

--- a/test/fixers/test_black_fixer_callback.vader
+++ b/test/fixers/test_black_fixer_callback.vader
@@ -36,6 +36,14 @@ Execute(The black callback should include options):
   \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/black')) . ' --some-option -' },
   \ ale#fixers#black#Fix(bufnr(''))
 
+Execute(The black callback should include --pyi for .pyi files):
+  let g:ale_python_black_change_directory = 0
+
+  silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.pyi')
+  AssertEqual
+  \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/black')) . ' --pyi -' },
+  \ ale#fixers#black#Fix(bufnr(''))
+
 Execute(Pipenv is detected when python_black_auto_pipenv is set):
   let g:ale_python_black_auto_pipenv = 1
   let g:ale_python_black_change_directory = 0


### PR DESCRIPTION
Fixes #2371

Black fixer should include --pyi for files with .pyi extension
