### PR TITLE
Fixed the markdownlint regex to use with the latest version

### DIFF
--- a/autoload/ale/handlers/markdownlint.vim
+++ b/autoload/ale/handlers/markdownlint.vim
@@ -2,7 +2,7 @@
 " Description: Adds support for markdownlint
 
 function! ale#handlers#markdownlint#Handle(buffer, lines) abort
-    let l:pattern=': \?\(\d*\):\? \(MD\d\{3}\)\(\/\)\([A-Za-z0-9-]\+\)\(.*\)$'
+    let l:pattern=': \?\(\d*\):\? \(MD\d\{3}\)\(\/\)\([A-Za-z0-9-\/]\+\)\(.*\)$'
     let l:output=[]
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/autoload/ale/handlers/markdownlint.vim
+++ b/autoload/ale/handlers/markdownlint.vim
@@ -2,7 +2,7 @@
 " Description: Adds support for markdownlint
 
 function! ale#handlers#markdownlint#Handle(buffer, lines) abort
-    let l:pattern=': \(\d*\): \(MD\d\{3}\)\(\/\)\([A-Za-z0-9-]\+\)\(.*\)$'
+    let l:pattern=': \?\(\d*\):\? \(MD\d\{3}\)\(\/\)\([A-Za-z0-9-]\+\)\(.*\)$'
     let l:output=[]
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_markdownlint_handler.vader
+++ b/test/handler/test_markdownlint_handler.vader
@@ -16,9 +16,15 @@ Execute(The Markdownlint handler should parse output correctly):
   \     'lnum': 298,
   \     'text': '(MD033/no-inline-html) Inline HTML [Element: p]',
   \     'type': 'W'
+  \   },
+  \   {
+  \     'lnum': 25,
+  \     'text': '(MD013/line-length) Line length [Expected: 80; Actual: 189]',
+  \     'type': 'W'
   \   }
   \ ],
   \ ale#handlers#markdownlint#Handle(0, [
   \ 'README.md: 1: MD002/first-header-h1 First header should be a top level header [Expected: h1; Actual: h2]',
-  \ 'README.md: 298: MD033/no-inline-html Inline HTML [Element: p]'
+  \ 'README.md: 298: MD033/no-inline-html Inline HTML [Element: p]',
+  \ 'README.md:25 MD013/line-length Line length [Expected: 80; Actual: 189]'
   \ ])

--- a/test/handler/test_markdownlint_handler.vader
+++ b/test/handler/test_markdownlint_handler.vader
@@ -21,10 +21,16 @@ Execute(The Markdownlint handler should parse output correctly):
   \     'lnum': 25,
   \     'text': '(MD013/line-length) Line length [Expected: 80; Actual: 189]',
   \     'type': 'W'
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'text': '(MD041/first-line-heading/first-line-h1) First line in file should be a top level heading [Context: "Header:"]',
+  \     'type': 'W'
   \   }
   \ ],
   \ ale#handlers#markdownlint#Handle(0, [
   \ 'README.md: 1: MD002/first-header-h1 First header should be a top level header [Expected: h1; Actual: h2]',
   \ 'README.md: 298: MD033/no-inline-html Inline HTML [Element: p]',
-  \ 'README.md:25 MD013/line-length Line length [Expected: 80; Actual: 189]'
+  \ 'README.md:25 MD013/line-length Line length [Expected: 80; Actual: 189]',
+  \ 'README.md:1 MD041/first-line-heading/first-line-h1 First line in file should be a top level heading [Context: "Header:"]'
   \ ])


### PR DESCRIPTION
This adds support for [DavidAnson/markdownlint](https://github.com/DavidAnson/markdownlint) the Javascript markdownlint which is inspired by the Ruby [markdownlint](https://github.com/markdownlint/markdownlint)