### PR TITLE
Allow the user to remove warnings from completions

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -298,7 +298,9 @@ function! ale#completion#ParseTSServerCompletions(response) abort
     let l:names = []
 
     for l:suggestion in a:response.body
-        if g:ale_completion_tsserver_remove_warnings == 0 || l:suggestion.kind isnot# 'warning'
+        let l:kind = get(l:suggestion, 'kind', '')
+
+        if g:ale_completion_tsserver_remove_warnings == 0 || l:kind isnot# 'warning'
             call add(l:names, {
             \ 'word': l:suggestion.name,
             \ 'source': get(l:suggestion, 'source', ''),

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -16,6 +16,7 @@ let g:ale_completion_delay = get(g:, 'ale_completion_delay', 100)
 let g:ale_completion_excluded_words = get(g:, 'ale_completion_excluded_words', [])
 let g:ale_completion_max_suggestions = get(g:, 'ale_completion_max_suggestions', 50)
 let g:ale_completion_tsserver_autoimport = get(g:, 'ale_completion_tsserver_autoimport', 0)
+let g:ale_completion_tsserver_remove_warnings = get(g:, 'ale_completion_tsserver_remove_warnings', 0)
 
 let s:timer_id = -1
 let s:last_done_pos = []
@@ -297,10 +298,12 @@ function! ale#completion#ParseTSServerCompletions(response) abort
     let l:names = []
 
     for l:suggestion in a:response.body
-        call add(l:names, {
-        \ 'word': l:suggestion.name,
-        \ 'source': get(l:suggestion, 'source', ''),
-        \})
+        if g:ale_completion_tsserver_remove_warnings == 0 || l:suggestion.kind isnot# 'warning'
+            call add(l:names, {
+            \ 'word': l:suggestion.name,
+            \ 'source': get(l:suggestion, 'source', ''),
+            \})
+        endif
     endfor
 
     return l:names

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -420,7 +420,9 @@ completion information with Deoplete, consult Deoplete's documentation.
 
 When working with TypeScript files, ALE by can support automatic imports
 from external modules. This behavior can be enabled by setting the
-|g:ale_completion_tsserver_autoimport| variable to `1`.
+|g:ale_completion_tsserver_autoimport| variable to `1`. ALE can also remove
+warnings from your completions by setting the
+|g:ale_completion_tsserver_remove_warnings| variable to 1.
 
                                                *ale-completion-completeopt-bug*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -644,6 +644,14 @@ b:ale_completion_enabled                             *b:ale_completion_enabled*
 
   See |ale-completion|
 
+g:ale_completion_tsserver_remove_warnings *g:ale_completion_tsserver_remove_warnings*
+
+  Type: Number
+  Default: `0`
+
+  When this option is set to `0`, ALE will return all completion items,
+  including those that are a warning. Warnings can be excluded from completed
+  items by setting it to `1`.
 
 g:ale_completion_tsserver_autoimport     *g:ale_completion_tsserver_autoimport*
 

--- a/test/completion/test_tsserver_completion_parsing.vader
+++ b/test/completion/test_tsserver_completion_parsing.vader
@@ -29,6 +29,51 @@ Execute(TypeScript completions responses should be parsed correctly):
   \ ],
   \})
 
+Execute(TypeScript completions responses should include warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'word': 'foo',
+  \     'source': '/path/to/foo.ts',
+  \   },
+  \   {
+  \     'word': 'bar',
+  \     'source': '',
+  \   },
+  \   {
+  \     'word': 'baz',
+  \     'source': '',
+  \   }
+  \ ],
+  \ ale#completion#ParseTSServerCompletions({
+  \ 'body': [
+  \   {'name': 'foo', 'source': '/path/to/foo.ts'},
+  \   {'name': 'bar', 'kind': 'warning'},
+  \   {'name': 'baz'},
+  \ ],
+  \})
+
+Execute(TypeScript completions responses should not include warnings if excluded):
+  let g:ale_completion_tsserver_remove_warnings = 1
+  AssertEqual
+  \ [
+  \   {
+  \     'word': 'foo',
+  \     'source': '/path/to/foo.ts',
+  \   },
+  \   {
+  \     'word': 'baz',
+  \     'source': '',
+  \   }
+  \ ],
+  \ ale#completion#ParseTSServerCompletions({
+  \ 'body': [
+  \   {'name': 'foo', 'source': '/path/to/foo.ts'},
+  \   {'name': 'bar', 'kind': 'warning'},
+  \   {'name': 'baz'},
+  \ ],
+  \})
+
 Execute(TypeScript completion details responses should be parsed correctly):
   AssertEqual
   \ [


### PR DESCRIPTION
Continues from #2846 

Switches to a solution that filters out suggestions that are warnings, and only if a global variable is set