### PR TITLE
Default errorview in pwsh7 now concise

### DIFF
--- a/ale_linters/powershell/powershell.vim
+++ b/ale_linters/powershell/powershell.vim
@@ -12,6 +12,7 @@ endfunction
 " https://rkeithhill.wordpress.com/2007/10/30/powershell-quicktip-preparsing-scripts-to-check-for-syntax-errors/
 function! ale_linters#powershell#powershell#GetCommand(buffer) abort
     let l:script = ['Param($Script);
+    \   $ErrorView = "Normal";
     \   trap {$_;continue} & {
     \   $Contents = Get-Content -Path $Script;
     \   $Contents = [string]::Join([Environment]::NewLine, $Contents);


### PR DESCRIPTION
In the upcoming powershell7, the default error view is now 'concise' which isn't as easy to parse. I'm working on another change to do most of the parsing in powershell, but this is an effective fix that works across all powershell versions until that's ready.