### PR TITLE
Clean up excess whitespace in deoplete completion menu

### DIFF
--- a/rplugin/python3/deoplete/sources/ale.py
+++ b/rplugin/python3/deoplete/sources/ale.py
@@ -54,6 +54,9 @@ class Source(Base):
             if result is not None:
                 context['is_async'] = False
 
+                for item in result:
+                    item['menu'] = ' '.join(item['menu'].split())
+
                 return result
         else:
             context['is_async'] = True


### PR DESCRIPTION
This patch simply removes the extra whitespace in the completion menu when passing the completion data to deoplete. I didn't add any tests because it doesn't change the behavior significantly. But I'll try to add one if you think it's needed.