### PR TITLE
clangtidy treat .h files as C++ when g:cpp_clangtidy_h_is_hpp

### DIFF
--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -13,6 +13,10 @@ call ale#Set('cpp_clangtidy_options', '')
 call ale#Set('cpp_clangtidy_extra_options', '')
 call ale#Set('c_build_dir', '')
 
+" Set this to enable treating .h header files as C++
+call ale#Set('cpp_clangtidy_h_is_hpp', 0)
+
+
 function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
     let l:checks = join(ale#Var(a:buffer, 'cpp_clangtidy_checks'), ',')
     let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
@@ -24,6 +28,16 @@ function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
 
     " Get the options to pass directly to clang-tidy
     let l:extra_options = ale#Var(a:buffer, 'cpp_clangtidy_extra_options')
+    let l:enable_h_is_hpp = ale#Var(a:buffer, 'cpp_clangtidy_h_is_hpp')
+
+    if l:enable_h_is_hpp && expand('#' . a:buffer . ':e') is? 'h'
+        " for .h header files, passing -x to compiler to force cpp
+        if empty(l:options)
+            let l:options .= '-x c++'
+        else
+            let l:options .= ' -x c++'
+        endif
+    endif
 
     return '%e'
     \   . (!empty(l:checks) ? ' -checks=' . ale#Escape(l:checks) : '')

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -155,6 +155,17 @@ g:ale_cpp_clangtidy_fix_errors                 *g:ale_cpp_clangtidy_fix_errors*
   |clangtidy| fixer.
 
 
+g:ale_cpp_clangtidy_h_is_hpp                   *g:ale_cpp_clangtidy_h_is_hpp*
+                                               *b:ale_cpp_clangtidy_h_is_hpp*
+
+  Type: |Number|
+  Default: 0
+
+  This variable can be changed to enable treating .h header files as C++.
+  This works by passing the `-x c++` option to `clang-tidy` since the default 
+  behaviour is only to parse .hpp header files.
+
+
 ===============================================================================
 clazy                                                           *ale-cpp-clazy*
 

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -76,3 +76,17 @@ Execute(The executable should be configurable):
 
   AssertLinter 'foobar',
   \ ale#Escape('foobar') . ' -checks=' . ale#Escape('*') . ' %s'
+
+Execute(Linting .h files should not be treated as C++ by default):
+  call ale#test#SetFilename('test.h')
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy') . ' %s'
+
+Execute(Linting .h files should be treated as C++ when ale_cpp_clangtidy_h_is_hpp = 1):
+  call ale#test#SetFilename('test.h')
+  let b:ale_cpp_clangtidy_h_is_hpp = 1
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy') . ' %s -- -x c++'
+


### PR DESCRIPTION
Fixes #1608 

Introduced new variable for clangtidy `g:cpp_clangtidy_h_is_hpp`.  This enables behaviour for  clangtidy to treat the .h header file as C++. 

Since cpp is the default filetype for .h files in vim, I have introduced this variable to avoid "normal" C header (.h) files being treated as C++ which could yield incorrect linter results. 
