### PR TITLE
Add option to prevent node from outputting deprecation warnings

### DIFF
--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -85,7 +85,7 @@ endfunction
 
 function! s:parseJSON(buffer, lines) abort
     try
-        let l:parsed = json_decode(a:lines[-1])
+        let l:parsed = json_decode(a:lines[0])
     catch
         return []
     endtry

--- a/autoload/ale/node.vim
+++ b/autoload/ale/node.vim
@@ -30,13 +30,18 @@ endfunction
 " function, the executable string will be escaped when returned by this
 " function.
 "
+" Node parameters can be passed as optional function params.
+"
 " The executable is only prefixed for Windows machines
-function! ale#node#Executable(buffer, executable) abort
+function! ale#node#Executable(buffer, executable, ...) abort
+    "Dont put deprecation warnings into the output
+    let l:node_options = join(get(a:, '000', []) + ['--no-deprecation'], ' ')
+
     if has('win32') && a:executable =~? '\.js$'
         let l:node = ale#Var(a:buffer, 'windows_node_executable_path')
-
-        return ale#Escape(l:node) . ' ' . ale#Escape(a:executable)
+    else
+        let l:node = 'node'
     endif
 
-    return ale#Escape(a:executable)
+    return ale#Escape(l:node) . ' ' . ale#Escape(l:node_options) . ' ' . ale#Escape(a:executable)
 endfunction

--- a/test/test_eslint_executable_detection.vader
+++ b/test/test_eslint_executable_detection.vader
@@ -51,7 +51,7 @@ Execute(eslint_d should be detected correctly):
   \ ale#path#Simplify(g:dir . '/eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'),
   \ ale#handlers#eslint#GetExecutable(bufnr(''))
 
-Execute(eslint.js executables should be run with node on Windows):
+Execute(eslint.js executables should be run with node to support Windows and to disable deprecation warnings):
   call ale#test#SetFilename('eslint-test-files/react-app/subdir/testfile.js')
 
   " We have to execute the file with node.
@@ -63,7 +63,8 @@ Execute(eslint.js executables should be run with node on Windows):
     \ ale#handlers#eslint#GetCommand(bufnr(''))
   else
     AssertEqual
-    \ ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
+    \ ale#Escape('node --no-deprecation') . ' '
+    \   . ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
     \   . ' -f json --stdin --stdin-filename %s',
     \ ale#handlers#eslint#GetCommand(bufnr(''))
   endif


### PR DESCRIPTION
Since the output of eslint should not contain anything more than linting errors, we should be able to pass node custom options to f.e. disable deprecation warnings.

Solution for https://github.com/dense-analysis/ale/issues/2891