### PR TITLE
Fix prettier_standard to respect the configuration file

### DIFF
--- a/autoload/ale/fixers/prettier_standard.vim
+++ b/autoload/ale/fixers/prettier_standard.vim
@@ -17,8 +17,8 @@ function! ale#fixers#prettier_standard#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(ale#fixers#prettier_standard#GetExecutable(a:buffer))
-    \       . ' %t'
+    \       . ' --stdin'
+    \       . ' --stdin-filepath=%s'
     \       . ' ' . l:options,
-    \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_prettier_standard_callback.vader
+++ b/test/fixers/test_prettier_standard_callback.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpFixerTest('javascript', 'prettier_standard')
+
+  silent cd ..
+  silent cd command_callback
+  let g:dir = getcwd()
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The prettier callback should return the correct default values):
+  call ale#test#SetFilename('../prettier-test-files/testfile.js')
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape(g:ale_javascript_prettier_standard_executable)
+  \     . ' --stdin'
+  \     . ' --stdin-filepath=%s ',
+  \ }


### PR DESCRIPTION
Before this change, prettier_standard would run and ignore any
.prettierrc, now it will respect the configuration of the file being
linted.

This change relies on prettier-standard 16.1.0 for the --stdin-filepath
flag, but is backward compatible: older versions of prettier-standard
will ignore the unknown flag and continue to run with no configuration
file.


<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.