### PR TITLE
Add popup support to ALEHover and ALEDetails

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -137,8 +137,8 @@ function! s:ShowCursorDetailForItem(loc, options) abort
     let s:last_detailed_line = line('.')
     let l:message = get(a:loc, 'detail', a:loc.text)
 
-    if g:ale_set_balloons == 1 && has('balloon_eval')
-        call ale#util#ShowMessage(l:message)
+    if g:ale_set_popups == 1
+        call ale#popup#Show(l:message)
     else
         let l:lines = split(l:message, "\n")
         call ale#preview#Show(l:lines, {'stay_here': l:stay_here})

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -136,8 +136,12 @@ function! s:ShowCursorDetailForItem(loc, options) abort
 
     let s:last_detailed_line = line('.')
     let l:message = get(a:loc, 'detail', a:loc.text)
-    let l:lines = split(l:message, "\n")
-    call ale#preview#Show(l:lines, {'stay_here': l:stay_here})
+    if g:ale_set_balloons == 1
+        call ale#util#ShowMessage(l:message)
+    else
+        let l:lines = split(l:message, "\n")
+        call ale#preview#Show(l:lines, {'stay_here': l:stay_here})
+    endif
 
     " Clear the echo message if we manually displayed details.
     if !l:stay_here

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -136,7 +136,8 @@ function! s:ShowCursorDetailForItem(loc, options) abort
 
     let s:last_detailed_line = line('.')
     let l:message = get(a:loc, 'detail', a:loc.text)
-    if g:ale_set_balloons == 1
+
+    if g:ale_set_balloons == 1 && has('balloon_eval')
         call ale#util#ShowMessage(l:message)
     else
         let l:lines = split(l:message, "\n")

--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -103,6 +103,8 @@ function! ale#hover#HandleLSPResponse(conn_id, response) abort
                 \&& exists('*balloon_show')
                 \&& ale#Var(l:options.buffer, 'set_balloons')
                     call balloon_show(l:str)
+                elseif g:ale_set_popups && g:ale_hover_to_popup
+                    call ale#popup#Show(l:str)
                 elseif g:ale_hover_to_preview
                     call ale#preview#Show(split(l:str, "\n"), {
                     \   'filetype': 'ale-preview.message',

--- a/autoload/ale/popup.vim
+++ b/autoload/ale/popup.vim
@@ -11,6 +11,7 @@ function! ale#popup#Show(string, ...) abort
     \    'padding': [0, 1, 0, 1],
     \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
     \    'border': [1, 1, 1, 1],
-    \    'moved':'any',
+    \    'pos': 'botright',
+    \    'moved': 'any',
     \})
 endfunction

--- a/autoload/ale/popup.vim
+++ b/autoload/ale/popup.vim
@@ -1,0 +1,18 @@
+" Author: ian-howell <ian.howell0@gmail.com>
+" Description: Popup windows for showing information.
+
+" Open a popup window and show the string in it.
+function! ale#popup#Show(string, ...) abort
+    echo "Called popup show"
+    if !g:ale_set_popups || !(exists('*popup_atcursor'))
+        return
+    endif
+
+    call popup_atcursor(split(a:string, "\n"), {
+          \    'padding': [0, 1, 0, 1],
+          \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
+          \    'border': [1, 1, 1, 1],
+          \    'moved':'any',
+          \})
+
+endfunction

--- a/autoload/ale/popup.vim
+++ b/autoload/ale/popup.vim
@@ -3,16 +3,14 @@
 
 " Open a popup window and show the string in it.
 function! ale#popup#Show(string, ...) abort
-    echo "Called popup show"
     if !g:ale_set_popups || !(exists('*popup_atcursor'))
         return
     endif
 
     call popup_atcursor(split(a:string, "\n"), {
-          \    'padding': [0, 1, 0, 1],
-          \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
-          \    'border': [1, 1, 1, 1],
-          \    'moved':'any',
-          \})
-
+    \    'padding': [0, 1, 0, 1],
+    \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
+    \    'border': [1, 1, 1, 1],
+    \    'moved':'any',
+    \})
 endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -24,20 +24,18 @@ function! ale#util#ShowMessage(string) abort
     " We have to assume the user is using a monospace font.
     if has('nvim') || (a:string !~? "\n" && len(a:string) < &columns)
         execute 'echo a:string'
