### PR TITLE
Remove texlab rust rewrite link

### DIFF
--- a/supported-tools.md
+++ b/supported-tools.md
@@ -248,7 +248,7 @@ formatting.
   * [lacheck](https://www.ctan.org/pkg/lacheck)
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)
-  * [texlab](https://texlab.netlify.com) ([Rust rewrite](https://github.com/latex-lsp/texlab/tree/rust))
+  * [texlab](https://texlab.netlify.com)
   * [textlint](https://textlint.github.io/)
   * [vale](https://github.com/ValeLint/vale)
   * [write-good](https://github.com/btford/write-good)


### PR DESCRIPTION
It seems like the texlab rust rewrite has completed so the link is now broken and not necessary.
