### PR TITLE
569 support vim sign group and priority

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -14,6 +14,7 @@ let g:ale_sign_style_error = get(g:, 'ale_sign_style_error', g:ale_sign_error)
 let g:ale_sign_warning = get(g:, 'ale_sign_warning', '--')
 let g:ale_sign_style_warning = get(g:, 'ale_sign_style_warning', g:ale_sign_warning)
 let g:ale_sign_info = get(g:, 'ale_sign_info', g:ale_sign_warning)
+let g:ale_sign_priority = get(g:, 'ale_sign_priority', 30)
 " This variable sets an offset which can be set for sign IDs.
 " This ID can be changed depending on what IDs are set for other plugins.
 " The dummy sign will use the ID exactly equal to the offset.
@@ -149,7 +150,7 @@ endfunction
 
 function! s:GroupCmd() abort
   if has('nvim-0.4.0') || v:version >= 801
-    return ' group=ale '
+    return ' group=ale priority=' . g:ale_sign_priority . ' '
   else
     return ' '
   endif

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1543,6 +1543,16 @@ g:ale_set_signs                                               *g:ale_set_signs*
   To limit the number of signs ALE will set, see |g:ale_max_signs|.
 
 
+g:ale_sign_priority                                       *g:ale_sign_priority*
+
+  Type: |Number|
+  Default: `30`
+
+  From Neovim 0.4.0 and Vim 8.1, ALE can set sign priority to all signs. The
+  larger this value is, the higher priority ALE signs have over other plugin
+  signs. See |sign-priority| for further details on how priority works.
+
+
 g:ale_shell                                                       *g:ale_shell*
 
   Type: |String|

--- a/test/sign/test_linting_sets_signs.vader
+++ b/test/sign/test_linting_sets_signs.vader
@@ -21,7 +21,7 @@ Before:
   let g:ale_set_highlights = 0
   let g:ale_echo_cursor = 0
 