+    elseif g:ale_set_balloons == 1 && has('balloon_eval')
+        call popup_atcursor(split(a:string, "\n"), {
+        \    'padding': [0, 1, 0, 1],
+        \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
+        \    'border': [1, 1, 1, 1],
+        \    'moved':'any',
+        \})
     else
-        if g:ale_set_balloons == 1 && has('balloon_eval')
-            call popup_atcursor(split(a:string, "\n"), {
-            \    'padding': [0, 1, 0, 1],
-            \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
-            \    'border': [1, 1, 1, 1],
-            \    'moved':'any',
-            \})
-        else
-            call ale#preview#Show(split(a:string, "\n"), {
-            \   'filetype': 'ale-preview.message',
-            \   'stay_here': 1,
-            \})
-        endif
+        call ale#preview#Show(split(a:string, "\n"), {
+        \   'filetype': 'ale-preview.message',
+        \   'stay_here': 1,
+        \})
     endif
 endfunction
 

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -25,10 +25,19 @@ function! ale#util#ShowMessage(string) abort
     if has('nvim') || (a:string !~? "\n" && len(a:string) < &columns)
         execute 'echo a:string'
     else
-        call ale#preview#Show(split(a:string, "\n"), {
-        \   'filetype': 'ale-preview.message',
-        \   'stay_here': 1,
-        \})
+        if g:ale_set_balloons == 1 && has('balloon_eval')
+            call popup_atcursor(split(a:string, "\n"), {
+            \    'padding': [0, 1, 0, 1],
+            \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
+            \    'border': [1, 1, 1, 1],
+            \    'moved':'any',
+            \})
+        else
+            call ale#preview#Show(split(a:string, "\n"), {
+            \   'filetype': 'ale-preview.message',
+            \   'stay_here': 1,
+            \})
+        endif
     endif
 endfunction
 

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -24,13 +24,6 @@ function! ale#util#ShowMessage(string) abort
     " We have to assume the user is using a monospace font.
     if has('nvim') || (a:string !~? "\n" && len(a:string) < &columns)
         execute 'echo a:string'
-    elseif g:ale_set_balloons == 1 && has('balloon_eval')
-        call popup_atcursor(split(a:string, "\n"), {
-        \    'padding': [0, 1, 0, 1],
-        \    'borderchars': ['━','┃','━','┃','┏','┓','┛','┗'],
-        \    'border': [1, 1, 1, 1],
-        \    'moved':'any',
-        \})
     else
         call ale#preview#Show(split(a:string, "\n"), {
         \   'filetype': 'ale-preview.message',

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -525,10 +525,11 @@ at the cursor taken from LSP linters. The following commands are supported:
 |ALEHover| - Print information about the symbol at the cursor.
 
 If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
-|balloon_show()| function, then "hover" information also show up when you move
-the mouse over a symbol in a buffer. Diagnostic information will take priority
-over hover information for balloons. If a line contains a problem, that
-problem will be displayed in a balloon instead of hover information.
+|balloon_show()| function, then "hover" information will appear in a balloon.
+This options will also cause balloons to show up when you move the mouse over
+a symbol in a buffer. Diagnostic information will take priority over hover
+information for balloons. If a line contains a problem, that problem will be
+displayed in a balloon instead of hover information.
 
 Hover information can be displayed in the preview window instead by setting
 |g:ale_hover_to_preview| to `1`.
@@ -2783,13 +2784,17 @@ ALEGoToTypeDefinitionInVSplit                   *ALEGoToTypeDefinitionInVSplit*
 
 ALEHover                                                             *ALEHover*
 
-  Print brief information about the symbol under the cursor, taken from any
-  available LSP linters. There may be a small non-blocking delay before
-  information is printed.
+  Print brief information about the symbol under the cursor to the prompt,
+  taken from any available LSP linters. There may be a small non-blocking
+  delay before information is printed.
 
   NOTE: In Vim 8, long messages will be shown in a preview window, as Vim 8
   does not support showing a prompt to press enter to continue for long
   messages from asynchronous callbacks.
