### PR TITLE
Properly extract all error messages from `nix-instantiate --parse`

### DIFF
--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -2,14 +2,14 @@
 " Description: nix-instantiate linter for nix files
 
 function! ale_linters#nix#nix#Handle(buffer, lines) abort
-    let l:pattern = '^\(.\+\): \(.\+\), at .*:\(\d\+\):\(\d\+\)$'
+    let l:pattern = '^\(.\+\): \(.\+\) at .*:\(\d\+\):\(\d\+\)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'lnum': l:match[3] + 0,
         \   'col': l:match[4] + 0,
-        \   'text': l:match[1] . ': ' . l:match[2],
+        \   'text': l:match[1] . ': ' . substitute(l:match[2], ',$', '', ''),
         \   'type': l:match[1] =~# '^error' ? 'E' : 'W',
         \})
     endfor


### PR DESCRIPTION
This command is actually able to detect invalid variable references,
however those aren't displayed in my Vim. The problem here is that the
regex expects a comma between the error message and the error's
location. However this isn't the case for invalid references:

    error: undefined variable 'bar' at /home/ma27/Projects/nixos-config/test.nix:1:11

Right now the `,` at the end of the string is directly stripped as
optional character groups `(,?)` would've been ignored by the regex
engine as it was interpreted as part of the second match group `(.+)`.
