### PR TITLE
Use `stdout` as output stream for ESLint

### DIFF
--- a/ale_linters/javascript/eslint.vim
+++ b/ale_linters/javascript/eslint.vim
@@ -3,7 +3,7 @@
 
 call ale#linter#Define('javascript', {
 \   'name': 'eslint',
-\   'output_stream': 'both',
+\   'output_stream': 'stdout',
 \   'executable': function('ale#handlers#eslint#GetExecutable'),
 \   'command': function('ale#handlers#eslint#GetCommand'),
 \   'callback': 'ale#handlers#eslint#HandleJSON',


### PR DESCRIPTION
When we changed to using the `json` format ([commit]) of the output from `eslint`
it failed to parse the output when you got a warnings in the output
since it tries to parse the whole thing as JSON.

Since the warnings output from `eslint` is directed to `stderr`, we can
assume that everything coming out from `stdout` is valid JSON containing
the linter errors that we then can parse.

[commit]: https://github.com/dense-analysis/ale/commit/79d1b99067878bbec129cfd29a7c9587c276dec6

> I'm not entirely sure how to test that output coming from `stderr` breaks the linter since we don't seem to run them as part of the tests. Do you have folks have any suggestions of how we could go about testing that?