+
+  If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
+  |balloon_show()| function, then "hover" information will appear in a
+  balloon.
 
   A plug mapping `<Plug>(ale_hover)` is defined for this command.
 
@@ -2928,6 +2933,9 @@ ALEDetail                                                           *ALEDetail*
   given line in the preview window. The preview window can be easily closed
   with the `q` key. If there is no message to show, the window will not be
   opened.
+
+  If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
+  |balloon_show()| function, then the message will appear in a balloon.
 
   If a loclist item has a `detail` key set, the message for that key will be
   preferred over `text`. See |ale-loclist-format|.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -525,11 +525,10 @@ at the cursor taken from LSP linters. The following commands are supported:
 |ALEHover| - Print information about the symbol at the cursor.
 
 If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
-|balloon_show()| function, then "hover" information will appear in a balloon.
-This options will also cause balloons to show up when you move the mouse over
-a symbol in a buffer. Diagnostic information will take priority over hover
-information for balloons. If a line contains a problem, that problem will be
-displayed in a balloon instead of hover information.
+|balloon_show()| function, then "hover" information also show up when you move
+the mouse over a symbol in a buffer. Diagnostic information will take priority
+over hover information for balloons. If a line contains a problem, that
+problem will be displayed in a balloon instead of hover information.
 
 Hover information can be displayed in the preview window instead by setting
 |g:ale_hover_to_preview| to `1`.
@@ -2784,17 +2783,13 @@ ALEGoToTypeDefinitionInVSplit                   *ALEGoToTypeDefinitionInVSplit*
 
 ALEHover                                                             *ALEHover*
 
-  Print brief information about the symbol under the cursor to the prompt,
-  taken from any available LSP linters. There may be a small non-blocking
-  delay before information is printed.
+  Print brief information about the symbol under the cursor, taken from any
+  available LSP linters. There may be a small non-blocking delay before
+  information is printed.
 
   NOTE: In Vim 8, long messages will be shown in a preview window, as Vim 8
   does not support showing a prompt to press enter to continue for long
   messages from asynchronous callbacks.
-
-  If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
-  |balloon_show()| function, then "hover" information will appear in a
-  balloon.
 
   A plug mapping `<Plug>(ale_hover)` is defined for this command.
 
@@ -2934,8 +2929,7 @@ ALEDetail                                                           *ALEDetail*
   with the `q` key. If there is no message to show, the window will not be
   opened.
 
-  If |g:ale_set_balloons| is set to `1` and your version of Vim supports the
-  |balloon_show()| function, then the message will appear in a balloon.
+  If |g:ale_set_popups| is set to `1`, then the message will appear in a popup.
 
   If a loclist item has a `detail` key set, the message for that key will be
   preferred over `text`. See |ale-loclist-format|.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -530,8 +530,9 @@ the mouse over a symbol in a buffer. Diagnostic information will take priority
 over hover information for balloons. If a line contains a problem, that
 problem will be displayed in a balloon instead of hover information.
 
-Hover information can be displayed in the preview window instead by setting
-|g:ale_hover_to_preview| to `1`.
+Hover information can be displayed in a popup instead by setting
+|g:ale_hover_to_popup| to `1`. If the preview window is preferred, it can be
+used by setting |g:ale_hover_to_preview| to `1`.
 
 For Vim 8.1+ terminals, mouse hovering is disabled by default. Enabling
 |balloonexpr| commands in terminals can cause scrolling issues in terminals,
@@ -1031,6 +1032,17 @@ g:ale_history_log_output                             *g:ale_history_log_output*
   if you want to save on some memory usage.
 
 
+g:ale_hover_to_popup                                     *g:ale_hover_to_popup*
+                                                         *b:ale_hover_to_popup*
+
+  Type: |Number|
+  Default: `0`
+
+  If set to `1`, hover messages will be displayed in popup, instead of in
+  balloons or the message line. This option takes precedence over
+  |g:ale_hover_to_preview|.
+
+
 g:ale_hover_to_preview                                 *g:ale_hover_to_preview*
                                                        *b:ale_hover_to_preview*
 
