### PR TITLE
fix broken govet linter with go 1.13

### DIFF
--- a/autoload/ale/handlers/go.vim
+++ b/autoload/ale/handlers/go.vim
@@ -8,7 +8,7 @@
 " Description: moved to generic Golang file from govet
 
 function! ale#handlers#go#Handler(buffer, lines) abort
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
+    let l:pattern = '\v^v*e*t*:*\s*([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
     let l:output = []
     let l:dir = expand('#' . a:buffer . ':p:h')
 


### PR DESCRIPTION
This is an attempt to address #2761. It's ugly, but it works. Would be happy to know if there's a better way.