### PR TITLE
verilog: Add filename to vlog linter output

### DIFF
--- a/ale_linters/verilog/vlog.vim
+++ b/ale_linters/verilog/vlog.vim
@@ -13,14 +13,15 @@ function! ale_linters#verilog#vlog#Handle(buffer, lines) abort
     "Matches patterns like the following:
     "** Warning: add.v(7): (vlog-2623) Undefined variable: C.
     "** Error: file.v(1): (vlog-13294) Identifier must be declared with a port mode: C.
-    let l:pattern = '^**\s\(\w*\):[a-zA-Z0-9\-\.\_\/ ]\+(\(\d\+\)):\s\+\(.*\)'
+    let l:pattern = '^**\s\(\w*\): \([a-zA-Z0-9\-\.\_\/ ]\+\)(\(\d\+\)):\s\+\(.*\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
-        \   'lnum': l:match[2] + 0,
+        \   'lnum': l:match[3] + 0,
         \   'type': l:match[1] is? 'Error' ? 'E' : 'W',
-        \   'text': l:match[3],
+        \   'text': l:match[4],
+        \   'filename': l:match[2],
         \})
     endfor
 
@@ -28,13 +29,14 @@ function! ale_linters#verilog#vlog#Handle(buffer, lines) abort
     "** Warning: (vlog-2623) add.v(7): Undefined variable: C.
     "** Error: (vlog-13294) file.v(1): Identifier must be declared with a port mode: C.
     " let l:pattern = '^**\s\(\w*\):[a-zA-Z0-9\-\.\_\/ ]\+(\(\d\+\)):\s\+\(.*\)'
-    let l:pattern = '^**\s\(\w*\):\s\([^)]*)\)[a-zA-Z0-9\-\.\_\/ ]\+(\(\d\+\)):\s\+\(.*\)'
+    let l:pattern = '^**\s\(\w*\):\s\([^)]*)\) \([a-zA-Z0-9\-\.\_\/ ]\+\)(\(\d\+\)):\s\+\(.*\)'
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
-        \   'lnum': l:match[3] + 0,
+        \   'lnum': l:match[4] + 0,
         \   'type': l:match[1] is? 'Error' ? 'E' : 'W',
-        \   'text': l:match[2] . ' ' . l:match[4],
+        \   'text': l:match[2] . ' ' . l:match[5],
+        \   'filename': l:match[3],
         \})
     endfor
 

--- a/test/handler/test_vlog_handler.vader
+++ b/test/handler/test_vlog_handler.vader
@@ -10,12 +10,14 @@ Execute(The vlog handler should parse old-style lines correctly):
   \   {
   \     'lnum': 7,
   \     'type': 'W',
-  \     'text': '(vlog-2623) Undefined variable: C.'
+  \     'text': '(vlog-2623) Undefined variable: C.',
+  \     'filename': 'add.v'
   \   },
   \   {
   \     'lnum': 1,
   \     'type': 'E',
-  \     'text': '(vlog-13294) Identifier must be declared with a port mode: C.'
+  \     'text': '(vlog-13294) Identifier must be declared with a port mode: C.',
+  \     'filename': 'file.v'
   \   },
   \ ],
   \ ale_linters#verilog#vlog#Handle(bufnr(''), [
@@ -29,12 +31,14 @@ Execute(The vlog handler should parse new-style lines correctly):
   \   {
   \     'lnum': 7,
   \     'type': 'W',
-  \     'text': '(vlog-2623) Undefined variable: C.'
+  \     'text': '(vlog-2623) Undefined variable: C.',
+  \     'filename': 'add.v'
   \   },
   \   {
   \     'lnum': 1,
   \     'type': 'E',
-  \     'text': '(vlog-13294) Identifier must be declared with a port mode: C.'
+  \     'text': '(vlog-13294) Identifier must be declared with a port mode: C.',
+  \     'filename': 'file.v'
   \   },
   \ ],
   \ ale_linters#verilog#vlog#Handle(bufnr(''), [


### PR DESCRIPTION
I have customized the options for `vlog` to lint all my verilog files because files depend on each other. But now the warnings in other files are always displayed in the current buffer.

For that reason I have extended the handler to also match the filename and include it in the output.

`./run-tests` works fine and it also works in my project now.