### PR TITLE
Add F# language server

### DIFF
--- a/ale_linters/fsharp/fsls.vim
+++ b/ale_linters/fsharp/fsls.vim
@@ -15,6 +15,6 @@ call ale#linter#Define('fsharp', {
 \    'name': 'fsharp-language-server',
 \    'lsp': 'stdio',
 \    'executable': {b -> ale#Var(b, 'fsharp_language_server_executable') },
-\    'command': { b -> '%e ' . ale#Var(b, 'fsharp_fsls_assembly') },
+\    'command': { b -> '%e ' . ale#Var(b, 'fsharp_language_server_assembly') },
 \    'project_root': function('ale_linters#fsharp#fsls#GetProjectRoot'),
 \})

--- a/ale_linters/fsharp/fsls.vim
+++ b/ale_linters/fsharp/fsls.vim
@@ -1,0 +1,20 @@
+" Author: Fernando Garcia Borges <fgborges@pm.me>
+" Description: F# Language server intergration for ALE
+
+call ale#Set('fsharp_language_server_assembly', '')
+call ale#Set('fsharp_language_server_executable', 'dotnet')
+
+function! ale_linters#fsharp#fsls#GetProjectRoot(buffer) abort
+    " TODO: Find nearest project file <project name>.fsproj
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
+endfunction
+
+call ale#linter#Define('fsharp', {
+\    'name': 'fsharp-language-server',
+\    'lsp': 'stdio',
+\    'executable': {b -> ale#Var(b, 'fsharp_language_server_executable') },
+\    'command': { b -> '%e ' . ale#Var(b, 'fsharp_fsls_assembly') },
+\    'project_root': function('ale_linters#fsharp#fsls#GetProjectRoot'),
+\})

--- a/doc/ale-fsharp.txt
+++ b/doc/ale-fsharp.txt
@@ -1,0 +1,26 @@
+===============================================================================
+ALE F# Integration                                         *ale-fsharp-options*
+
+===============================================================================
+fsharp-language-server                             *ale-fsharp-language-server*
+
+g:ale_fsharp_language_server_executable *g:ale_fsharp_language_server_executable*
+                                        *b:ale_fsharp_language_server_executable*
+
+  Type: |String|
+  Default: `'dotnet'`
+
+  This variable can be set to change the executable path used for dotnet
+
+g:ale_fsharp_language_server_assembly   *g:ale_fsharp_language_server_assembly*
+                                        *b:ale_fsharp_language_server_assembly*
+
+  Type: |String|
+  Default: `''`
+
+  The variable can be set to configure the assembly that will be used for
+  running the F# language server. Since default value is empty, you have to set
+  a path to `FSharpLanguageServer.dll`.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -134,6 +134,8 @@ Notes:
 * Erlang
   * `erlc`
   * `SyntaxErl`
+* F#
+  * `fsharp-language-server`
 * Fish
   * `fish` (-n flag)
 * Fortran

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2322,6 +2322,8 @@ documented in additional help files.
     gcc...................................|ale-fortran-gcc|
     language_server.......................|ale-fortran-language-server|
   fountain................................|ale-fountain-options|
+  f#......................................|ale-fsharp-options|
+    fsharp-language-server................|ale-fsharp-language-server|
   fusionscript............................|ale-fuse-options|
     fusion-lint...........................|ale-fuse-fusionlint|
   git commit..............................|ale-gitcommit-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -143,6 +143,8 @@ formatting.
 * Erlang
   * [erlc](http://erlang.org/doc/man/erlc.html)
   * [SyntaxErl](https://github.com/ten0s/syntaxerl)
+* F#
+  * [fsharp-language-server](https://github.com/fsprojects/fsharp/fsharp-language-server)
 * Fish
   * fish [-n flag](https://linux.die.net/man/1/fish)
 * Fortran

--- a/test/command_callback/test_fsharp_fsls_callbacks.vader
+++ b/test/command_callback/test_fsharp_fsls_callbacks.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpLinterTest('fsharp', 'fsls')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  AssertLinter 'dotnet', ale#Escape('dotnet')
+
+Execute(The toolchain should be configurable):
+  let g:ale_fsharp_fsls_assembly = '/opt/fsharp-language-server/src/FSharpLanguageServer/bin/Release/netcoreapp2.0/FSharpLanguageServer.dll'
+
+  AssertLinter 'dotnet', ale#Escape('dotnet') . ' ' . ale#Escape('/opt/fsharp-language-server/src/FSharpLanguageServer/bin/Release/netcoreapp2.0/FSharpLanguageServer.dll')
+
+Execute(The project path should be correct for .git directories):
+  call ale#test#SetFilename('fsharp-fsls-project/with-git/test.fsx')
+  silent! call mkdir('fsharp-fsls-project/with-git/.git')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/fsharp-fsls-project/with-git')

--- a/test/command_callback/test_fsharp_fsls_callbacks.vader
+++ b/test/command_callback/test_fsharp_fsls_callbacks.vader
@@ -1,5 +1,5 @@
 Before:
-  call ale#assert#SetUpLinterTest('fsharp', 'fsls')
+  call ale#assert#SetUpLinterTest('fsharp', 'fsharp-language-server')
 
 After:
   call ale#assert#TearDownLinterTest()


### PR DESCRIPTION
I added a language server for F#.
There are two problems.
- ALE will set a project root with `.git` directory, but I prefer to set a project root with `<project name>.fsproj`. I did not get how to get a project root with that file, because `ale#path#FindNearestFile` does not use wildcard matching. 
Please tell me if you know that.
- Since  F# language server is often installed in various directories, I keep the F# language server path empty. Thus, users should set the path `g:ale_fsharp_language_server_assembly` first.

P.S.
This request is work in progress.