### PR TITLE
Adding linting for rmd filetype (duplicate of rmarkdown)

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -322,7 +322,7 @@ let s:default_registry = {
 \   },
 \   'styler': {
 \       'function': 'ale#fixers#styler#Fix',
-\       'suggested_filetypes': ['r', 'rmarkdown'],
+\       'suggested_filetypes': ['r', 'rmarkdown', 'rmd'],
 \       'description': 'Fix R files with styler.',
 \   },
 \   'latexindent': {

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -14,6 +14,7 @@ let s:default_ale_linter_aliases = {
 \   'csh': 'sh',
 \   'plaintex': 'tex',
 \   'rmarkdown': 'r',
+\   'rmd': 'r',
 \   'systemverilog': 'verilog',
 \   'verilog_systemverilog': ['verilog_systemverilog', 'verilog'],
 \   'vimwiki': 'markdown',

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1043,6 +1043,7 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
   \   'csh': 'sh',
   \   'plaintex': 'tex',
   \   'rmarkdown': 'r',
+  \   'rmd': 'r',
   \   'systemverilog': 'verilog',
   \   'verilog_systemverilog': ['verilog_systemverilog', 'verilog'],
   \   'vimwiki': 'markdown',


### PR DESCRIPTION
Hello, this is merely a copy-paste from another PR that got accepted to allow ALE on rmarkdown.
Thing is most of the time `ft` for Rmd files is called rmd (as in https://github.com/jalvesaq/Nvim-R that is likely to be use by anyone using R in vim).

Anyway I can now get ALE on rmd.
Regards and thanks for your addin