### PR TITLE
Use Makefile output with clang-tidy when useful

### DIFF
--- a/ale_linters/c/clangtidy.vim
+++ b/ale_linters/c/clangtidy.vim
@@ -22,10 +22,9 @@ call ale#Set('c_build_dir', '')
 function! ale_linters#c#clangtidy#GetCommand(buffer, output) abort
     let l:checks = join(ale#Var(a:buffer, 'c_clangtidy_checks'), ',')
     let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
-
-    " Get the extra options if we couldn't find a build directory.
     let l:options = ''
 
+    " Get the extra options if we couldn't find a build directory.
     if empty(l:build_dir)
         let l:options = ale#Var(a:buffer, 'c_clangtidy_options')
         let l:cflags = ale#c#GetCFlags(a:buffer, a:output)

--- a/ale_linters/c/clangtidy.vim
+++ b/ale_linters/c/clangtidy.vim
@@ -19,14 +19,18 @@ call ale#Set('c_clangtidy_options', '')
 call ale#Set('c_clangtidy_extra_options', '')
 call ale#Set('c_build_dir', '')
 
-function! ale_linters#c#clangtidy#GetCommand(buffer) abort
+function! ale_linters#c#clangtidy#GetCommand(buffer, output) abort
     let l:checks = join(ale#Var(a:buffer, 'c_clangtidy_checks'), ',')
     let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
 
     " Get the extra options if we couldn't find a build directory.
-    let l:options = empty(l:build_dir)
-    \   ? ale#Var(a:buffer, 'c_clangtidy_options')
-    \   : ''
+    let l:options = ''
+
+    if empty(l:build_dir)
+        let l:options = ale#Var(a:buffer, 'c_clangtidy_options')
+        let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
+        let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
+    endif
 
     " Get the options to pass directly to clang-tidy
     let l:extra_options = ale#Var(a:buffer, 'c_clangtidy_extra_options')
@@ -43,7 +47,7 @@ call ale#linter#Define('c', {
 \   'name': 'clangtidy',
 \   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'c_clangtidy_executable')},
-\   'command': function('ale_linters#c#clangtidy#GetCommand'),
+\   'command': {b -> ale#c#RunMakeCommand(b, function('ale_linters#c#clangtidy#GetCommand'))},
 \   'callback': 'ale#handlers#gcc#HandleGCCFormat',
 \   'lint_file': 1,
 \})

--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -13,14 +13,18 @@ call ale#Set('cpp_clangtidy_options', '')
 call ale#Set('cpp_clangtidy_extra_options', '')
 call ale#Set('c_build_dir', '')
 
-function! ale_linters#cpp#clangtidy#GetCommand(buffer) abort
+function! ale_linters#cpp#clangtidy#GetCommand(buffer, output) abort
     let l:checks = join(ale#Var(a:buffer, 'cpp_clangtidy_checks'), ',')
     let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
 
     " Get the extra options if we couldn't find a build directory.
-    let l:options = empty(l:build_dir)
-    \   ? ale#Var(a:buffer, 'cpp_clangtidy_options')
-    \   : ''
+    let l:options = ''
+
+    if empty(l:build_dir)
+        let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
+        let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
+        let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
+    endif
 
     " Get the options to pass directly to clang-tidy
     let l:extra_options = ale#Var(a:buffer, 'cpp_clangtidy_extra_options')
@@ -37,7 +41,7 @@ call ale#linter#Define('cpp', {
 \   'name': 'clangtidy',
 \   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'cpp_clangtidy_executable')},
-\   'command': function('ale_linters#cpp#clangtidy#GetCommand'),
+\   'command': {b -> ale#c#RunMakeCommand(b, function('ale_linters#cpp#clangtidy#GetCommand'))},
 \   'callback': 'ale#handlers#gcc#HandleGCCFormat',
 \   'lint_file': 1,
 \})

--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -16,10 +16,9 @@ call ale#Set('c_build_dir', '')
 function! ale_linters#cpp#clangtidy#GetCommand(buffer, output) abort
     let l:checks = join(ale#Var(a:buffer, 'cpp_clangtidy_checks'), ',')
     let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
-
-    " Get the extra options if we couldn't find a build directory.
     let l:options = ''
 
+    " Get the extra options if we couldn't find a build directory.
     if empty(l:build_dir)
         let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
         let l:cflags = ale#c#GetCFlags(a:buffer, a:output)

--- a/test/command_callback/test_c_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_c_clang_tidy_command_callback.vader
@@ -1,4 +1,7 @@
 Before:
+  Save g:ale_c_parse_makefile
+  let g:ale_c_parse_makefile = 0
+
   call ale#assert#SetUpLinterTest('c', 'clangtidy')
   call ale#test#SetFilename('test.c')
 

--- a/test/command_callback/test_c_import_paths.vader
+++ b/test/command_callback/test_c_import_paths.vader
@@ -121,6 +121,16 @@ Execute(The C Clang handler should include root directories for projects with .h
   \   . ' -I' . ale#Escape(ale#path#Simplify(g:dir .  '/../test_c_projects/hpp_file_project'))
   \   . ' -'
 
+Execute(The C ClangTidy handler should include 'include' directories for projects with a Makefile):
+  call ale#assert#SetUpLinterTest('c', 'clangtidy')
+  call ale#test#SetFilename('../test_c_projects/makefile_project/subdir/file.cpp')
+  let g:ale_c_clangtidy_options = ''
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy')
+  \ . ' %s '
+  \ . '-- -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test_c_projects/makefile_project/include'))
+
 Execute(The C++ GCC handler should include 'include' directories for projects with a Makefile):
   call ale#assert#SetUpLinterTest('cpp', 'gcc')
   call ale#test#SetFilename('../test_c_projects/makefile_project/subdir/file.cpp')
@@ -225,3 +235,14 @@ Execute(The C++ ClangTidy handler should include json folders for projects with 
   \ ale#Escape('clang-tidy')
   \   . ' %s '
   \   . '-p ' . ale#Escape(ale#path#Simplify(g:dir . '/../test_c_projects/json_project/build'))
+
+Execute(The C++ ClangTidy handler should include 'include' directories for projects with a Makefile):
+  call ale#assert#SetUpLinterTest('cpp', 'clangtidy')
+  call ale#test#SetFilename('../test_c_projects/makefile_project/subdir/file.cpp')
+  let g:ale_cpp_clangtidy_options = ''
+
+  AssertLinter 'clang-tidy',
+  \ ale#Escape('clang-tidy')
+  \ . ' %s '
+  \ . '-- -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test_c_projects/makefile_project/include'))
+

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -1,4 +1,7 @@
 Before:
+  Save g:ale_c_parse_makefile
+  let g:ale_c_parse_makefile = 0
+
   call ale#assert#SetUpLinterTest('cpp', 'clangtidy')
   call ale#test#SetFilename('test.cpp')
 


### PR DESCRIPTION
In the case where neither a build directory nor a compile_commands.json
file is found, use the output of `make -n` to provide options to
clang-tidy.

If a compile_commands.json file is found, then `empty(l:build_dir)` will be false, so the behavior is unchanged. This will only affect instances where there is not a compile_commands.json file present.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->
