### PR TITLE
Support revive for go files

### DIFF
--- a/ale_linters/go/revive.vim
+++ b/ale_linters/go/revive.vim
@@ -1,0 +1,21 @@
+" Author: Penghui Liao <liaoishere@gmail.com>
+" Description: Adds support for revive
+
+call ale#Set('go_revive_executable', 'revive')
+call ale#Set('go_revive_options', '')
+
+function! ale_linters#go#revive#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'go_revive_options')
+
+    return ale#go#EnvString(a:buffer) . '%e'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' %t'
+endfunction
+
+call ale#linter#Define('go', {
+\   'name': 'revive',
+\   'output_stream': 'both',
+\   'executable': {b -> ale#Var(b, 'go_revive_executable')},
+\   'command': function('ale_linters#go#revive#GetCommand'),
+\   'callback': 'ale#handlers#unix#HandleAsWarning',
+\})

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -220,6 +220,25 @@ g:ale_go_govet_options                                 *g:ale_go_govet_options*
 
 
 ===============================================================================
+revive                                                          *ale-go-revive*
+
+g:ale_go_revive_executable                         *g:ale_go_revive_executable*
+                                                   *b:ale_go_revive_executable*
+  Type: |String|
+  Default: `'revive'`
+
+  This variable can be set to change the revive executable path.
+
+
+g:ale_go_revive_options                               *g:ale_go_revive_options*
+                                                      *b:ale_go_revive_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the revive
+
+
+===============================================================================
 staticcheck                                                *ale-go-staticcheck*
 
 g:ale_go_staticcheck_options                     *g:ale_go_staticcheck_options*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -162,6 +162,7 @@ Notes:
   * `gosimple`!!
   * `gotype`!!
   * `go vet`!!
+  * `revive`!!
   * `staticcheck`!!
 * GraphQL
   * `eslint`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2339,6 +2339,7 @@ documented in additional help files.
     gometalinter..........................|ale-go-gometalinter|
     gopls.................................|ale-go-gopls|
     govet.................................|ale-go-govet|
+    revive................................|ale-go-revive|
     staticcheck...........................|ale-go-staticcheck|
   graphql.................................|ale-graphql-options|
     eslint................................|ale-graphql-eslint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -171,6 +171,7 @@ formatting.
   * [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) :warning: :floppy_disk:
   * [gotype](https://godoc.org/golang.org/x/tools/cmd/gotype) :warning: :floppy_disk:
   * [go vet](https://golang.org/cmd/vet/) :floppy_disk:
+  * [revive](https://github.com/mgechev/revive) :warning: :floppy_disk:
   * [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) :warning: :floppy_disk:
 * GraphQL
   * [eslint](http://eslint.org/)

--- a/test/command_callback/test_revive_command_callbacks.vader
+++ b/test/command_callback/test_revive_command_callbacks.vader
@@ -1,0 +1,30 @@
+Before:
+  Save g:ale_go_go111module
+
+  call ale#assert#SetUpLinterTest('go', 'revive')
+
+After:
+  Restore
+
+  unlet! b:ale_go_go111module
+
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default revive command should be correct):
+  AssertLinter 'revive', ale#Escape('revive') . ' %t'
+
+Execute(The revive executable should be configurable):
+  let b:ale_go_revive_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar') . ' %t'
+
+Execute(The revive options should be configurable):
+  let b:ale_go_revive_options = '--foo'
+
+  AssertLinter 'revive', ale#Escape('revive') . ' --foo %t'
+
+Execute(The revive command should support Go environment variables):
+  let b:ale_go_go111module = 'on'
+
+  AssertLinter 'revive',
+  \ ale#Env('GO111MODULE', 'on') . ale#Escape('revive') . ' %t'


### PR DESCRIPTION
[revive](https://github.com/mgechev/revive) is a drop-in replacement of golint.
It is extensible, configurable, provides a superset of the rules of golint, and has significantly better performance.
