### PR TITLE
fix line regex pattern in markdownlint

### DIFF
--- a/autoload/ale/handlers/markdownlint.vim
+++ b/autoload/ale/handlers/markdownlint.vim
@@ -2,13 +2,13 @@
 " Description: Adds support for markdownlint
 
 function! ale#handlers#markdownlint#Handle(buffer, lines) abort
-    let l:pattern=': \(\d*\): \(MD\d\{3}\)\(\/\)\([A-Za-z0-9-]\+\)\(.*\)$'
+    let l:pattern=': \=\(\d\+\)[: ]\+\(MD\d\{3}\)\([A-Za-z0-9-\/]\+\)\(.*\)$'
     let l:output=[]
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \ 'lnum': l:match[1] + 0,
-        \ 'text': '(' . l:match[2] . l:match[3] . l:match[4] . ')' . l:match[5],
+        \ 'text': '(' . l:match[2] . l:match[3] . ')' . l:match[4],
         \ 'type': 'W',
         \})
     endfor

--- a/test/handler/test_markdownlint_handler.vader
+++ b/test/handler/test_markdownlint_handler.vader
@@ -22,3 +22,22 @@ Execute(The Markdownlint handler should parse output correctly):
   \ 'README.md: 1: MD002/first-header-h1 First header should be a top level header [Expected: h1; Actual: h2]',
   \ 'README.md: 298: MD033/no-inline-html Inline HTML [Element: p]'
   \ ])
+
+Execute(The Markdownlint handler should parse new output correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'text': '(MD041/first-line-heading/first-line-h1) First line in file should be a top level heading [Context: "## foo"]',
+  \     'type': 'W'
+  \   },
+  \   {
+  \     'lnum': 298,
+  \     'text': '(MD033/no-inline-html) Inline HTML [Element: p]',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale#handlers#markdownlint#Handle(0, [
+  \ 'README.md:1 MD041/first-line-heading/first-line-h1 First line in file should be a top level heading [Context: "## foo"]',
+  \ 'README.md:298 MD033/no-inline-html Inline HTML [Element: p]',
+  \ ])


### PR DESCRIPTION
I have:

```sh
npm install -g markdownlint-cli
markdownlint --version
0.19.0
```

The current parser for markdownlint doesn't work, this fixes it.

pinging @tylucaskelley the original contributor, thanks.