### PR TITLE
Allow code actions to work on callback based sources

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -722,7 +722,7 @@ endfunction
 function! ale#completion#HandleUserData(completed_item) abort
     let l:source = get(get(b:, 'ale_completion_info', {}), 'source', '')
 
-    if l:source isnot# 'ale-automatic' && l:source isnot# 'ale-manual'
+    if l:source isnot# 'ale-automatic' && l:source isnot# 'ale-manual' && l:source isnot# 'ale-callback'
         return
     endif
 

--- a/test/completion/test_completion_events.vader
+++ b/test/completion/test_completion_events.vader
@@ -431,6 +431,12 @@ Execute(HandleUserData should call ale#code_action#HandleCodeAction):
   \})
   AssertEqual g:handle_code_action_called, 2
 
+  let b:ale_completion_info = {'source': 'ale-callback'}
+  call ale#completion#HandleUserData({
+  \  'user_data': '{"codeActions": [{"description":"", "changes": []}]}'
+  \})
+  AssertEqual g:handle_code_action_called, 3
+
 Execute(ale#code_action#HandleCodeAction should not be called when when source is not ALE):
   call MockHandleCodeAction()
   let b:ale_completion_info = {'source': 'syntastic'}


### PR DESCRIPTION
This enables code actions on callback based sources such as `asyncomplete` so everyone can participate with the fun :)