### PR TITLE
Provide configuration option to run flake8 from project root.

### DIFF
--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -169,13 +169,14 @@ flake8                                                      *ale-python-flake8*
 
 g:ale_python_flake8_change_directory     *g:ale_python_flake8_change_directory*
                                          *b:ale_python_flake8_change_directory*
-  Type: |Number|
-  Default: `1`
+  Type: |String|
+  Default: `project`
 
-  If set to `1`, ALE will switch to the directory the Python file being
-  checked with `flake8` is in before checking it. This helps `flake8` find
-  configuration files more easily. This option can be turned off if you want
-  to control the directory Python is executed from yourself.
+  If set to `project`, ALE will switch to the project root before checking file.
+  If set to `file`, ALE will switch to directory the Python file being
+  checked with `flake8` is in before checking it.
+  You can turn it off with `off` option if you want to control the directory
+  Python is executed from yourself.
 
 
 g:ale_python_flake8_executable                 *g:ale_python_flake8_executable*

--- a/test/command_callback/test_flake8_command_callback.vader
+++ b/test/command_callback/test_flake8_command_callback.vader
@@ -34,11 +34,30 @@ Execute(The flake8 callbacks should return the correct default values):
   \]
 
 Execute(The option for disabling changing directories should work):
-  let g:ale_python_flake8_change_directory = 0
+  let g:ale_python_flake8_change_directory = 'off'
 
   AssertLinter 'flake8', [
   \ ale#Escape('flake8') . ' --version',
   \ ale#Escape('flake8') . ' --format=default --stdin-display-name %s -',
+  \]
+
+Execute(The option for changing directory to project root should work):
+  silent execute 'file ' . fnameescape(g:dir . '/python_paths/namespace_package_tox/namespace/foo/bar.py')
+
+  AssertLinter 'flake8', [
+  \ ale#Escape('flake8') . ' --version',
+  \ ale#path#CdString(ale#python#FindProjectRootIni(bufnr('')))
+  \   . ale#Escape('flake8') . ' --format=default --stdin-display-name %s -',
+  \]
+
+Execute(The option for changing directory to file dir should work):
+  let g:ale_python_flake8_change_directory = 'file'
+  silent execute 'file ' . fnameescape(g:dir . '/python_paths/namespace_package_tox/namespace/foo/bar.py')
+
+  AssertLinter 'flake8', [
+  \ ale#Escape('flake8') . ' --version',
+  \ ale#path#BufferCdString(bufnr(''))
+  \   . ale#Escape('flake8') . ' --format=default --stdin-display-name %s -',
   \]
 
 Execute(The flake8 command callback should let you set options):
@@ -163,5 +182,5 @@ Execute(Pipenv is detected when python_flake8_auto_pipenv is set):
   call ale#test#SetFilename('../python_fixtures/pipenv/whatever.py')
 
   AssertLinter 'pipenv',
-  \ ale#path#BufferCdString(bufnr(''))
+  \ ale#path#CdString(ale#python#FindProjectRootIni(bufnr('')))
   \   . ale#Escape('pipenv') . ' run flake8 --format=default --stdin-display-name %s -'


### PR DESCRIPTION
Option `per-file-ignores` was introduced in flake8 version 3.7.0.
It allows to ignore specific errors in specific files using glob syntax.
For example `per-file-ignores = src/generated/*.py:F401` will
ignore `F401` error in all python files in `src/generated`.
Thus ale have to run flake8 from project root where .flake8 config
is placed otherwise glob won't match linted file.

Not sure how that should be handled in ale style but I'm ready to follow on this pr.