### PR TITLE
clang: pass appropriate language for header files

### DIFF
--- a/ale_linters/c/clang.vim
+++ b/ale_linters/c/clang.vim
@@ -9,7 +9,8 @@ function! ale_linters#c#clang#GetCommand(buffer, output) abort
 
     " -iquote with the directory the file is in makes #include work for
     "  headers in the same directory.
-    return '%e -S -x c -fsyntax-only'
+    return '%e -S -fsyntax-only'
+    \   . ' -x ' . ale#c#GetLanguage(a:buffer)
     \   . ' -iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
     \   . ale#Pad(l:cflags)
     \   . ale#Pad(ale#Var(a:buffer, 'c_clang_options')) . ' -'

--- a/ale_linters/cpp/clang.vim
+++ b/ale_linters/cpp/clang.vim
@@ -9,7 +9,8 @@ function! ale_linters#cpp#clang#GetCommand(buffer, output) abort
 
     " -iquote with the directory the file is in makes #include work for
     "  headers in the same directory.
-    return '%e -S -x c++ -fsyntax-only'
+    return '%e -S -fsyntax-only'
+    \   . ' -x ' . ale#c#GetLanguage(a:buffer)
     \   . ' -iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
     \   . ale#Pad(l:cflags)
     \   . ale#Pad(ale#Var(a:buffer, 'cpp_clang_options')) . ' -'

--- a/ale_linters/objc/clang.vim
+++ b/ale_linters/objc/clang.vim
@@ -9,8 +9,9 @@ endif
 function! ale_linters#objc#clang#GetCommand(buffer) abort
     " -iquote with the directory the file is in makes #include work for
     "  headers in the same directory.
-    return 'clang -S -x objective-c -fsyntax-only '
-    \   . '-iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
+    return '%e -S -fsyntax-only'
+    \   . ' -x ' . ale#c#GetLanguage(a:buffer)
+    \   . ' -iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
     \   . ' ' . ale#Var(a:buffer, 'objc_clang_options') . ' -'
 endfunction
 

--- a/ale_linters/objcpp/clang.vim
+++ b/ale_linters/objcpp/clang.vim
@@ -9,8 +9,9 @@ endif
 function! ale_linters#objcpp#clang#GetCommand(buffer) abort
     " -iquote with the directory the file is in makes #include work for
     "  headers in the same directory.
-    return 'clang++ -S -x objective-c++ -fsyntax-only '
-    \   . '-iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
+    return '%e -S -fsyntax-only'
+    \   . ' -x ' . ale#c#GetLanguage(a:buffer)
+    \   . ' -iquote ' . ale#Escape(fnamemodify(bufname(a:buffer), ':p:h'))
     \   . ' ' . ale#Var(a:buffer, 'objcpp_clang_options') . ' -'
 endfunction
 


### PR DESCRIPTION
Some C/C++ constructs cause errors in translation units, but not in header files. For example, the following:

```c
static const int x = 0;
```

...fails to compile with `clang -x c -Wall -Werror -fsyntax-only`, but succeeds with `clang -x c-header -Wall -Werror -fsyntax-only`.

This commit updates the Clang linters to use a buffer's filetype and extension to pass the appropriate language as `-x`. This fixes false-positive errors when linting header files.

I've left this marked as a draft for now as it doesn't include any tests - I've yet to figure out how to write tests, and I'm out of free time for today. This is my first time writing any Vimscript more complicated than a `.vimrc` so if there are any coding guidelines I've ran afoul of please let me know!