### PR TITLE
Fix TCP server config example.

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -172,7 +172,7 @@ address to connect to instead. >
 
   call ale#linter#Define('filetype_here', {
   \   'name': 'any_name_you_want',
-  \   'lsp': 'stdio',
+  \   'lsp': 'socket',
   \   'address': 'servername:1234',
   \   'project_root': '/path/to/root_of_project',
   \})


### PR DESCRIPTION
The docs for the `address` parameter of `Define` say:

> This argument must only be set if the `lsp` argument
> is set to `'socket'`.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
