### PR TITLE
Exclude undetailed items

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -16,6 +16,7 @@ let g:ale_completion_delay = get(g:, 'ale_completion_delay', 100)
 let g:ale_completion_excluded_words = get(g:, 'ale_completion_excluded_words', [])
 let g:ale_completion_max_suggestions = get(g:, 'ale_completion_max_suggestions', 50)
 let g:ale_completion_tsserver_autoimport = get(g:, 'ale_completion_tsserver_autoimport', 0)
+let g:ale_completion_tsserver_remove_items_without_detail = get(g:, 'ale_completion_tsserver_remove_items_without_detail', 0)
 
 let s:timer_id = -1
 let s:last_done_pos = []
@@ -358,7 +359,7 @@ function! ale#completion#ParseTSServerCompletionEntryDetails(response) abort
 
     let l:names = getbufvar(l:buffer, 'ale_tsserver_completion_names', [])
 
-    if !empty(l:names) && len(l:names) != len(l:results)
+    if !empty(l:names) && len(l:names) != len(l:results) && g:ale_completion_tsserver_remove_items_without_detail == 0
         let l:names_with_details = map(copy(l:results), 'v:val.word')
         let l:missing_names = filter(
         \   copy(l:names),

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -492,10 +492,17 @@ function! ale#completion#HandleTSServerResponse(conn_id, response) abort
             let l:identifiers = []
 
             for l:name in l:names
-                call add(l:identifiers, {
+                let l:identifier = {
                 \   'name': l:name.word,
-                \   'source': get(l:name, 'source', ''),
-                \})
+                \}
+                let l:source = get(l:name, 'source', '')
+
+                " Empty source results in no details for the completed item
+                if !empty(l:source)
+                    call extend(l:identifier, { 'source': l:source })
+                endif
+
+                call add(l:identifiers, l:identifier)
             endfor
 
             let b:ale_completion_info.request_id = ale#lsp#Send(

--- a/test/completion/test_lsp_completion_messages.vader
+++ b/test/completion/test_lsp_completion_messages.vader
@@ -190,10 +190,8 @@ Execute(The right message sent to the tsserver LSP when the first completion mes
   \          'source': '/path/to/foo.ts',
   \         }, {
   \          'name': 'FooBar',
-  \          'source': '',
   \         }, {
   \          'name': 'frazzle',
-  \          'source': '',
   \     }],
   \     'offset': 1,
   \     'line': 1,

--- a/test/completion/test_tsserver_completion_parsing.vader
+++ b/test/completion/test_tsserver_completion_parsing.vader
@@ -197,3 +197,83 @@ Execute(Entries without details should be included in the responses):
   \   },
   \ ],
   \})
+
+Execute(Entries without details should be excluded in the responses when user excludes them):
+  let g:ale_completion_tsserver_remove_items_without_detail = 1
+  let b:ale_tsserver_completion_names = [{
+  \  'word': 'xyz',
+  \  'source': '/path/to/xyz.ts',
+  \ }]
+
+  AssertEqual
+  \ [
+  \   {
+  \     'word': 'abc',
+  \     'menu': 'import { def } from "./Foo"; (property) Foo.abc: number',
+  \     'info': '',
+  \     'kind': 'f',
+  \     'icase': 1,
+  \     'user_data': json_encode({
+  \         'codeActions': [{
+  \             'description': 'import { def } from "./Foo";',
+  \             'changes': [],
+  \         }],
+  \     }),
+  \     'dup': g:ale_completion_tsserver_autoimport,
+  \   },
+  \   {
+  \     'word': 'def',
+  \     'menu': '(property) Foo.def: number',
+  \     'info': 'foo bar baz',
+  \     'kind': 'f',
+  \     'icase': 1,
+  \     'dup': g:ale_completion_tsserver_autoimport,
+  \   },
+  \ ],
+  \ ale#completion#ParseTSServerCompletionEntryDetails({
+  \ 'body': [
+  \   {
+  \     'name': 'abc',
+  \     'kind': 'parameterName',
+  \     'displayParts': [
+  \       {'text': '('},
+  \       {'text': 'property'},
+  \       {'text': ')'},
+  \       {'text': ' '},
+  \       {'text': 'Foo'},
+  \       {'text': '.'},
+  \       {'text': 'abc'},
+  \       {'text': ':'},
+  \       {'text': ' '},
+  \       {'text': 'number'},
+  \     ],
+  \     'codeActions': [{
+  \        'description': 'import { def } from "./Foo";',
+  \        'changes': [],
+  \     }],
+  \   },
+  \   {
+  \     'name': 'def',
+  \     'kind': 'parameterName',
+  \     'displayParts': [
+  \       {'text': '('},
+  \       {'text': 'property'},
+  \       {'text': ')'},
+  \       {'text': ' '},
+  \       {'text': 'Foo'},
+  \       {'text': '.'},
+  \       {'text': 'def'},
+  \       {'text': ':'},
+  \       {'text': ' '},
+  \       {'text': 'number'},
+  \     ],
+  \     'documentation': [
+  \       {'text': 'foo'},
+  \       {'text': ' '},
+  \       {'text': 'bar'},
+  \       {'text': ' '},
+  \       {'text': 'baz'},
+  \     ],
+  \   },
+  \ ],
+  \})


### PR DESCRIPTION
Allows the user to exclude items without details when completing with the `tsserver`. This can drastically clean up completions in situations where `tsserver` just returns junk data

Relies on #2845