### PR TITLE
Fix clang-tidy for out-of-tree builds

### DIFF
--- a/ale_linters/c/clangtidy.vim
+++ b/ale_linters/c/clangtidy.vim
@@ -47,6 +47,6 @@ call ale#linter#Define('c', {
 \   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'c_clangtidy_executable')},
 \   'command': {b -> ale#c#RunMakeCommand(b, function('ale_linters#c#clangtidy#GetCommand'))},
-\   'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\   'callback': 'ale#handlers#clangtidy#HandleClangTidyFormat',
 \   'lint_file': 1,
 \})

--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -41,6 +41,6 @@ call ale#linter#Define('cpp', {
 \   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'cpp_clangtidy_executable')},
 \   'command': {b -> ale#c#RunMakeCommand(b, function('ale_linters#cpp#clangtidy#GetCommand'))},
-\   'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\   'callback': 'ale#handlers#clangtidy#HandleClangTidyFormat',
 \   'lint_file': 1,
 \})

--- a/autoload/ale/handlers/clangtidy.vim
+++ b/autoload/ale/handlers/clangtidy.vim
@@ -1,0 +1,14 @@
+" Author: Timur Celik https://github.com/clktmr
+" Description: Handle errors for clang-tidy
+
+function! ale#handlers#clangtidy#HandleClangTidyFormat(buffer, lines) abort
+    let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
+    let l:items = ale#handlers#gcc#HandleGCCFormat(a:buffer, a:lines)
+
+    for l:item in l:items
+        let l:item['filename'] = ale#path#GetAbsPath(l:build_dir, l:item['filename'])
+    endfor
+
+    return l:items
+endfunction
+


### PR DESCRIPTION
clang-tidy prints file paths relative to the build directory if
compile-commands.json is used via the '-p' option.  This causes ALE to
fail resolving the filename if the build directory is any other than
pwd.

This patch prepends the build directory to the filenames to get the
absolute path.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
