### PR TITLE
Updated Luacheck to be project aware

### DIFF
--- a/ale_linters/lua/luacheck.vim
+++ b/ale_linters/lua/luacheck.vim
@@ -12,7 +12,7 @@ function! ale_linters#lua#luacheck#GetCommand(buffer) abort
     let l:target = !ale#Var(a:buffer, 'lua_luacheck_lint_project') ? '--filename %s -'
     \ : !empty(l:luacheckrc)
     \ ? fnamemodify(l:luacheckrc, ':p:h')
-    \ : '%s' 
+    \ : '%s'
     let l:cd_string = !empty(l:luacheckrc) && ale#Var(a:buffer, 'lua_luacheck_change_directory')
     \   ? ale#path#CdString(fnamemodify(l:luacheckrc, ':p:h'))
     \   : ''

--- a/ale_linters/lua/luacheck.vim
+++ b/ale_linters/lua/luacheck.vim
@@ -38,9 +38,9 @@ function! ale_linters#lua#luacheck#Handle(buffer, lines) abort
 
         call add(l:output, {
         \   'filename': l:match[1],
-        \   'lnum': l:match[2],
-        \   'col': l:match[3],
-        \   'end_col': l:match[4],
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
+        \   'end_col': l:match[4] + 0,
         \   'type': l:match[5],
         \   'code': l:match[5] . l:match[6],
         \   'text': l:match[7],

--- a/doc/ale-lua.txt
+++ b/doc/ale-lua.txt
@@ -30,5 +30,28 @@ g:ale_lua_luacheck_options                         *g:ale_lua_luacheck_options*
   This variable can be set to pass additional options to luacheck.
 
 
+g:ale_lua_luacheck_change_directory         *g:ale_lua_luacheck_change_directory*
+                                            *b:ale_lua_luacheck_change_directory*
+  Type: |Number|
+  Default: `1`
+
+  When set to `1` ALE will attempt to find a `'.luacheckrc'` file and change
+  to the directory before linting. If not it will fall back on 'pwd'
+
+
+g:ale_lua_luacheck_lint_project                 *g:ale_lua_luacheck_lint_project*
+
+  Type: |Number|
+  Default: `1`
+
+  When set to `1` will attempt to find a `'.luacheckrc'` file and lint that
+  directory rather than just the individual buffer. If not it will lint the
+  single current file on disk.
+  When set to `0` ALE will be able to lint the current buffer without the
+  context of the project directory.
+
+  Changing this value requires vim to be restarted or
+  `'ale_linter/lua/luacheck.vim'` to be re-sourced for changes to take place.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/command_callback/test_luacheck_command_callback.vader
+++ b/test/command_callback/test_luacheck_command_callback.vader
@@ -6,7 +6,33 @@ After:
 
 Execute(The lua luacheck command callback should return the correct default string):
   AssertLinter 'luacheck',
-  \ ale#Escape('luacheck') . ' --formatter plain --codes --filename %s -'
+  \ ale#Escape('luacheck') . ' --formatter plain --codes --ranges %s'
+
+Execute(The lua luacheck command callback should be able to lint stdin when set):
+  let g:ale_lua_luacheck_lint_project = 0
+
+  AssertLinter 'luacheck',
+  \ ale#Escape('luacheck')
+  \ . ' --formatter plain --codes --ranges'
+  \ . ' --filename %s -'
+
+Execute(The lua luacheck command callback should be able to lint the project directory):
+  call ale#test#SetFilename(g:dir . '/lua-paths/luacheck-project/.luacheckrc') 
+
+  AssertLinter 'luacheck',
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/lua-paths/luacheck-project'))
+  \ . ale#Escape('luacheck')
+  \ . ' --formatter plain --codes --ranges '
+  \ . ale#path#Simplify(g:dir . '/lua-paths/luacheck-project')
+
+Execute(The lua luacheck command callback should be able to disable the Cd callback):
+  let g:ale_lua_luacheck_change_directory = 0
+  call ale#test#SetFilename(g:dir . '/lua-paths/luacheck-project/.luacheckrc')
+
+  AssertLinter 'luacheck',
+  \ ale#Escape('luacheck')
+  \ . ' --formatter plain --codes --ranges '
+  \ . ale#path#Simplify(g:dir . '/lua-paths/luacheck-project')
 
 Execute(The lua luacheck command callback should let you set options):
   let g:ale_lua_luacheck_options = '--config filename'
@@ -14,10 +40,10 @@ Execute(The lua luacheck command callback should let you set options):
   AssertLinter 'luacheck',
   \ ale#Escape('luacheck')
   \   . ' --config filename'
-  \   . ' --formatter plain --codes --filename %s -'
+  \   . ' --formatter plain --codes --ranges %s'
 
 Execute(The luacheck executable should be configurable):
   let g:ale_lua_luacheck_executable = 'luacheck.sh'
 
   AssertLinter 'luacheck.sh',
-  \ ale#Escape('luacheck.sh') . ' --formatter plain --codes --filename %s -'
+  \ ale#Escape('luacheck.sh') . ' --formatter plain --codes --ranges %s'

--- a/test/handler/test_luacheck_handler.vader
+++ b/test/handler/test_luacheck_handler.vader
@@ -13,31 +13,37 @@ Execute(The luacheck handler should parse lines correctly):
   AssertEqual
   \ [
   \   {
+  \     'filename': '/file/path/here.lua',
   \     'lnum': 1,
   \     'col': 8,
+  \     'end_col': 8,
   \     'text': 'line contains trailing whitespace',
   \     'code': 'W612',
   \     'type': 'W',
   \   },
   \   {
+  \     'filename': '/file/path/here.lua',
   \     'lnum': 3,
   \     'col': 5,
+  \     'end_col': 5,
   \     'text': 'unused loop variable ''k''',
   \     'code': 'W213',
   \     'type': 'W',
   \   },
   \   {
+  \     'filename': '/file/path/here.lua',
   \     'lnum': 3,
   \     'col': 19,
+  \     'end_col': 19,
   \     'text': 'accessing undefined variable ''x''',
   \     'code': 'W113',
   \     'type': 'W',
   \   },
   \ ],
   \ ale_linters#lua#luacheck#Handle(347, [
-  \   '    /file/path/here.lua:1:8: (W612) line contains trailing whitespace',
-  \   '    /file/path/here.lua:3:5: (W213) unused loop variable ''k''',
-  \   '    /file/path/here.lua:3:19: (W113) accessing undefined variable ''x''',
+  \   '/file/path/here.lua:1:8-8: (W612) line contains trailing whitespace',
+  \   '/file/path/here.lua:3:5-5: (W213) unused loop variable ''k''',
+  \   '/file/path/here.lua:3:19-19: (W113) accessing undefined variable ''x''',
   \ ])
 
 Execute(The luacheck handler should respect the warn_about_trailing_whitespace option):
