### PR TITLE
Add support for rust-analyzer

### DIFF
--- a/ale_linters/rust/analyzer.vim
+++ b/ale_linters/rust/analyzer.vim
@@ -15,7 +15,7 @@ function! ale_linters#rust#analyzer#GetProjectRoot(buffer) abort
 endfunction
 
 call ale#linter#Define('rust', {
-\   'name': 'rust-analyzer',
+\   'name': 'analyzer',
 \   'lsp': 'stdio',
 \   'lsp_config': {b -> ale#Var(b, 'rust_analyzer_config')},
 \   'executable': {b -> ale#Var(b, 'rust_analyzer_executable')},

--- a/ale_linters/rust/analyzer.vim
+++ b/ale_linters/rust/analyzer.vim
@@ -1,7 +1,7 @@
 " Author: Jon Gjengset <jon@thesquareplanet.com>
 " Description: The next generation language server for Rust
 
-call ale#Set('rust_analyzer_executable', 'ra_lsp_server')
+call ale#Set('rust_analyzer_executable', 'rust-analyzer')
 call ale#Set('rust_analyzer_config', {})
 
 function! ale_linters#rust#analyzer#GetCommand(buffer) abort

--- a/ale_linters/rust/analyzer.vim
+++ b/ale_linters/rust/analyzer.vim
@@ -1,0 +1,24 @@
+" Author: Jon Gjengset <jon@thesquareplanet.com>
+" Description: The next generation language server for Rust
+
+call ale#Set('rust_analyzer_executable', 'ra_lsp_server')
+call ale#Set('rust_analyzer_config', {})
+
+function! ale_linters#rust#analyzer#GetCommand(buffer) abort
+    return '%e'
+endfunction
+
+function! ale_linters#rust#analyzer#GetProjectRoot(buffer) abort
+    let l:cargo_file = ale#path#FindNearestFile(a:buffer, 'Cargo.toml')
+
+    return !empty(l:cargo_file) ? fnamemodify(l:cargo_file, ':h') : ''
+endfunction
+
+call ale#linter#Define('rust', {
+\   'name': 'rust-analyzer',
+\   'lsp': 'stdio',
+\   'lsp_config': {b -> ale#Var(b, 'rust_analyzer_config')},
+\   'executable': {b -> ale#Var(b, 'rust_analyzer_executable')},
+\   'command': function('ale_linters#rust#analyzer#GetCommand'),
+\   'project_root': function('ale_linters#rust#analyzer#GetProjectRoot'),
+\})

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -9,7 +9,7 @@ Integration Information
   files for Rust distributed in Vim >=8.0.0501 or upstream:
   https://github.com/rust-lang/rust.vim
 
-  Note that there are three possible linters for Rust files:
+  Note that there are several possible linters and fixers for Rust files:
 
   1. rustc -- The Rust compiler is used to check the currently edited file.
      So, if your project consists of multiple files, you will get some errors
@@ -23,12 +23,12 @@ Integration Information
      over cargo. rls implements the Language Server Protocol for incremental
      compilation of Rust code, and can check Rust files while you type. `rls`
      requires Rust files to contained in Cargo projects.
-  3. analyzer -- If you have rust-analyzer installed, you might prefer using
+  4. analyzer -- If you have rust-analyzer installed, you might prefer using
      this linter over cargo and rls. rust-analyzer also implements the
      Language Server Protocol for incremental compilation of Rust code, and is
      the next iteration of rls. rust-analyzer, like rls, requires Rust files
      to contained in Cargo projects.
-  4. rustfmt -- If you have `rustfmt` installed, you can use it as a fixer to
+  5. rustfmt -- If you have `rustfmt` installed, you can use it as a fixer to
      consistently reformat your Rust code.
 
   Only cargo is enabled by default. To switch to using rustc instead of cargo,

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -47,7 +47,7 @@ analyzer                                                    *ale-rust-analyzer*
 g:ale_rust_analyzer_executable                 *g:ale_rust_analyzer_executable*
                                                *b:ale_rust_analyzer_executable*
   Type: |String|
-  Default: `'ra_lsp_server'`
+  Default: `'rust-analyzer'`
 
   This variable can be modified to change the executable path for
   `rust-analyzer`.

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -23,6 +23,11 @@ Integration Information
      over cargo. rls implements the Language Server Protocol for incremental
      compilation of Rust code, and can check Rust files while you type. `rls`
      requires Rust files to contained in Cargo projects.
+  3. analyzer -- If you have rust-analyzer installed, you might prefer using
+     this linter over cargo and rls. rust-analyzer also implements the
+     Language Server Protocol for incremental compilation of Rust code, and is
+     the next iteration of rls. rust-analyzer, like rls, requires Rust files
+     to contained in Cargo projects.
   4. rustfmt -- If you have `rustfmt` installed, you can use it as a fixer to
      consistently reformat your Rust code.
 
@@ -189,6 +194,25 @@ g:ale_rust_rls_config                                   *g:ale_rust_rls_config*
       \   }
       \ }
 
+
+===============================================================================
+analyzer                                                    *ale-rust-analyzer*
+
+g:ale_rust_analyzer_executable                 *g:ale_rust_analyzer_executable*
+                                               *b:ale_rust_analyzer_executable*
+  Type: |String|
+  Default: `'ra_lsp_server'`
+
+  This variable can be modified to change the executable path for
+  `rust-analyzer`.
+
+
+g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
+                                                   *b:ale_rust_analyzer_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary with configuration settings for rust-analyzer.
 
 ===============================================================================
 rustc                                                          *ale-rust-rustc*

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -42,6 +42,25 @@ Integration Information
 
 
 ===============================================================================
