### PR TITLE
ShellDetect falls back to filetype if no hashbang (fixes #2886)

### DIFF
--- a/ale_linters/sh/shell.vim
+++ b/ale_linters/sh/shell.vim
@@ -1,5 +1,5 @@
 " Author: w0rp <devw0rp@gmail.com>
-" Description: Lints sh files using bash -n
+" Description: Lints shell files by invoking the shell with -n
 
 " Backwards compatibility
 if exists('g:ale_linters_sh_shell_default_shell')

--- a/autoload/ale/handlers/sh.vim
+++ b/autoload/ale/handlers/sh.vim
@@ -4,17 +4,24 @@
 function! ale#handlers#sh#GetShellType(buffer) abort
     let l:bang_line = get(getbufline(a:buffer, 1), 0, '')
 
+    let l:command = ''
+
     " Take the shell executable from the hashbang, if we can.
     if l:bang_line[:1] is# '#!'
         " Remove options like -e, etc.
         let l:command = substitute(l:bang_line, ' --\?[a-zA-Z0-9]\+', '', 'g')
-
-        for l:possible_shell in ['bash', 'dash', 'ash', 'tcsh', 'csh', 'zsh', 'ksh', 'sh']
-            if l:command =~# l:possible_shell . '\s*$'
-                return l:possible_shell
-            endif
-        endfor
     endif
+
+    " If we couldn't find a hashbang, try the filetype
+    if l:command is# ''
+        let l:command = &filetype
+    endif
+
+    for l:possible_shell in ['bash', 'dash', 'ash', 'tcsh', 'csh', 'zsh', 'ksh', 'sh']
+        if l:command =~# l:possible_shell . '\s*$'
+            return l:possible_shell
+        endif
+    endfor
 
     return ''
 endfunction

--- a/test/test_shell_detection.vader
+++ b/test/test_shell_detection.vader
@@ -98,6 +98,16 @@ Execute(The ksh dialect should be used for shellcheck if b:is_kornshell is 1):
 
   AssertEqual 'ksh', ale_linters#sh#shellcheck#GetDialectArgument(bufnr(''))
 
+Execute(The filetype should be used as the default shell type when there is no hashbang line):
+  set filetype=zsh
+  AssertEqual 'zsh', ale#handlers#sh#GetShellType(bufnr(''))
+
+  set filetype=tcsh
+  AssertEqual 'tcsh', ale#handlers#sh#GetShellType(bufnr(''))
+
+  set filetype=python
+  AssertEqual '', ale#handlers#sh#GetShellType(bufnr(''))
+
 Given(A file with /bin/ash):
   #!/bin/ash
 


### PR DESCRIPTION
Some files lack a hashbang line but still have an unambiguous filetype. For example, the file `.zshrc` has the filetype `zsh`.

Augment `ale#handlers#sh#GetShellType` to fall back to the filetype if no hashbang line can be found.

Also update the description of the `shell` linter, which does more than just bash now.

Fixes #2886.