@@ -46,17 +52,19 @@ Execute(The luacheck handler should respect the warn_about_trailing_whitespace o
   AssertEqual
   \ [
   \   {
+  \     'filename': '/file/path/here.lua',
   \     'lnum': 5,
   \     'col': 43,
+  \     'end_col': 43,
   \     'text': 'unused argument ''g''',
   \     'code': 'W212',
   \     'type': 'W',
   \   }
   \ ],
   \ ale_linters#lua#luacheck#Handle(347, [
-  \   '/file/path/here.lua:15:97: (W614) trailing whitespace in a comment',
-  \   '/file/path/here.lua:16:60: (W612) line contains trailing whitespace',
-  \   '/file/path/here.lua:17:1: (W611) line contains only whitespace',
-  \   '/file/path/here.lua:27:57: (W613) trailing whitespace in a string',
-  \   '/file/path/here.lua:5:43: (W212) unused argument ''g''',
+  \   '/file/path/here.lua:15:97-97: (W614) trailing whitespace in a comment',
+  \   '/file/path/here.lua:16:60-60: (W612) line contains trailing whitespace',
+  \   '/file/path/here.lua:17:1-1: (W611) line contains only whitespace',
+  \   '/file/path/here.lua:27:57-57: (W613) trailing whitespace in a string',
+  \   '/file/path/here.lua:5:43-43: (W212) unused argument ''g''',
   \ ])


### PR DESCRIPTION
Updated luacheck to be able to find and lint a directory containing _.luacheckrc_.
Luacheck is also able to parse the range of an error using the `--ranges` option.
When the option `lua_luacheck_lint_project` is disabled ale is able to return to the previous behavior of linting the buffer rather than the file on disk.

Tests and docs have been updated to reflect changes.