+analyzer                                                    *ale-rust-analyzer*
+
+g:ale_rust_analyzer_executable                 *g:ale_rust_analyzer_executable*
+                                               *b:ale_rust_analyzer_executable*
+  Type: |String|
+  Default: `'ra_lsp_server'`
+
+  This variable can be modified to change the executable path for
+  `rust-analyzer`.
+
+
+g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
+                                                   *b:ale_rust_analyzer_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary with configuration settings for rust-analyzer.
+
+===============================================================================
 cargo                                                          *ale-rust-cargo*
 
 g:ale_rust_cargo_use_check                         *g:ale_rust_cargo_use_check*
@@ -194,25 +213,6 @@ g:ale_rust_rls_config                                   *g:ale_rust_rls_config*
       \   }
       \ }
 
-
-===============================================================================
-analyzer                                                    *ale-rust-analyzer*
-
-g:ale_rust_analyzer_executable                 *g:ale_rust_analyzer_executable*
-                                               *b:ale_rust_analyzer_executable*
-  Type: |String|
-  Default: `'ra_lsp_server'`
-
-  This variable can be modified to change the executable path for
-  `rust-analyzer`.
-
-
-g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
-                                                   *b:ale_rust_analyzer_config*
-  Type: |Dictionary|
-  Default: `{}`
-
-  Dictionary with configuration settings for rust-analyzer.
 
 ===============================================================================
 rustc                                                          *ale-rust-rustc*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -404,6 +404,7 @@ Notes:
 * Rust
   * `cargo`!!
   * `rls`
+  * `rust-analyzer`
   * `rustc` (see |ale-integration-rust|)
   * `rustfmt`
 * Sass

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2411,6 +2411,7 @@ documented in additional help files.
   rust....................................|ale-rust-options|
     cargo.................................|ale-rust-cargo|
     rls...................................|ale-rust-rls|
+    rust-analyzer.........................|ale-rust-analyzer|
     rustc.................................|ale-rust-rustc|
     rustfmt...............................|ale-rust-rustfmt|
   sass....................................|ale-sass-options|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2411,7 +2411,7 @@ documented in additional help files.
   rust....................................|ale-rust-options|
     cargo.................................|ale-rust-cargo|
     rls...................................|ale-rust-rls|
-    rust-analyzer.........................|ale-rust-analyzer|
+    analyzer..............................|ale-rust-analyzer|
     rustc.................................|ale-rust-rustc|
     rustfmt...............................|ale-rust-rustfmt|
   sass....................................|ale-sass-options|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2409,9 +2409,9 @@ documented in additional help files.
     sorbet................................|ale-ruby-sorbet|
     standardrb............................|ale-ruby-standardrb|
   rust....................................|ale-rust-options|
+    analyzer..............................|ale-rust-analyzer|
     cargo.................................|ale-rust-cargo|
     rls...................................|ale-rust-rls|
-    analyzer..............................|ale-rust-analyzer|
     rustc.................................|ale-rust-rustc|
     rustfmt...............................|ale-rust-rustfmt|
   sass....................................|ale-sass-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -413,6 +413,7 @@ formatting.
 * Rust
   * [cargo](https://github.com/rust-lang/cargo) :floppy_disk: (see `:help ale-integration-rust` for configuration instructions)
   * [rls](https://github.com/rust-lang-nursery/rls) :warning:
+  * [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer) :warning:
   * [rustc](https://www.rust-lang.org/) :warning:
   * [rustfmt](https://github.com/rust-lang-nursery/rustfmt)
 * Sass

--- a/test/command_callback/test_rust_analyzer_callbacks.vader
+++ b/test/command_callback/test_rust_analyzer_callbacks.vader
@@ -5,7 +5,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
-  AssertLinter 'analyzer', ale#Escape('ra_lsp_server')
+  AssertLinter 'ra_lsp_server', ale#Escape('ra_lsp_server')
 
 Execute(The project root should be detected correctly):
   AssertLSPProject ''

--- a/test/command_callback/test_rust_analyzer_callbacks.vader
+++ b/test/command_callback/test_rust_analyzer_callbacks.vader
@@ -1,0 +1,20 @@
+Before:
+  call ale#assert#SetUpLinterTest('rust', 'analyzer')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  AssertLinter 'analyzer', ale#Escape('ra_lsp_server')
+
+Execute(The project root should be detected correctly):
+  AssertLSPProject ''
+
+  call ale#test#SetFilename('rust-rls-project/test.rs')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/rust-rls-project')
+
+Execute(Should accept configuration settings):
+  AssertLSPConfig {}
+  let b:ale_rust_analyzer_config = {'rust': {'clippy_preference': 'on'}}
+  AssertLSPConfig {'rust': {'clippy_preference': 'on'}}

--- a/test/command_callback/test_rust_analyzer_callbacks.vader
+++ b/test/command_callback/test_rust_analyzer_callbacks.vader
@@ -5,7 +5,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
-  AssertLinter 'ra_lsp_server', ale#Escape('ra_lsp_server')
+  AssertLinter 'rust-analyzer', ale#Escape('rust-analyzer')
 
 Execute(The project root should be detected correctly):
   AssertLSPProject ''


### PR DESCRIPTION
Fixes #2832.

This is a very straightforward adaptation of the existing `rls` support.