### PR TITLE
Fix golangci-lint to run on package and not files.

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -3,26 +3,15 @@
 
 call ale#Set('go_golangci_lint_options', '--enable-all')
 call ale#Set('go_golangci_lint_executable', 'golangci-lint')
-call ale#Set('go_golangci_lint_package', 0)
 
 function! ale_linters#go#golangci_lint#GetCommand(buffer) abort
     let l:filename = expand('#' . a:buffer . ':t')
     let l:options = ale#Var(a:buffer, 'go_golangci_lint_options')
-    let l:lint_package = ale#Var(a:buffer, 'go_golangci_lint_package')
-
-
-    if l:lint_package
-        return ale#path#BufferCdString(a:buffer)
-        \   . ale#go#EnvString(a:buffer)
-        \   . '%e run '
-        \   .  l:options
-    endif
 
     return ale#path#BufferCdString(a:buffer)
     \   . ale#go#EnvString(a:buffer)
     \   . '%e run '
-    \   . ale#Escape(l:filename)
-    \   . ' ' . l:options
+    \   .  l:options
 endfunction
 
 function! ale_linters#go#golangci_lint#GetMatches(lines) abort

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -104,15 +104,6 @@ g:ale_go_golangci_lint_options                 *g:ale_go_golangci_lint_options*
   golangci-lint invocation.
 
 
-g:ale_go_golangci_lint_package                 *g:ale_go_golangci_lint_package*
-                                               *b:ale_go_golangci_lint_package*
-  Type: |Number|
-  Default: `0`
-
-  When set to `1`, the whole Go package will be checked instead of only the
-  current file.
-
-
 ===============================================================================
 golangserver                                              *ale-go-golangserver*
 


### PR DESCRIPTION
Relates to #2339 - but instead of trying to get golangci-lint to support individual files we instead fix ale to do the correct thing all the time.

I removed the g:ale_go_golangci_lint_package variable. Tested manually this works. I think I updated the tests, but not sure if they work. Currently on low bandwidth to pull a docker image in to test, but will soon, and update this PR.

# commit message

Fix golangci-lint to run on package and not files.

I don't think golangci-lint ever operated on individual files.

Like most go tooling it operates on packages. A package is just a
collection of files but also has an "import path" which is used
to identify on the filesystem where things are (using GOPATH or
the go modules system).

Before this change ALE would run the following on a buffer viewing
foo.go.

    cd /path/to/foo/ && golangci-lint run foo.go --options

This change omits the file in the buffer and just runs it on the
directory; golangci-lint will automatically figure out the package
import.

    cd /path/to/foo && golangci-lint run --options

I also removed traces of g:ale_go_golangci_lint_package since
this shouldn't be a choice.

If and when golangci-lint decides to implement some way to
operate on indviidual files, then we should consider introducing
it again and making package scope the default. Wouldn't
worry about the performance implications of this, golangci-lint
is pretty damn fast at package scope.
