### PR TITLE
Add extra options config to eclipselsp.

### DIFF
--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -7,6 +7,7 @@ call ale#Set('java_eclipselsp_path', ale#path#Simplify($HOME . '/eclipse.jdt.ls'
 call ale#Set('java_eclipselsp_config_path', '')
 call ale#Set('java_eclipselsp_workspace_path', '')
 call ale#Set('java_eclipselsp_executable', 'java')
+call ale#Set('java_eclipselsp_extra_options', [])
 
 function! ale_linters#java#eclipselsp#Executable(buffer) abort
     return ale#Var(a:buffer, 'java_eclipselsp_executable')
@@ -100,6 +101,20 @@ function! ale_linters#java#eclipselsp#WorkspacePath(buffer) abort
     return ale#path#Dirname(ale#java#FindProjectRoot(a:buffer))
 endfunction
 
+function! ale_linters#java#eclipselsp#AddExtraOptions(buffer, cmd) abort
+     let l:opts = ale#Var(a:buffer, 'java_eclipselsp_extra_options')
+
+     if type(l:opts) == v:t_string
+         return extend(a:cmd, split(l:opts, ','))
+     endif
+
+     if type(l:opts) == v:t_list
+         return extend(a:cmd, l:opts)
+     endif
+
+     return a:cmd
+endfunction
+
 function! ale_linters#java#eclipselsp#Command(buffer, version) abort
     let l:path = ale#Var(a:buffer, 'java_eclipselsp_path')
 
@@ -119,6 +134,8 @@ function! ale_linters#java#eclipselsp#Command(buffer, version) abort
     \ '-data',
     \ ale#Escape(ale_linters#java#eclipselsp#WorkspacePath(a:buffer))
     \ ]
+
+    let l:cmd = ale_linters#java#eclipselsp#AddExtraOptions(a:buffer, l:cmd)
 
     if ale#semver#GTE(a:version, [1, 9])
         call add(l:cmd, '--add-modules=ALL-SYSTEM')

--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -102,17 +102,17 @@ function! ale_linters#java#eclipselsp#WorkspacePath(buffer) abort
 endfunction
 
 function! ale_linters#java#eclipselsp#AddExtraOptions(buffer, cmd) abort
-     let l:opts = ale#Var(a:buffer, 'java_eclipselsp_extra_options')
+    let l:opts = ale#Var(a:buffer, 'java_eclipselsp_extra_options')
 
-     if type(l:opts) == v:t_string
-         return extend(a:cmd, split(l:opts, ','))
-     endif
+    if type(l:opts) == v:t_string
+        return extend(a:cmd, split(l:opts, ','))
+    endif
 
-     if type(l:opts) == v:t_list
-         return extend(a:cmd, l:opts)
-     endif
+    if type(l:opts) == v:t_list
+        return extend(a:cmd, l:opts)
+    endif
 
-     return a:cmd
+    return a:cmd
 endfunction
 
 function! ale_linters#java#eclipselsp#Command(buffer, version) abort

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -212,6 +212,21 @@ g:ale_java_eclipselsp_config_path              *g:ale_java_eclipse_config_path*
   installed via system package.
 
 
+g:ale_java_eclipselsp_extra_options       *g:ale_java_eclipselsp_extra_options*
+                                          *b:ale_java_eclipselsp_extra_options*
+
+  Type: |String|
+  Default: `[]`
+
+  An array of java command line options to be added to the eclipselsp
+  command. For example:
+>
+  let g:ale_java_eclipselsp_extra_options = [
+    \ '-javaagent:lombok.jar'
+    \ 'Xbootclasspath/p:lombok.jar'
+    \ ]
+
+
 g:ale_java_eclipselsp_workspace_path     *g:ale_java_eclipselsp_workspace_path*
                                          *b:ale_java_eclipselsp_workspace_path*
 

--- a/test/command_callback/test_eclipselsp_command_callback.vader
+++ b/test/command_callback/test_eclipselsp_command_callback.vader
@@ -104,3 +104,27 @@ Execute(The eclipselsp callback should allow custom configuration path):
     \ ale#Escape(ale#path#Simplify(''))
     \]
   AssertLinter 'java', join(cmd, ' ')
+
+Execute(The eclipselsp callback should allow extra java options string):
+  let b:ale_java_eclipselsp_extra_options = [
+    \ '-Xbootclasspath/p:$HOME/jars/lombok.jar',
+    \ '-javaagent:$LOMBOK_JAR'
+    \ ]
+
+  let cmd = [ ale#Escape('java'),
+    \ '-Declipse.application=org.eclipse.jdt.ls.core.id1',
+    \ '-Dosgi.bundles.defaultStartLevel=4',
+    \ '-Declipse.product=org.eclipse.jdt.ls.core.product',
+    \ '-Dlog.level=ALL',
+    \ '-noverify',
+    \ '-Xmx1G',
+    \ '-jar',
+    \ ale#Escape(''),
+    \ '-configuration',
+    \ ale#Escape(b:cfg),
+    \ '-data',
+    \ ale#Escape(ale#path#Simplify('')),
+    \ '-Xbootclasspath/p:$HOME/jars/lombok.jar',
+    \ '-javaagent:$LOMBOK_JAR'
+    \]
+  AssertLinter 'java', join(cmd, ' ')


### PR DESCRIPTION
A new `g:ale_java_eclipselsp_extra_options` variable that allows to add
additional command line options to the command that invoke eclipese LSP.
