### PR TITLE
Fix regural expression for cppcheck. issues 2507

### DIFF
--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -43,9 +43,11 @@ endfunction
 
 function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
     " Look for lines like the following.
-    "
-    " [test.cpp:5]: (error) Array 'a[10]' accessed at index 10, which is out of bounds
+    " 'test.cpp:5:10: error: Array ''a[10]'' accessed at index 10, which is out of bounds'
     let l:pattern = '\v^(.+):(\d+):(\d+): (\w+): (.+)$'
+    " Pattern for old version cppcheck
+    " [test.cpp:5]: (error) Array 'a[10]' accessed at index 10, which is out of bounds
+    let l:pattern_1_69 = '\v^\[(.+):(\d+)\]: \(([a-z]+)\) (.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
@@ -58,6 +60,18 @@ function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
             \})
         endif
     endfor
+
+    if (l:output == [])
+        for l:match in ale#util#GetMatches(a:lines, l:pattern_1_69)
+            if ale#path#IsBufferPath(a:buffer, l:match[1])
+                call add(l:output, {
+                \   'lnum': str2nr(l:match[2]),
+                \   'type': l:match[3] is# 'error' ? 'E' : 'W',
+                \   'text': l:match[4],
+                \})
+            endif
+        endfor
+    endif
 
     return l:output
 endfunction

--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -45,15 +45,16 @@ function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
     " Look for lines like the following.
     "
     " [test.cpp:5]: (error) Array 'a[10]' accessed at index 10, which is out of bounds
-    let l:pattern = '\v^\[(.+):(\d+)\]: \(([a-z]+)\) (.+)$'
+    let l:pattern = '\v^(.+):(\d+):(\d+): (\w+): (.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         if ale#path#IsBufferPath(a:buffer, l:match[1])
             call add(l:output, {
             \   'lnum': str2nr(l:match[2]),
-            \   'type': l:match[3] is# 'error' ? 'E' : 'W',
-            \   'text': l:match[4],
+            \   'col': l:match[3],
+            \   'type': l:match[4] is# 'error' ? 'E' : 'W',
+            \   'text': l:match[5],
             \})
         endif
     endfor

--- a/test/handler/test_cppcheck_handler.vader
+++ b/test/handler/test_cppcheck_handler.vader
@@ -36,3 +36,34 @@ Execute(Problems from other files should be ignored by cppcheck):
   \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
   \ 'bar.cpp:5:3: error: Array ''a[10]'' accessed at index 10, which is out of bounds',
   \ ])
+
+Execute(Old Version Cppcheck: Basic errors should be handled by cppcheck):
+  call ale#test#SetFilename('test.cpp')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 5,
+  \     'type': 'E',
+  \     'text': 'Array ''a[10]'' accessed at index 10, which is out of bounds',
+  \   },
+  \   {
+  \     'lnum': 7,
+  \     'type': 'W',
+  \     'text': 'Some other problem',
+  \   },
+  \ ],
+  \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
+  \ '[test.cpp:5]: (error) Array ''a[10]'' accessed at index 10, which is out of bounds',
+  \ '[test.cpp:7]: (warning) Some other problem',
+  \ ])
+
+Execute(Old Version Cppcheck: Problems from other files should be ignored by cppcheck):
+  call ale#test#SetFilename('test.cpp')
+
+  AssertEqual
+  \ [
+  \ ],
+  \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
+  \ '[bar.cpp:5]: (error) Array ''a[10]'' accessed at index 10, which is out of bounds',
+  \ ])

--- a/test/handler/test_cppcheck_handler.vader
+++ b/test/handler/test_cppcheck_handler.vader
@@ -12,17 +12,19 @@ Execute(Basic errors should be handled by cppcheck):
   \   {
   \     'lnum': 5,
   \     'type': 'E',
+  \     'col': '10',
   \     'text': 'Array ''a[10]'' accessed at index 10, which is out of bounds',
   \   },
   \   {
   \     'lnum': 7,
   \     'type': 'W',
+  \     'col': '3',
   \     'text': 'Some other problem',
   \   },
   \ ],
   \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
-  \ '[test.cpp:5]: (error) Array ''a[10]'' accessed at index 10, which is out of bounds',
-  \ '[test.cpp:7]: (warning) Some other problem',
+  \ 'test.cpp:5:10: error: Array ''a[10]'' accessed at index 10, which is out of bounds',
+  \ 'test.cpp:7:3: warning: Some other problem',
   \ ])
 
 Execute(Problems from other files should be ignored by cppcheck):
@@ -32,5 +34,5 @@ Execute(Problems from other files should be ignored by cppcheck):
   \ [
   \ ],
   \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
-  \ '[bar.cpp:5]: (error) Array ''a[10]'' accessed at index 10, which is out of bounds',
+  \ 'bar.cpp:5:3: error: Array ''a[10]'' accessed at index 10, which is out of bounds',
   \ ])


### PR DESCRIPTION
In new version cppcheck change error format by default.
Change Regexp for parsing this and change tests.

New version cppcheck(1.89)
```
$ cppcheck --template=gcc --enable=style ../learn_c/test.c 
Checking ../learn_c/test.c ...
../learn_c/test.c:6:3: warning: %d in format string (no. 1) requires 'int' but the argument type is 'const char *'. [invalidPrintfArgType_sint]
  printf("%d", "More then 2 input value");
  ^
```
Old version(1.69):
```
$ ./cppcheck --template=gcc --enable=style ../learn_c/test.c 
Checking ../learn_c/test.c...
../learn_c/test.c:6: warning: %d in format string (no. 1) requires 'int' but the argument type is 'const char *'.
```
Now it works for both.