### PR TITLE
Fix tsserver not returning details for items with empty source

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -492,10 +492,17 @@ function! ale#completion#HandleTSServerResponse(conn_id, response) abort
             let l:identifiers = []
 
             for l:name in l:names
-                call add(l:identifiers, {
+                let l:identifier = {
                 \   'name': l:name.word,
-                \   'source': get(l:name, 'source', ''),
-                \})
+                \}
+                let l:source = get(l:name, 'source', '')
+
+                " Empty source results in no details for the completed item
+                if !empty(l:source)
+                    call extend(l:identifier, { 'source': l:source })
+                endif
+
+                call add(l:identifiers, l:identifier)
             endfor
 
             let b:ale_completion_info.request_id = ale#lsp#Send(

--- a/test/completion/test_lsp_completion_messages.vader
+++ b/test/completion/test_lsp_completion_messages.vader
@@ -190,10 +190,8 @@ Execute(The right message sent to the tsserver LSP when the first completion mes
   \          'source': '/path/to/foo.ts',
   \         }, {
   \          'name': 'FooBar',
-  \          'source': '',
   \         }, {
   \          'name': 'frazzle',
-  \          'source': '',
   \     }],
   \     'offset': 1,
   \     'line': 1,


### PR DESCRIPTION
Prior to #2709 `tsserver` based completions would include details on more items, whereas now there are fewer items with details.

This is caused by including an empty string as the source when communicating with the `tsserver`, which confuses it and forces it to return less information about completed items.

This resolves the issue, and fixes the requisite tests