### PR TITLE
Add semistandard to node_modules search.

### DIFF
--- a/ale_linters/javascript/standard.vim
+++ b/ale_linters/javascript/standard.vim
@@ -8,6 +8,7 @@ call ale#Set('javascript_standard_options', '')
 function! ale_linters#javascript#standard#GetExecutable(buffer) abort
     return ale#node#FindExecutable(a:buffer, 'javascript_standard', [
     \   'node_modules/standard/bin/cmd.js',
+    \   'node_modules/semistandard/bin/cmd.js',
     \   'node_modules/.bin/standard',
     \])
 endfunction


### PR DESCRIPTION
This MR adds semistandard executable to the automatic search within node_modules.

See: https://github.com/dense-analysis/ale/issues/2733#issuecomment-533461320