### PR TITLE
Python linter pylint generate --indent-string opt

### DIFF
--- a/test/command_callback/test_pylint_command_callback.vader
+++ b/test/command_callback/test_pylint_command_callback.vader
@@ -53,6 +53,29 @@ Execute(The pylint callbacks should detect virtualenv directories):
   \ ale#path#CdString(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/subdir'))
   \   . ale#Escape(b:executable) . ' ' . b:command_tail
 
+Execute(The pylint command should send vim python default as the indent string):
+  let g:ale_python_pylint_auto_indent_string = 1
+
+  AssertLinter 'pylint',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('pylint') . ' ' . ' --indent-string "    "' . b:command_tail
+
+Execute(The pylint command should send 2 spaces as the indent string):
+  let g:ale_python_pylint_auto_indent_string = 1
+  set expandtab tabstop=2 shiftwidth=2
+
+  AssertLinter 'pylint',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('pylint') . ' ' . ' --indent-string "  "' . b:command_tail
+
+Execute(The pylint command should send tab as the indent string):
+  let g:ale_python_pylint_auto_indent_string = 1
+  set expandtab!
+
+  AssertLinter 'pylint',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('pylint') . ' ' . ' --indent-string "\\t"' . b:command_tail
+
 Execute(You should able able to use the global pylint instead):
   silent execute 'file ' . fnameescape(g:dir . '/python_paths/with_virtualenv/subdir/foo/bar.py')
   let g:ale_python_pylint_use_global = 1


### PR DESCRIPTION
# Description

I've added an additional feature to pylint command `let g:ale_python_pylint_auto_indent_string` that when enabled will generate the value for the pylint option `--indent-string` from the buffers `expandtab,shiftwidth,tabstop` values. I modeled this off the implementation for the [shfmt fixer](https://github.com/dense-analysis/ale/blob/master/autoload/ale/fixers/shfmt.vim#L8) which does something similar.

# Motivation

To reduce the sources of truth for this value down to one place.

From

```vimscript
let g:ale_python_pylint_options = '--indent-string="  "'
autocmd FileType python set expandtab tabstop=2 shiftwidth=2
```

To

```vimscript
let g:ale_python_pylint_auto_indent_string = 1
autocmd FileType python set expandtab tabstop=2 shiftwidth=2
```



