### PR TITLE
Fix #2621 - Set default build directory options

### DIFF
--- a/ale_linters/c/ccls.vim
+++ b/ale_linters/c/ccls.vim
@@ -3,6 +3,22 @@
 
 call ale#Set('c_ccls_executable', 'ccls')
 call ale#Set('c_ccls_init_options', {})
+call ale#Set('c_build_dir', '')
+
+function! ale_linters#c#ccls#GetOptions(buffer) abort
+    let l:options = copy(ale#Var(a:buffer, 'c_ccls_init_options'))
+
+    " Set the compile_commands directory by default, if one is not provided.
+    if !has_key(l:options, 'compilationDatabaseDirectory')
+        let l:dir = ale#c#GetBuildDirectory(a:buffer)
+
+        if !empty(l:dir)
+            let l:options.compilationDatabaseDirectory = l:dir
+        endif
+    endif
+
+    return l:options
+endfunction
 
 call ale#linter#Define('c', {
 \   'name': 'ccls',
@@ -10,5 +26,5 @@ call ale#linter#Define('c', {
 \   'executable': {b -> ale#Var(b, 'c_ccls_executable')},
 \   'command': '%e',
 \   'project_root': function('ale#handlers#ccls#GetProjectRoot'),
-\   'initialization_options': {b -> ale#Var(b, 'c_ccls_init_options')},
+\   'initialization_options': function('ale_linters#c#ccls#GetOptions'),
 \})

--- a/ale_linters/c/clangd.vim
+++ b/ale_linters/c/clangd.vim
@@ -3,9 +3,22 @@
 
 call ale#Set('c_clangd_executable', 'clangd')
 call ale#Set('c_clangd_options', '')
+call ale#Set('c_build_dir', '')
 
 function! ale_linters#c#clangd#GetCommand(buffer) abort
-    return '%e' . ale#Pad(ale#Var(a:buffer, 'c_clangd_options'))
+    let l:options = ale#Var(a:buffer, 'c_clangd_options')
+    let l:dir_option = ''
+
+    " Set the compile_commands directory by default, if one is not provided.
+    if l:options !~# '-compile-commands-dir'
+        let l:dir = ale#c#GetBuildDirectory(a:buffer)
+
+        if !empty(l:dir)
+            let l:dir_option = '-compile-commands-dir=' . ale#Escape(l:dir)
+        endif
+    endif
+
+    return '%e' . ale#Pad(l:options) . ale#Pad(l:dir_option)
 endfunction
 
 call ale#linter#Define('c', {

--- a/ale_linters/cpp/ccls.vim
+++ b/ale_linters/cpp/ccls.vim
@@ -3,6 +3,22 @@
 
 call ale#Set('cpp_ccls_executable', 'ccls')
 call ale#Set('cpp_ccls_init_options', {})
+call ale#Set('c_build_dir', '')
+
+function! ale_linters#cpp#ccls#GetOptions(buffer) abort
+    let l:options = copy(ale#Var(a:buffer, 'cpp_ccls_init_options'))
+
+    " Set the compile_commands directory by default, if one is not provided.
+    if !has_key(l:options, 'compilationDatabaseDirectory')
+        let l:dir = ale#c#GetBuildDirectory(a:buffer)
+
+        if !empty(l:dir)
+            let l:options.compilationDatabaseDirectory = l:dir
+        endif
+    endif
+
+    return l:options
+endfunction
 
 call ale#linter#Define('cpp', {
 \   'name': 'ccls',
@@ -10,5 +26,5 @@ call ale#linter#Define('cpp', {
 \   'executable': {b -> ale#Var(b, 'cpp_ccls_executable')},
 \   'command': '%e',
 \   'project_root': function('ale#handlers#ccls#GetProjectRoot'),
-\   'initialization_options': {b -> ale#Var(b, 'cpp_ccls_init_options')},
+\   'initialization_options': function('ale_linters#cpp#ccls#GetOptions'),
 \})

--- a/ale_linters/cpp/clangd.vim
+++ b/ale_linters/cpp/clangd.vim
@@ -3,9 +3,22 @@
 
 call ale#Set('cpp_clangd_executable', 'clangd')
 call ale#Set('cpp_clangd_options', '')
+call ale#Set('c_build_dir', '')
 
 function! ale_linters#cpp#clangd#GetCommand(buffer) abort
-    return '%e' . ale#Pad(ale#Var(a:buffer, 'cpp_clangd_options'))
+    let l:options = ale#Var(a:buffer, 'cpp_clangd_options')
+    let l:dir_option = ''
+
+    " Set the compile_commands directory by default, if one is not provided.
+    if l:options !~# '-compile-commands-dir'
+        let l:dir = ale#c#GetBuildDirectory(a:buffer)
+
+        if !empty(l:dir)
+            let l:dir_option = '-compile-commands-dir=' . ale#Escape(l:dir)
+        endif
+    endif
+
+    return '%e' . ale#Pad(l:options) . ale#Pad(l:dir_option)
 endfunction
 
 call ale#linter#Define('cpp', {


### PR DESCRIPTION
clangd and ccls require the build directory to be set when `compile_commands.json` exists in other directories.

Tests are needed.