@@ -1038,7 +1050,8 @@ g:ale_hover_to_preview                                 *g:ale_hover_to_preview*
   Default: `0`
 
   If set to `1`, hover messages will be displayed in the preview window,
-  instead of in balloons or the message line.
+  instead of in balloons or the message line. This option is overridden by
+  |g:ale_hover_to_popup|.
 
 
 g:ale_keep_list_window_open                       *g:ale_keep_list_window_open*
@@ -1618,6 +1631,26 @@ g:ale_set_loclist                                           *g:ale_set_loclist*
   When this option is set to `1`, the |loclist| will be populated with any
   warnings and errors which are found by ALE. This feature can be used to
   implement jumping between errors through typical use of |lnext| and |lprev|.
+
+
+g:ale_set_popups                                             *g:ale_set_popups*
+
+  Type: |Number|
+  Default: `has('popupwin')`
+
+  When this option is set to `1`, popup messages can be used to be display for
+  problems or hover information if available. This can be preferential to
+  balloons when using terminal versions of Vim due to the strange mouse
+  behavior when balloons are enabled.
+
+  This option will cause |ALEDetail| to display diagnostic information in a
+  popup window.
+
+  When used with |g:ale_hover_to_popup| = `1`, |ALEHover| will display hover
+  information in a popup window.
+
+  If your version of Vim does not support the |popup_atcursor| function, then
+  this option does nothing meaningful.
 
 
 g:ale_set_quickfix                                         *g:ale_set_quickfix*
@@ -2929,7 +2962,8 @@ ALEDetail                                                           *ALEDetail*
   with the `q` key. If there is no message to show, the window will not be
   opened.
 
-  If |g:ale_set_popups| is set to `1`, then the message will appear in a popup.
+  If |g:ale_hover_to_popup| is set to `1`, then the message will appear in a
+  popup.
 
   If a loclist item has a `detail` key set, the message for that key will be
   preferred over `text`. See |ale-loclist-format|.

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -125,11 +125,14 @@ let g:ale_close_preview_on_insert = get(g:, 'ale_close_preview_on_insert', 0)
 " This flag can be set to 0 to disable balloon support.
 let g:ale_set_balloons = get(g:, 'ale_set_balloons', has('balloon_eval') && has('gui_running'))
 
+" This flag can be set to 0 to disable popup support.
+let g:ale_set_popups = get(g:, 'ale_set_popups', has('popupwin'))
+
 " Use preview window for hover messages.
 let g:ale_hover_to_preview = get(g:, 'ale_hover_to_preview', 0)
 
-" This flag can be set to 1 to enable popup support.
-let g:ale_set_popups = get(g:, 'ale_set_popups', 0)
+" Use popup window for hover messages.
+let g:ale_hover_to_popup = get(g:, 'ale_hover_to_popup', 0)
 
 " This flag can be set to 0 to disable warnings for trailing whitespace
 let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -128,6 +128,9 @@ let g:ale_set_balloons = get(g:, 'ale_set_balloons', has('balloon_eval') && has(
 " Use preview window for hover messages.
 let g:ale_hover_to_preview = get(g:, 'ale_hover_to_preview', 0)
 
+" This flag can be set to 1 to enable popup support.
+let g:ale_set_popups = get(g:, 'ale_set_popups', 0)
+
 " This flag can be set to 0 to disable warnings for trailing whitespace
 let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)
 " This flag can be set to 0 to disable warnings for trailing blank lines


### PR DESCRIPTION
Addresses #2922.

This causes the behavior of `ALEHover` and `ALEDetails` to change when `g:ale_set_balloons = 1`, causing each command to output information to a balloon rather than using the preview window.

It doesn't appear that the modified functions have tests, and I'm honestly not sure how to go about testing such a change. If anyone has any suggestions, I'll write them.

@dotdash This change is merely a slight change to the patch you proposed in #2922. If you'd like to take ownership of this change, I will gladly abandon this PR.