### PR TITLE
Implement commandline options for cfn_python_lint

### DIFF
--- a/ale_linters/cloudformation/cfn_python_lint.vim
+++ b/ale_linters/cloudformation/cfn_python_lint.vim
@@ -1,6 +1,13 @@
 " Author: Yasuhiro Kiyota <yasuhiroki.duck@gmail.com>
 " Description: Support cfn-python-lint for AWS Cloudformation template file
 
+call ale#Set('cloudformation_cfnlint_options', '')
+
+function! ale_linters#cloudformation#cfn_python_lint#GetCommand(buffer) abort
+    return 'cfn-lint --template %t --format parseable '
+    \ . ale#Var(a:buffer, 'cloudformation_cfnlint_options')
+endfunction
+
 function! ale_linters#cloudformation#cfn_python_lint#Handle(buffer, lines) abort
     " Matches patterns line the following:
     "
@@ -30,6 +37,6 @@ endfunction
 call ale#linter#Define('cloudformation', {
 \   'name': 'cloudformation',
 \   'executable': 'cfn-lint',
-\   'command': 'cfn-lint --template %t --format parseable',
+\   'command': function('ale_linters#cloudformation#cfn_python_lint#GetCommand'),
 \   'callback': 'ale_linters#cloudformation#cfn_python_lint#Handle',
 \})

--- a/doc/ale-cloudformation.txt
+++ b/doc/ale-cloudformation.txt
@@ -4,10 +4,25 @@ ALE CloudFormation Integration                      *ale-cloudformation-options*
 
 ===============================================================================
 cfn-python-lint                             *ale-cloudformation-cfn-python-lint*
+                                                    *ale-cloudformation-cfnlint*
 
 cfn-python-lint is a linter for AWS CloudFormation template file.
 
 https://github.com/awslabs/cfn-python-lint
+
+g:ale_cloudformation_cfnlint_options      *g:ale_cloudformation_cfnlint_options*
+                                          *b:ale_cloudformation_cfnlint_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to add command-line arguments to the cfn-lint
+  invocation.
+
+  For example, to ignore the specific W2001 check you can do the following >
+
+  let g:ale_cloudformation_cfnlint_options = '--ignore-checks W2001'
+<
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
Implemented the cloudformation_cfnlint_options option in order to allow setting commandline options for cfn-lint. Added documentation for the option. Used terminology that excluded "_python_" so that it would match naming convention standard of `<language>_<lintername>_options` without additional underscores.

🍻
