### PR TITLE
Add option to show hover messages in preview.

### DIFF
--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -42,6 +42,11 @@ function! ale#hover#HandleTSServerResponse(conn_id, response) abort
             \&& exists('*balloon_show')
             \&& ale#Var(l:options.buffer, 'set_balloons')
                 call balloon_show(a:response.body.displayString)
+            elseif g:ale_hover_to_preview
+                call ale#preview#Show(split(a:response.body.displayString, "\n"), {
+                \   'filetype': 'ale-preview.message',
+                \   'stay_here': 1,
+                \})
             else
                 call ale#util#ShowMessage(a:response.body.displayString)
             endif
@@ -98,6 +103,11 @@ function! ale#hover#HandleLSPResponse(conn_id, response) abort
                 \&& exists('*balloon_show')
                 \&& ale#Var(l:options.buffer, 'set_balloons')
                     call balloon_show(l:str)
+                elseif g:ale_hover_to_preview
+                    call ale#preview#Show(split(l:str, "\n"), {
+                    \   'filetype': 'ale-preview.message',
+                    \   'stay_here': 1,
+                    \})
                 else
                     call ale#util#ShowMessage(l:str)
                 endif

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -125,6 +125,9 @@ let g:ale_close_preview_on_insert = get(g:, 'ale_close_preview_on_insert', 0)
 " This flag can be set to 0 to disable balloon support.
 let g:ale_set_balloons = get(g:, 'ale_set_balloons', has('balloon_eval') && has('gui_running'))
 
+" Use preview window for hover messages.
+let g:ale_hover_to_preview = get(g:, 'ale_hover_to_preview', 0)
+
 " This flag can be set to 0 to disable warnings for trailing whitespace
 let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)
 " This flag can be set to 0 to disable warnings for trailing blank lines


### PR DESCRIPTION
Add new option 'ale_hover_to_preview' to show hover messages
in preview window.

Main reason is that I want to read the function signature while editing the code.

Possible solution for #2317

TODO: Add this option to documentation. 