### PR TITLE
Fix 2777 - Add IBM openapi validator

### DIFF
--- a/ale_linters/openapi/ibm_validator.vim
+++ b/ale_linters/openapi/ibm_validator.vim
@@ -1,0 +1,58 @@
+" Author: Horacio Sanson <hsanson@gmail.com>
+
+call ale#Set('openapi_ibm_validator_executable', 'lint-openapi')
+call ale#Set('openapi_ibm_validator_options', '')
+
+function! ale_linters#openapi#ibm_validator#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'openapi_ibm_validator_options'))
+    \ . ' %t'
+endfunction
+
+function! ale_linters#openapi#ibm_validator#Handle(buffer, lines) abort
+    let l:output = []
+    let l:type = 'E'
+    let l:message = ''
+    let l:nr = -1
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, '^errors$')
+
+        if !empty(l:match)
+            let l:type = 'E'
+        endif
+
+        let l:match = matchlist(l:line, '^warnings$')
+
+        if !empty(l:match)
+            let l:type = 'W'
+        endif
+
+        let l:match = matchlist(l:line, '^ *Message : *\(.\+\)$')
+
+        if !empty(l:match)
+            let l:message = l:match[1]
+        endif
+
+        let l:match = matchlist(l:line, '^ *Line *: *\(\d\+\)$')
+
+        if !empty(l:match)
+            let l:nr = l:match[1]
+
+            call add(l:output, {
+            \   'lnum': l:nr + 0,
+            \   'col': 0,
+            \   'text': l:message,
+            \   'type': l:type,
+            \})
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('openapi', {
+\   'name': 'ibm-validator',
+\   'executable': {b -> ale#Var(b, 'openapi_ibm_validator_executable')},
+\   'command': function('ale_linters#openapi#ibm_validator#GetCommand'),
+\   'callback': 'ale_linters#openapi#ibm_validator#Handle',
+\})

--- a/ale_linters/openapi/ibm_validator.vim
+++ b/ale_linters/openapi/ibm_validator.vim
@@ -51,7 +51,7 @@ function! ale_linters#openapi#ibm_validator#Handle(buffer, lines) abort
 endfunction
 
 call ale#linter#Define('openapi', {
-\   'name': 'ibm-validator',
+\   'name': 'ibm_validator',
 \   'executable': {b -> ale#Var(b, 'openapi_ibm_validator_executable')},
 \   'command': function('ale_linters#openapi#ibm_validator#GetCommand'),
 \   'callback': 'ale_linters#openapi#ibm_validator#Handle',

--- a/ale_linters/openapi/yamllint.vim
+++ b/ale_linters/openapi/yamllint.vim
@@ -1,9 +1,7 @@
-" Author: KabbAmine <amine.kabb@gmail.com>
-
 call ale#Set('yaml_yamllint_executable', 'yamllint')
 call ale#Set('yaml_yamllint_options', '')
 
-call ale#linter#Define('yaml', {
+call ale#linter#Define('openapi', {
 \   'name': 'yamllint',
 \   'executable': {b -> ale#Var(b, 'yaml_yamllint_executable')},
 \   'command': function('ale#handlers#yamllint#GetCommand'),

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -102,7 +102,7 @@ let s:default_registry = {
 \   },
 \   'prettier': {
 \       'function': 'ale#fixers#prettier#Fix',
-\       'suggested_filetypes': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue', 'html', 'yaml'],
+\       'suggested_filetypes': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue', 'html', 'yaml', 'openapi'],
 \       'description': 'Apply prettier to a file.',
 \   },
 \   'prettier_eslint': {

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -83,6 +83,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
         \    'markdown': 'markdown',
         \    'vue': 'vue',
         \    'yaml': 'yaml',
+        \    'openapi': 'yaml',
         \    'html': 'html',
         \}
 

--- a/autoload/ale/handlers/yamllint.vim
+++ b/autoload/ale/handlers/yamllint.vim
@@ -1,0 +1,39 @@
+function! ale#handlers#yamllint#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'yaml_yamllint_options'))
+    \   . ' -f parsable %t'
+endfunction
+
+function! ale#handlers#yamllint#Handle(buffer, lines) abort
+    " Matches patterns line the following:
+    " something.yaml:1:1: [warning] missing document start "---" (document-start)
+    " something.yml:2:1: [error] syntax error: expected the node content, but found '<stream end>'
+    let l:pattern = '\v^.*:(\d+):(\d+): \[(error|warning)\] (.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:item = {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[4],
+        \   'type': l:match[3] is# 'error' ? 'E' : 'W',
+        \}
+
+        let l:code_match = matchlist(l:item.text, '\v^(.+) \(([^)]+)\)$')
+
+        if !empty(l:code_match)
+            if l:code_match[2] is# 'trailing-spaces'
+            \&& !ale#Var(a:buffer, 'warn_about_trailing_whitespace')
+                " Skip warnings for trailing whitespace if the option is off.
+                continue
+            endif
+
+            let l:item.text = l:code_match[1]
+            let l:item.code = l:code_match[2]
+        endif
+
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction
+

--- a/doc/ale-openapi.txt
+++ b/doc/ale-openapi.txt
@@ -15,7 +15,27 @@ Install ibm-openapi-validator either globally or locally: >
   npm install ibm-openapi-validator -g  # global
   npm install ibm-openapi-validator     # local
 <
-Recommended plugin for openapi filetype detection:
+Configuration
+-------------------------------------------------------------------------------
+
+OpenAPI files can be written in YAML or JSON so in order for ALE plugins to
+work with these files we must set the buffer |filetype| to either |openapi.yaml|
+or |openapi.json| respectively. This causes ALE to lint the file with linters
+configured for openapi and yaml files or openapi and json files respectively.
+
+For example setting filetype to |openapi.yaml| on a buffer and the following
+|g:ale_linters| configuration will enable linting of openapi files using both
+|ibm-validator| and |yamlint|:
+
+>
+  let g:ale_linters = {
+    \   'yaml': ['yamllint'],
+    \   'openapi': ['ibm-validator']
+  \}
+<
+
+The following plugin will detect openapi files automatically and set the
+filetype to |openapi.yaml| or |openapi.json|:
 
   https://github.com/hsanson/vim-openapi
 

--- a/doc/ale-openapi.txt
+++ b/doc/ale-openapi.txt
@@ -39,4 +39,16 @@ g:ale_openapi_ibm_validator_options       *g:ale_openapi_ibm_validator_options*
 
 
 ===============================================================================
+prettier                                                   *ale-openapi-prettier*
+
+See |ale-javascript-prettier| for information about the available options.
+
+
+===============================================================================
+yamllint                                                  *ale-openapi-yamllint*
+
+See |ale-yaml-yamllint| for information about the available options.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-openapi.txt
+++ b/doc/ale-openapi.txt
@@ -1,0 +1,42 @@
+===============================================================================
+ALE OpenApi Integration                                     *ale-openapi-options*
+
+===============================================================================
+ibm-validator                                        *ale-openapi-ibm-validator*
+
+Website: https://github.com/IBM/openapi-validator
+
+
+Installation
+-------------------------------------------------------------------------------
+
+Install ibm-openapi-validator either globally or locally: >
+
+  npm install ibm-openapi-validator -g  # global
+  npm install ibm-openapi-validator     # local
+<
+Recommended plugin for openapi filetype detection:
+
+  https://github.com/hsanson/vim-openapi
+
+Options
+-------------------------------------------------------------------------------
+
+g:ale_openapi_ibm_validator_executable   *g:ale_openapi_ibm_validator_executable*
+                                         *b:ale_openapi_ibm_validator_executable*
+  Type: |String|
+  Default: `'lint-openapi'`
+
+  This variable can be set to change the path to lint-openapi.
+
+
+g:ale_openapi_ibm_validator_options       *g:ale_openapi_ibm_validator_options*
+                                          *b:ale_openapi_ibm_validator_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to lint-openapi.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-openapi.txt
+++ b/doc/ale-openapi.txt
@@ -2,7 +2,7 @@
 ALE OpenApi Integration                                     *ale-openapi-options*
 
 ===============================================================================
-ibm-validator                                        *ale-openapi-ibm-validator*
+ibm_validator                                        *ale-openapi-ibm-validator*
 
 Website: https://github.com/IBM/openapi-validator
 
@@ -25,12 +25,12 @@ configured for openapi and yaml files or openapi and json files respectively.
 
 For example setting filetype to |openapi.yaml| on a buffer and the following
 |g:ale_linters| configuration will enable linting of openapi files using both
-|ibm-validator| and |yamlint|:
+|ibm_validator| and |yamlint|:
 
 >
   let g:ale_linters = {
     \   'yaml': ['yamllint'],
-    \   'openapi': ['ibm-validator']
+    \   'openapi': ['ibm_validator']
   \}
 <
 

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -324,6 +324,8 @@ Notes:
   * `ols`
 * OpenApi
   * `ibm-validator`
+  * `prettier`
+  * `yamllint`
 * Pawn
   * `uncrustify`
 * Perl

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -322,6 +322,8 @@ Notes:
   * `ocamlformat`
   * `ocp-indent`
   * `ols`
+* OpenApi
+  * `ibm-validator`
 * Pawn
   * `uncrustify`
 * Perl

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -323,7 +323,7 @@ Notes:
   * `ocp-indent`
   * `ols`
 * OpenApi
-  * `ibm-validator`
+  * `ibm_validator`
   * `prettier`
   * `yamllint`
 * Pawn

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2836,7 +2836,7 @@ documented in additional help files.
     ocamlformat...........................|ale-ocaml-ocamlformat|
     ocp-indent............................|ale-ocaml-ocp-indent|
   openapi.................................|ale-openapi-options|
-    ibm-validator.........................|ale-openapi-ibm-validator|
+    ibm_validator.........................|ale-openapi-ibm-validator|
     prettier..............................|ale-openapi-prettier|
     yamllint..............................|ale-openapi-yamllint|
   pawn....................................|ale-pawn-options|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2835,6 +2835,8 @@ documented in additional help files.
     ols...................................|ale-ocaml-ols|
     ocamlformat...........................|ale-ocaml-ocamlformat|
     ocp-indent............................|ale-ocaml-ocp-indent|
+  openapi.................................|ale-openapi-options|
+    ibm-validator.........................|ale-openapi-ibm-validator|
   pawn....................................|ale-pawn-options|
     uncrustify............................|ale-pawn-uncrustify|
   perl....................................|ale-perl-options|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2837,6 +2837,8 @@ documented in additional help files.
     ocp-indent............................|ale-ocaml-ocp-indent|
   openapi.................................|ale-openapi-options|
     ibm-validator.........................|ale-openapi-ibm-validator|
+    prettier..............................|ale-openapi-prettier|
+    yamllint..............................|ale-openapi-yamllint|
   pawn....................................|ale-pawn-options|
     uncrustify............................|ale-pawn-uncrustify|
   perl....................................|ale-perl-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -333,6 +333,8 @@ formatting.
   * [ols](https://github.com/freebroccolo/ocaml-language-server)
 * OpenApi
   * [ibm-validator](https://github.com/IBM/openapi-validator)
+  * [prettier](https://github.com/prettier/prettier)
+  * [yamllint](https://yamllint.readthedocs.io/)
 * Pawn
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * Perl

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -331,6 +331,8 @@ formatting.
   * [ocamlformat](https://github.com/ocaml-ppx/ocamlformat)
   * [ocp-indent](https://github.com/OCamlPro/ocp-indent)
   * [ols](https://github.com/freebroccolo/ocaml-language-server)
+* OpenApi
+  * [ibm-validator](https://github.com/IBM/openapi-validator)
 * Pawn
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * Perl

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -332,7 +332,7 @@ formatting.
   * [ocp-indent](https://github.com/OCamlPro/ocp-indent)
   * [ols](https://github.com/freebroccolo/ocaml-language-server)
 * OpenApi
-  * [ibm-validator](https://github.com/IBM/openapi-validator)
+  * [ibm_validator](https://github.com/IBM/openapi-validator)
   * [prettier](https://github.com/prettier/prettier)
   * [yamllint](https://yamllint.readthedocs.io/)
 * Pawn

--- a/test/command_callback/test_ibm_openapi_validator_command_callback.vader
+++ b/test/command_callback/test_ibm_openapi_validator_command_callback.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#assert#SetUpLinterTest('openapi', 'ibm_validator')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The yaml ibm-openapi-validator command callback should return the correct default string):
+  AssertLinter 'lint-openapi', ale#Escape('lint-openapi') . ' %t'
+
+Execute(The yaml ibm-openapi-validator command callback should be configurable):
+  let g:ale_openapi_ibm_validator_executable = '~/.local/bin/lint-openapi'
+  let g:ale_openapi_ibm_validator_options = '-c ~/.config'
+
+  AssertLinter '~/.local/bin/lint-openapi', ale#Escape('~/.local/bin/lint-openapi')
+  \ . ' -c ~/.config %t'

--- a/test/handler/test_ibm_openapi_validator_handler.vader
+++ b/test/handler/test_ibm_openapi_validator_handler.vader
@@ -1,0 +1,49 @@
+Before:
+  runtime! ale_linters/openapi/ibm_validator.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(Problems should be parsed correctly for openapi-ibm-validator):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 54,
+  \     'col': 0,
+  \     'type': 'E',
+  \     'text': 'Items with a description must have content in it.',
+  \   },
+  \   {
+  \     'lnum': 24,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': 'Operations must have a non-empty `operationId`.',
+  \   },
+  \   {
+  \     'lnum': 40,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': 'operationIds must follow case convention: lower_snake_case',
+  \   },
+  \ ],
+  \ ale_linters#openapi#ibm_validator#Handle(bufnr(''), [
+  \   '',
+  \   '[Warning] No .validaterc file found. The validator will run in default mode.',
+  \   'To configure the validator, create a .validaterc file.',
+  \   '',
+  \   'errors',
+  \   '',
+  \   '  Message :   Items with a description must have content in it.',
+  \   '  Path    :   paths./settings.patch.description',
+  \   '  Line    :   54',
+  \   '',
+  \   'warnings',
+  \   '',
+  \   '  Message :   Operations must have a non-empty `operationId`.',
+  \   '  Path    :   paths./stats.get.operationId',
+  \   '  Line    :   24',
+  \   '',
+  \   '  Message :   operationIds must follow case convention: lower_snake_case',
+  \   '  Path    :   paths./settings.get.operationId',
+  \   '  Line    :   40'
+  \ ])

--- a/test/handler/test_yamllint_handler.vader
+++ b/test/handler/test_yamllint_handler.vader
@@ -3,7 +3,7 @@ Before:
 
   let g:ale_warn_about_trailing_whitespace = 1
 
-  runtime! ale_linters/yaml/yamllint.vim
+  runtime! ale/handlers/yamllint.vim
 
 After:
   Restore
@@ -29,7 +29,7 @@ Execute(Problems should be parsed correctly for yamllint):
   \     'text': 'syntax error: expected the node content, but found ''<stream end>''',
   \   },
   \ ],
-  \ ale_linters#yaml#yamllint#Handle(bufnr(''), [
+  \ ale#handlers#yamllint#Handle(bufnr(''), [
   \   'something.yaml:1:1: [warning] missing document start "---" (document-start)',
   \   'something.yml:2:1: [error] syntax error: expected the node content, but found ''<stream end>''',
   \ ])
@@ -45,7 +45,7 @@ Execute(The yamllint handler should respect ale_warn_about_trailing_whitespace):
   \     'code': 'trailing-spaces',
   \   },
   \ ],
-  \ ale_linters#yaml#yamllint#Handle(bufnr(''), [
+  \ ale#handlers#yamllint#Handle(bufnr(''), [
   \   'something.yml:5:18: [error] trailing spaces (trailing-spaces)',
   \ ])
 
@@ -54,6 +54,6 @@ Execute(The yamllint handler should respect ale_warn_about_trailing_whitespace):
   AssertEqual
   \ [
   \ ],
-  \ ale_linters#yaml#yamllint#Handle(bufnr(''), [
+  \ ale#handlers#yamllint#Handle(bufnr(''), [
   \   'something.yml:5:18: [error] trailing spaces (trailing-spaces)',
   \ ])


### PR DESCRIPTION
Adds IBM openapi validator to the ever growing list of ALE linters. This allows us to edit open api specs in yaml within vim/neovim with confidence.

Closes #2777 