### PR TITLE
clangtidy: ensure *.h header files are treated as C++ (filetype cpp)

### DIFF
--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -25,6 +25,14 @@ function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
     " Get the options to pass directly to clang-tidy
     let l:extra_options = ale#Var(a:buffer, 'cpp_clangtidy_extra_options')
 
+    if expand('#' . a:buffer . ':e') is? 'h'
+        " for .h header files, passing -x to compiler to force cpp
+        if !empty(l:options)
+            let l:options .= ' '
+        endif
+        let l:options .= '-x c++'
+    endif
+
     return '%e'
     \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')
     \   . (!empty(l:extra_options) ? ' ' . ale#Escape(l:extra_options) : '')

--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -30,6 +30,7 @@ function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
         if !empty(l:options)
             let l:options .= ' '
         endif
+
         let l:options .= '-x c++'
     endif
 

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -63,7 +63,7 @@ Execute(The build directory should be ignored for header files):
 
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy')
-  \   . ' -checks=' . ale#Escape('*') . ' %s -- -Wall'
+  \   . ' -checks=' . ale#Escape('*') . ' %s -- -Wall -x c++'
 
   call ale#test#SetFilename('test.hpp')
 
@@ -76,3 +76,10 @@ Execute(The executable should be configurable):
 
   AssertLinter 'foobar',
   \ ale#Escape('foobar') . ' -checks=' . ale#Escape('*') . ' %s'
+
+Execute(Linting .h files under cpp filetype should include c++ as compiler option):
+  call ale#test#SetFilename('test.h')
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy') . ' %s -- -x c++'
+


### PR DESCRIPTION
Fixes #1608

Including "-x c++" option such that clang-tidy treats .h files as C++.  

This PR only applies to `cpp` filetype - the default for .h files in vim.