### PR TITLE
Update irrelevant JSCS site link

### DIFF
--- a/supported-tools.md
+++ b/supported-tools.md
@@ -223,7 +223,7 @@ formatting.
   * [eslint](http://eslint.org/)
   * [fecs](http://fecs.baidu.com/)
   * [flow](https://flowtype.org/)
-  * [jscs](http://jscs.info/)
+  * [jscs](https://jscs-dev.github.io/)
   * [jshint](http://jshint.com/)
   * [prettier](https://github.com/prettier/prettier)
   * [prettier-eslint](https://github.com/prettier/prettier-eslint-cli)


### PR DESCRIPTION
jscs.info appears to have nothing to do with the linter, and just contains a blogpost about student debt.
This appears to be the closest to canonical site for the project (although it's now merged with ESLint I suppose some still use it?)