### PR TITLE
Elm language server params update

### DIFF
--- a/ale_linters/elm/elm_ls.vim
+++ b/ale_linters/elm/elm_ls.vim
@@ -3,9 +3,12 @@
 
 call ale#Set('elm_ls_executable', 'elm-language-server')
 call ale#Set('elm_ls_use_global', get(g:, 'ale_use_global_executables', 1))
-call ale#Set('elm_ls_elm_path', 'elm')
-call ale#Set('elm_ls_elm_format_path', 'elm-format')
-call ale#Set('elm_ls_elm_test_path', 'elm-test')
+
+" elm-language-server will search for local and global binaries, if empty
+call ale#Set('elm_ls_elm_path', '')
+call ale#Set('elm_ls_elm_format_path', '')
+call ale#Set('elm_ls_elm_test_path', '')
+call ale#Set('elm_ls_elm_analyse_trigger', 'change')
 
 function! elm_ls#GetRootDir(buffer) abort
     let l:elm_json = ale#path#FindNearestFile(a:buffer, 'elm.json')
@@ -15,10 +18,10 @@ endfunction
 
 function! elm_ls#GetOptions(buffer) abort
     return {
-    \   'runtime': 'node',
     \   'elmPath': ale#Var(a:buffer, 'elm_ls_elm_path'),
     \   'elmFormatPath': ale#Var(a:buffer, 'elm_ls_elm_format_path'),
     \   'elmTestPath': ale#Var(a:buffer, 'elm_ls_elm_test_path'),
+    \   'elmAnalyseTrigger': ale#Var(a:buffer, 'elm_ls_elm_analyse_trigger'),
     \}
 endfunction
 

--- a/doc/ale-elm.txt
+++ b/doc/ale-elm.txt
@@ -50,7 +50,7 @@ g:ale_elm_ls_use_global                               *g:ale_elm_ls_use_global*
 g:ale_elm_ls_elm_path                                   *g:ale_elm_ls_elm_path*
                                                         *b:ale_elm_ls_elm_path*
   Type: |String|
-  Default: `'elm'`
+  Default: `''`
 
   See |ale-integrations-local-executables|
 
@@ -58,7 +58,7 @@ g:ale_elm_ls_elm_path                                   *g:ale_elm_ls_elm_path*
 g:ale_elm_ls_elm_format_path                     *g:ale_elm_ls_elm_format_path*
                                                  *b:ale_elm_ls_elm_format_path*
   Type: |String|
-  Default: `'elm-format'`
+  Default: `''`
 
   See |ale-integrations-local-executables|
 
@@ -66,9 +66,17 @@ g:ale_elm_ls_elm_format_path                     *g:ale_elm_ls_elm_format_path*
 g:ale_elm_ls_elm_test_path                         *g:ale_elm_ls_elm_test_path*
                                                    *b:ale_elm_ls_elm_test_path*
   Type: |String|
-  Default: `'elm-test'`
+  Default: `''`
 
   See |ale-integrations-local-executables|
+
+
+g:ale_elm_ls_elm_analyse_trigger             *g:ale_elm_ls_elm_analyse_trigger*
+                                             *b:ale_elm_ls_elm_analyse_trigger*
+  Type: |String|
+  Default: `'change'`
+
+  One of 'change', 'save' or 'never'
 
 ===============================================================================
 elm-make                                                     *ale-elm-elm-make*


### PR DESCRIPTION
## Changes

* There is a new param 'elmAnalyseTrigger' (change|save|never)
* Empty path default to let the language server search for binary

## Note

Although `--stdio` argument is now default, it'll still be passed for compatibility with people using older version of the language server,

## Settings documentation

https://github.com/elm-tooling/elm-language-server#server-settings
