### PR TITLE
Map mypy "note" messages to info-level lints

### DIFF
--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -51,7 +51,7 @@ function! ale_linters#python#mypy#Handle(buffer, lines) abort
     " Lines like these should be ignored below:
     "
     " file.py:4: note: (Stub files are from https://github.com/python/typeshed)
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?: (error|warning): (.+)$'
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?: (error|warning|note): (.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
@@ -61,11 +61,19 @@ function! ale_linters#python#mypy#Handle(buffer, lines) abort
             continue
         endif
 
+        if l:match[4] is# 'error'
+            let l:type = 'E'
+        elseif l:match[4] is# 'warning'
+            let l:type = 'W'
+        else
+            let l:type = 'I'
+        endif
+
         call add(l:output, {
         \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
-        \   'type': l:match[4] is# 'error' ? 'E' : 'W',
+        \   'type': l:type,
         \   'text': l:match[5],
         \})
     endfor


### PR DESCRIPTION
ALE shows errors from mypy, but not notes. This firstly makes it hard to
debug some issues, since mypy often emits a note immediately after an
error with more explanation of the types involved or a link to an
explanation of the error (and these notes aren't even visible in
:ALEDetail), and secondly means that adding reveal_type to something
doesn't show the type of the expression in the editor – you have to go
and run mypy by hand to see the result.

We map "note" messages to ALEInfo highlight level groups because that
means when the user runs :lwin they'll see the expanded note if there's
also an error on the line, and if there's no error they'll just see the
ALEInfo highlight group.

Fixes #2704

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
