### PR TITLE
credo now recognizes umbrella projects

### DIFF
--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -46,7 +46,7 @@ function! ale_linters#elixir#credo#GetMode() abort
 endfunction
 
 function! ale_linters#elixir#credo#GetCommand(buffer) abort
-    let l:project_root = ale#handlers#elixir#FindMixProjectRoot(a:buffer)
+    let l:project_root = ale#handlers#elixir#FindMixUmbrellaRoot(a:buffer)
     let l:mode = ale_linters#elixir#credo#GetMode()
 
     return ale#path#CdString(l:project_root)

--- a/test/command_callback/test_elixir_credo.vader
+++ b/test/command_callback/test_elixir_credo.vader
@@ -8,6 +8,18 @@ After:
 
   call ale#assert#TearDownLinterTest()
 
+Execute(Builds credo command with normal project):
+  AssertLinter 'mix',
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
+  \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
+
+Execute(Builds credo command with umbrella project):
+  call ale#test#SetFilename('elixir_paths/umbrella_project/apps/mix_project/lib/app.ex')
+
+  AssertLinter 'mix',
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
+  \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
+
 Execute(Builds credo command with --strict mode when set to 1):
   let g:ale_elixir_credo_strict = 1
 


### PR DESCRIPTION
Use ale#handlers#elixir#FindMixUmbrellaRoot to determine project root
instead of ale#handlers#elixir#FindMixProjectRoot

Updated tests so they check both reguler and umbrella project compatibility.