### PR TITLE
"Fixed" missing references in flow linter

### DIFF
--- a/ale_linters/javascript/flow.vim
+++ b/ale_linters/javascript/flow.vim
@@ -60,16 +60,16 @@ function! s:ExtraErrorMsg(current, new, source, line, context) abort
 
     if a:current is# ''
         if a:source is# ''
-          " extra messages appear to already have a :
-          let l:newMsg = a:new
+            " extra messages appear to already have a :
+            let l:newMsg = a:new
         else
-          let l:newMsg = '    ' . a:source . "\n" . a:new . ' ' . a:line . '|' . a:context
+            let l:newMsg = '    ' . a:source . "\n" . a:new . ' ' . a:line . '|' . a:context
         endif
     else
         if a:source is# ''
-          let l:newMsg = a:current . ' ' . a:new
+            let l:newMsg = a:current . ' ' . a:new
         else
-          let l:newMsg = a:current . "\n\n    " . a:source . "\n" . a:new . ' ' . a:line . '|' . a:context
+            let l:newMsg = a:current . "\n\n    " . a:source . "\n" . a:new . ' ' . a:line . '|' . a:context
         endif
     endif
 
@@ -84,16 +84,15 @@ function! s:GetDetails(error) abort
             for l:extra_message in l:extra_error.message
                 let l:source = ''
                 let l:line = ''
-                if has_key(l:extra_message, 'loc')
-                  if has_key(l:extra_message.loc, 'source')
+
+                if has_key(l:extra_message, 'loc') && has_key(l:extra_message.loc, 'source')
                     let l:source = l:extra_message.loc.source
-                    if has_key(l:extra_message.loc, 'start')
-                      if has_key(l:extra_message.loc.start, 'line')
+
+                    if has_key(l:extra_message.loc, 'start') && has_key(l:extra_message.loc.start, 'line')
                         let l:line = l:extra_message.loc.start.line
-                      endif
                     endif
-                  endif
                 endif
+
                 let l:detail = s:ExtraErrorMsg(l:detail, l:extra_message.descr, l:source, l:line, l:extra_message.context)
             endfor
         endif


### PR DESCRIPTION
Some of the output from Flow is [swallowed by ale](https://github.com/dense-analysis/ale/issues/1398). This makes it a little bit better. While the ideal thing would be to show the entire region delimited by the `loc` key in the extra messages (which is what flow outputs when used in human readable format), I've only added the first line of them. The more complete solution would be to read the referenced file, showing the range of lines and highlighting the bit where Flow is blowing up.