### PR TITLE
Add support for sql-formatter-cli

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -250,6 +250,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['sql'],
 \       'description': 'Fix SQL files with sqlfmt.',
 \   },
+\   'sql_formatter_cli': {
+\       'function': 'ale#fixers#sql_formatter_cli#Fix',
+\       'suggested_filetypes': ['sql'],
+\       'description': 'Fix SQL files with sql_formatter_cli.',
+\   },
 \   'google_java_format': {
 \       'function': 'ale#fixers#google_java_format#Fix',
 \       'suggested_filetypes': ['java'],

--- a/autoload/ale/fixers/sql_formatter_cli.vim
+++ b/autoload/ale/fixers/sql_formatter_cli.vim
@@ -1,0 +1,19 @@
+" Author: Baeo Maltinsky <maltinsky.net>
+" Description: Integration of sql-formatter-cli with ALE.
+
+call ale#Set('sql_sql_formatter_cli_executable', 'sql-formatter-cli')
+call ale#Set('sql_sql_formatter_cli_options', '')
+
+function! ale#fixers#sql_formatter_cli#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'sql_sql_formatter_cli_executable')
+endfunction
+
+function! ale#fixers#sql_formatter_cli#Fix(buffer) abort
+    let l:options = ale#Var(a:buffer, 'sql_sql_formatter_cli_options')
+
+    return {
+    \ 'command': ale#Escape(ale#fixers#sql_formatter_cli#GetExecutable(a:buffer))
+    \     . (empty(l:options) ? '' : ' ' . l:options),
+    \}
+endfunction
+

--- a/doc/ale-sql.txt
+++ b/doc/ale-sql.txt
@@ -21,6 +21,32 @@ g:ale_sql_pgformatter_options                   *g:ale_sql_pgformatter_options*
 
 
 ===============================================================================
+sql-formatter-cli                                   *ale-sql-sql-formatter-cli*
+
+sql-formatter-cli is SQL whitespace formatter. It supports Standard SQL,
+Couchbase N1QL, IBM DB2 and Oracle PL/SQL dialects.
+
+You can install it using npm:
+
+  $ npm i -g sql-formatter-cli
+
+g:ale_sql_sql_formatter_cli            *g:ale_sql_sql_formatter_cli_executable*
+                                       *b:ale_sql_sql_formatter_cli_executable*
+  Type: |String|
+  Default: `'sql-formatter-cli'`
+
+  This variable sets the executable used for sql-formatter-cli.
+
+g:ale_sql_sql_formatter_options
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the
+  sql-formatter-cli fixer.
+
+
+===============================================================================
 sqlfmt                                                         *ale-sql-sqlfmt*
 
 g:ale_sql_sqlfmt_executable                       *g:ale_sql_sqlfmt_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -422,6 +422,7 @@ Notes:
   * `solium`
 * SQL
   * `pgformatter`
+  * `sql-formatter-cli`
   * `sqlfmt`
   * `sqlint`
 * Stylus

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2306,6 +2306,7 @@ documented in additional help files.
     rpmlint...............................|ale-spec-rpmlint|
   sql.....................................|ale-sql-options|
     pgformatter...........................|ale-sql-pgformatter|
+    sql-formatter-cli.....................|ale-sql-sql-formatter-cli|
     sqlfmt................................|ale-sql-sqlfmt|
   stylus..................................|ale-stylus-options|
     stylelint.............................|ale-stylus-stylelint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -431,6 +431,7 @@ formatting.
   * [solium](https://github.com/duaraghav8/Solium)
 * SQL
   * [pgformatter](https://github.com/darold/pgFormatter)
+  * [sql-formatter-cli](https://github.com/osv/sql-formatter-cli)
   * [sqlfmt](https://github.com/jackc/sqlfmt)
   * [sqlint](https://github.com/purcell/sqlint)
 * Stylus

--- a/test/fixers/test_sql_formatter_cli_callback.vader
+++ b/test/fixers/test_sql_formatter_cli_callback.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_sql_sql_formatter_cli_executable
+  Save g:ale_sql_sql_formatter_cli_options
+
+After:
+  Restore
+
+Execute(The sql_formatter_cli callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('sql-formatter-cli'),
+  \ },
+  \ ale#fixers#sql_formatter_cli#Fix(bufnr(''))
+
+Execute(The sql_formatter_cli executable and options should be configurable):
+  let g:ale_sql_sql_formatter_cli_executable = '/path/to/sql-formatter-cli'
+  let g:ale_sql_sql_formatter_cli_options = '-s sql'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/sql-formatter-cli')
+  \     . ' -s sql',
+  \ },
+  \ ale#fixers#sql_formatter_cli#Fix(bufnr(''))


### PR DESCRIPTION
I found the formatting provided by sqlfmt (see #1897) to be a bit fragile, so I added support for [sql-formatter](https://github.com/zeroturnaround/sql-formatter) (through [sql-formatter-cli](https://github.com/osv/sql-formatter-cli)) as was suggested in this [thread](https://github.com/dense-analysis/ale/pull/1897#issuecomment-419764643).

Edit: The `diff README.md and doc/ale.txt tables` lint is currently failing on master. I don't think this pull request introduces further failures.