### PR TITLE
Fix 2913 - checkstyle config file ignored.

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -52,7 +52,7 @@ endfunction
 function! ale_linters#java#checkstyle#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'java_checkstyle_options')
     let l:config_option = ale#Var(a:buffer, 'java_checkstyle_config')
-    let l:config = l:options !~# '\v(^| )-c' && !empty(l:config_option)
+    let l:config = l:options !~# '\v(^| )-c ' && !empty(l:config_option)
     \   ? s:GetConfig(a:buffer, l:config_option)
     \   : ''
 

--- a/test/command_callback/test_checkstyle_command_callback.vader
+++ b/test/command_callback/test_checkstyle_command_callback.vader
@@ -20,11 +20,11 @@ Execute(The checkstyle executable should be configurable):
   \ . ' %s'
 
 Execute(Custom options should be supported):
-  let b:ale_java_checkstyle_options = '--foobar'
+  let b:ale_java_checkstyle_options = '--foobar -cp -classpath /path/to/checkstyle-8.7-all.jar'
 
   AssertLinter 'checkstyle',
   \ ale#Escape('checkstyle')
-  \ . ' --foobar'
+  \ . ' --foobar -cp -classpath /path/to/checkstyle-8.7-all.jar'
   \ . ' -c ' . ale#Escape('/google_checks.xml')
   \ . ' %s'
 


### PR DESCRIPTION
If checkstyle is configured with custom options that contain "-c" then
the checkstyle config file option is ignored. This PR modifies the
regular expression when creating the checkstyle command to avoid this.

Fixes #2913 