### PR TITLE
Allow headers to participate in the project.

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -9,12 +9,6 @@ let s:sep = has('win32') ? '\' : '/'
 let g:__ale_c_project_filenames = ['.git/HEAD', 'configure', 'Makefile', 'CMakeLists.txt']
 
 function! ale#c#GetBuildDirectory(buffer) abort
-    " Don't include build directory for header files, as compile_commands.json
-    " files don't consider headers to be translation units, and provide no
-    " commands for compiling header files.
-    if expand('#' . a:buffer) =~# '\v\.(h|hpp)$'
-        return ''
-    endif
 
     let l:build_dir = ale#Var(a:buffer, 'c_build_dir')
 


### PR DESCRIPTION
I don't think there's a good reason to disable unconditionally the use of the compile database when editing headers. It's an unexpected behavior and at least on my use case here it seems to break the linting on headers.

There are no tests, I could not find the tests that are testing that, and I can understand if that is denied on this grounds. Unfortunately I have little time to dig into how to run and add tests, sorry.