### PR TITLE
Fix for incorrect eslint output parsing for graphql files

### DIFF
--- a/ale_linters/graphql/eslint.vim
+++ b/ale_linters/graphql/eslint.vim
@@ -5,5 +5,5 @@ call ale#linter#Define('graphql', {
 \   'name': 'eslint',
 \   'executable': function('ale#handlers#eslint#GetExecutable'),
 \   'command': function('ale#handlers#eslint#GetCommand'),
-\   'callback': 'ale#handlers#eslint#Handle',
+\   'callback': 'ale#handlers#eslint#HandleJSON',
 \})


### PR DESCRIPTION
The eslint output is configured to be JSON, but the handler was parsing it as 'lines'. Both JS & TS eslint linter configurations are using `HandleJSON` and I can't see any reason why graphql should be configured differently. With this changes errors appear in signs and the quickfix list as expected.