-  sign unplace *
+  call ale#sign#Clear()
 
   function! TestCallback(buffer, output)
     return [
@@ -32,16 +32,20 @@ Before:
 
   function! CollectSigns()
     redir => l:output
-       silent exec 'sign place'
+      if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
+        silent exec 'sign place group=ale'
+      else
+        silent exec 'sign place'
+      endif
     redir END
 
     let l:actual_sign_list = []
 
     for l:line in split(l:output, "\n")
-      let l:match = matchlist(l:line, '\v^.*\=(\d+).*\=\d+.*\=(ALE[a-zA-Z]+Sign)')
+      let l:match = matchlist(l:line, ale#sign#ParsePattern())
 
       if len(l:match) > 0
-        call add(l:actual_sign_list, [l:match[1], l:match[2]])
+        call add(l:actual_sign_list, [l:match[1], l:match[3]])
       endif
     endfor
 
@@ -60,7 +64,7 @@ After:
   delfunction CollectSigns
 
   unlet! g:ale_run_synchronously_callbacks
-  sign unplace *
+  call ale#sign#Clear()
   call ale#linter#Reset()
 
 Execute(The signs should be updated after linting is done):

--- a/test/sign/test_sign_column_highlighting.vader
+++ b/test/sign/test_sign_column_highlighting.vader
@@ -30,7 +30,7 @@ After:
   delfunction SetHighlight
   unlet! g:sign_highlight
 
-  sign unplace *
+  call ale#sign#Clear()
 
 Execute(The SignColumn highlight shouldn't be changed if the option is off):
   let g:ale_change_sign_column_color = 0

--- a/test/sign/test_sign_limits.vader
+++ b/test/sign/test_sign_limits.vader
@@ -30,7 +30,7 @@ After:
 
   delfunction SetNProblems
 
-  sign unplace *
+  call ale#sign#Clear()
 
 Execute(There should be no limit on signs with negative numbers):
   AssertEqual range(1, 42), SetNProblems(42)

--- a/test/sign/test_sign_parsing.vader
+++ b/test/sign/test_sign_parsing.vader
@@ -1,5 +1,5 @@
 Execute (Parsing English signs should work):
-  if has('nvim-0.4.0') || v:version >= 801
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
     AssertEqual
     \ [0, [[9, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns([
@@ -16,7 +16,7 @@ Execute (Parsing English signs should work):
   endif
 
 Execute (Parsing Russian signs should work):
-  if has('nvim-0.4.0') || v:version >= 801
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
     AssertEqual
     \ [0, [[1, 1000001, 'ALEErrorSign']]],
     \ ale#sign#ParseSigns(['    строка=1  id=1000001  group=ale  имя=ALEErrorSign'])
@@ -27,7 +27,7 @@ Execute (Parsing Russian signs should work):
   endif
 
 Execute (Parsing Japanese signs should work):
-  if has('nvim-0.4.0') || v:version >= 801
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns(['    行=1  識別子=1000001  group=ale  名前=ALEWarningSign'])
@@ -38,7 +38,7 @@ Execute (Parsing Japanese signs should work):
   endif
 
 Execute (Parsing Spanish signs should work):
-  if has('nvim-0.4.0') || v:version >= 801
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
     AssertEqual
     \ [0, [[12, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns(['    línea=12 id=1000001  group=ale  nombre=ALEWarningSign'])
@@ -49,7 +49,7 @@ Execute (Parsing Spanish signs should work):
   endif
 
 Execute (Parsing Italian signs should work):
-  if has('nvim-0.4.0') || v:version >= 801
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns(['    riga=1 id=1000001, group=ale  nome=ALEWarningSign'])
@@ -60,7 +60,7 @@ Execute (Parsing Italian signs should work):
   endif
 
 Execute (The sign parser should indicate if the dummy sign is set):
-  if has('nvim-0.4.0') || v:version >= 801
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
     AssertEqual
     \ [1, [[1, 1000001, 'ALEErrorSign']]],
     \ ale#sign#ParseSigns([

--- a/test/sign/test_sign_parsing.vader
+++ b/test/sign/test_sign_parsing.vader
@@ -1,35 +1,77 @@
 Execute (Parsing English signs should work):
-  AssertEqual
-  \ [0, [[9, 1000001, 'ALEWarningSign']]],
-  \ ale#sign#ParseSigns([
-  \   'Signs for app.js:',
-  \   '    line=9  id=1000001  name=ALEWarningSign',
-  \ ])
+  if has('nvim-0.4.0') || v:version >= 801
+    AssertEqual
+    \ [0, [[9, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns([
+    \   'Signs for app.js:',
+    \   '    line=9  id=1000001  group=ale  name=ALEWarningSign',
+    \ ])
+  else
+    AssertEqual
+    \ [0, [[9, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns([
+    \   'Signs for app.js:',
+    \   '    line=9  id=1000001  name=ALEWarningSign',
+    \ ])
+  endif
 
 Execute (Parsing Russian signs should work):
-  AssertEqual
-  \ [0, [[1, 1000001, 'ALEErrorSign']]],
-  \ ale#sign#ParseSigns(['    строка=1  id=1000001  имя=ALEErrorSign'])
+  if has('nvim-0.4.0') || v:version >= 801
+    AssertEqual
+    \ [0, [[1, 1000001, 'ALEErrorSign']]],
+    \ ale#sign#ParseSigns(['    строка=1  id=1000001  group=ale  имя=ALEErrorSign'])
+  else
+    AssertEqual
+    \ [0, [[1, 1000001, 'ALEErrorSign']]],
+    \ ale#sign#ParseSigns(['    строка=1  id=1000001  имя=ALEErrorSign'])
+  endif
 
 Execute (Parsing Japanese signs should work):
-  AssertEqual
-  \ [0, [[1, 1000001, 'ALEWarningSign']]],
-  \ ale#sign#ParseSigns(['    行=1  識別子=1000001  名前=ALEWarningSign'])
+  if has('nvim-0.4.0') || v:version >= 801
+    AssertEqual
+    \ [0, [[1, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns(['    行=1  識別子=1000001  group=ale  名前=ALEWarningSign'])
+  else
+    AssertEqual
+    \ [0, [[1, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns(['    行=1  識別子=1000001  名前=ALEWarningSign'])
+  endif
 
 Execute (Parsing Spanish signs should work):
-  AssertEqual
-  \ [0, [[12, 1000001, 'ALEWarningSign']]],
-  \ ale#sign#ParseSigns(['    línea=12 id=1000001 nombre=ALEWarningSign'])
+  if has('nvim-0.4.0') || v:version >= 801
+    AssertEqual
+    \ [0, [[12, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns(['    línea=12 id=1000001  group=ale  nombre=ALEWarningSign'])
+  else
+    AssertEqual
+    \ [0, [[12, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns(['    línea=12 id=1000001  nombre=ALEWarningSign'])
+  endif
 
 Execute (Parsing Italian signs should work):
-  AssertEqual
-  \ [0, [[1, 1000001, 'ALEWarningSign']]],
-  \ ale#sign#ParseSigns(['    riga=1 id=1000001, nome=ALEWarningSign'])
-  \
+  if has('nvim-0.4.0') || v:version >= 801
+    AssertEqual
+    \ [0, [[1, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns(['    riga=1 id=1000001, group=ale  nome=ALEWarningSign'])
+  else
+    AssertEqual
+    \ [0, [[1, 1000001, 'ALEWarningSign']]],
+    \ ale#sign#ParseSigns(['    riga=1 id=1000001, nome=ALEWarningSign'])
+  endif
+
 Execute (The sign parser should indicate if the dummy sign is set):
-  AssertEqual
-  \ [1, [[1, 1000001, 'ALEErrorSign']]],
-  \ ale#sign#ParseSigns([
-  \   '    строка=1  id=1000001  имя=ALEErrorSign',
-  \   '    line=1  id=1000000  name=ALEDummySign',
-  \ ])
+  if has('nvim-0.4.0') || v:version >= 801
+    AssertEqual
+    \ [1, [[1, 1000001, 'ALEErrorSign']]],
+    \ ale#sign#ParseSigns([
+    \   '    строка=1  id=1000001  group=ale  имя=ALEErrorSign',
+    \   '    line=1  id=1000000  group=ale  name=ALEDummySign',
+    \ ])
+  else
+    AssertEqual
+    \ [1, [[1, 1000001, 'ALEErrorSign']]],
+    \ ale#sign#ParseSigns([
+    \   '    строка=1  id=1000001  имя=ALEErrorSign',
+    \   '    line=1  id=1000000  name=ALEDummySign',
+    \ ])
+  endif

--- a/test/sign/test_sign_placement.vader
+++ b/test/sign/test_sign_placement.vader
@@ -17,7 +17,7 @@ Before:
   let g:ale_echo_cursor = 0
 
   call ale#linter#Reset()
-  sign unplace *
+  call ale#sign#Clear()
 
   function! GenerateResults(buffer, output)
     return [
@@ -68,12 +68,16 @@ Before:
 
   function! ParseSigns()
     redir => l:output
-      silent sign place
+      if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
+        silent sign place group=ale
+      else
+        silent sign place
+      endif
     redir END
 
     return map(
     \ split(l:output, '\n')[2:],
-    \ 'matchlist(v:val, ''^.*=\(\d\+\).*=\(\d\+\).*=\(.*\)$'')[1:3]',
+    \ 'matchlist(v:val, ''' . ale#sign#ParsePattern() . ''')[1:3]',
     \)
   endfunction
 
@@ -92,7 +96,7 @@ After:
   delfunction GenerateResults
   delfunction ParseSigns
   call ale#linter#Reset()
-  sign unplace *
+  call ale#sign#Clear()
 
 Execute(ale#sign#GetSignName should return the right sign names):
   AssertEqual 'ALEErrorSign', ale#sign#GetSignName([{'type': 'E'}])
@@ -148,9 +152,15 @@ Execute(The current signs should be set for running a job):
   \ ParseSigns()
 
 Execute(Loclist items with sign_id values should be kept):
-  exec 'sign place 1000347 line=3 name=ALEErrorSign buffer=' . bufnr('')
-  exec 'sign place 1000348 line=15 name=ALEErrorSign buffer=' . bufnr('')
-  exec 'sign place 1000349 line=16 name=ALEWarningSign buffer=' . bufnr('')
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
+    exec 'sign place 1000347 group=ale line=3 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000348 group=ale line=15 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000349 group=ale line=16 name=ALEWarningSign buffer=' . bufnr('')
+  else
+    exec 'sign place 1000347 line=3 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000348 line=15 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000349 line=16 name=ALEWarningSign buffer=' . bufnr('')
+  endif
 
   let g:loclist = [
   \ {'bufnr': bufnr(''), 'lnum': 1, 'col': 1, 'type': 'E', 'text': 'a', 'sign_id': 1000348},
@@ -287,10 +297,17 @@ Execute(No exceptions should be thrown when setting signs for invalid buffers):
 Execute(Signs should be removed when lines have multiple sign IDs on them):
   " We can fail to remove signs if there are multiple signs on one line,
   " say after deleting lines in Vim, etc.
-  exec 'sign place 1000347 line=3 name=ALEErrorSign buffer=' . bufnr('')
-  exec 'sign place 1000348 line=3 name=ALEWarningSign buffer=' . bufnr('')
-  exec 'sign place 1000349 line=10 name=ALEErrorSign buffer=' . bufnr('')
-  exec 'sign place 1000350 line=10 name=ALEWarningSign buffer=' . bufnr('')
+  if has('nvim-0.4.0') || (v:version >= 801 && has('patch614'))
+    exec 'sign place 1000347 group=ale line=3 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000348 group=ale line=3 name=ALEWarningSign buffer=' . bufnr('')
+    exec 'sign place 1000349 group=ale line=10 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000350 group=ale line=10 name=ALEWarningSign buffer=' . bufnr('')
+  else
+    exec 'sign place 1000347 line=3 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000348 line=3 name=ALEWarningSign buffer=' . bufnr('')
+    exec 'sign place 1000349 line=10 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000350 line=10 name=ALEWarningSign buffer=' . bufnr('')
+  endif
 
   call ale#sign#SetSigns(bufnr(''), [])
   AssertEqual [], ParseSigns()

--- a/test/test_ale_toggle.vader
+++ b/test/test_ale_toggle.vader
@@ -82,7 +82,7 @@ Before:
   \ 'read_buffer': 0,
   \})
 
-  sign unplace *
+  call ale#sign#Clear()
 
 After:
   Restore
@@ -105,7 +105,7 @@ After:
   delfunction ParseAuGroups
 
   call setloclist(0, [])
-  sign unplace *
+  call ale#sign#Clear()
   call clearmatches()
 
 Given foobar (Some imaginary filetype):

--- a/test/test_highlight_placement.vader
+++ b/test/test_highlight_placement.vader
@@ -114,7 +114,7 @@ After:
   delfunction GenerateResults
   call ale#linter#Reset()
   call clearmatches()
-  sign unplace *
+  call ale#sign#Clear()
   highlight clear SomeOtherGroup
 
   runtime autoload/ale/highlight.vim

--- a/test/test_results_not_cleared_when_opening_loclist.vader
+++ b/test/test_results_not_cleared_when_opening_loclist.vader
@@ -8,7 +8,7 @@ After:
 
   call setloclist(0, [])
   call clearmatches()
-  sign unplace *
+  call ale#sign#Clear()
 
 Given foobar (Some file):
   abc

--- a/test/test_setting_problems_found_in_previous_buffers.vader
+++ b/test/test_setting_problems_found_in_previous_buffers.vader
@@ -38,7 +38,7 @@ After:
   " Items and markers, etc.
   call setloclist(0, [])
   call clearmatches()
-  sign unplace *
+  call ale#sign#Clear()
 
 Given foobar(A file with some lines):
   foo


### PR DESCRIPTION
Add sign-group and sign-priority support to ALE. With sign-group ALE can manipulate the signs without risk of conflicts with other plugins that also set signs and with priority users are able to adjust ALE signs priority to override or be overridden by other plugins signs.

