### PR TITLE
Run ESLint from project root dir where possible

### DIFF
--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -42,7 +42,18 @@ function! ale#handlers#eslint#GetCommand(buffer) abort
 
     let l:options = ale#Var(a:buffer, 'javascript_eslint_options')
 
-    return ale#node#Executable(a:buffer, l:executable)
+    " ESLint 6 loads plugins/configs/parsers from the project root
+    " By default, the project root is simply the CWD of the running process.
+    " https://github.com/eslint/rfcs/blob/master/designs/2018-simplified-package-loading/README.md
+    " https://github.com/dense-analysis/ale/issues/2787
+    " Identify project root from presence of node_modules dir.
+    " Note: If node_modules not present yet, can't load local deps anyway.
+    let l:modules_dir = ale#path#FindNearestDirectory(a:buffer, 'node_modules')
+    let l:project_dir = !empty(l:modules_dir) ? fnamemodify(l:modules_dir, ':h:h') : ''
+    let l:cd_command = !empty(l:project_dir) ? ale#path#CdString(l:project_dir) : ''
+
+    return l:cd_command
+    \   . ale#node#Executable(a:buffer, l:executable)
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' -f json --stdin --stdin-filename %s'
 endfunction

--- a/test/test_eslint_executable_detection.vader
+++ b/test/test_eslint_executable_detection.vader
@@ -57,13 +57,25 @@ Execute(eslint.js executables should be run with node on Windows):
   " We have to execute the file with node.
   if has('win32')
     AssertEqual
-    \ ale#Escape('node.exe') . ' '
+    \ ale#path#CdString(ale#path#Simplify(g:dir . '/eslint-test-files/react-app'))
+    \   . ale#Escape('node.exe') . ' '
     \   . ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
     \   . ' -f json --stdin --stdin-filename %s',
     \ ale#handlers#eslint#GetCommand(bufnr(''))
   else
     AssertEqual
-    \ ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
+    \ ale#path#CdString(ale#path#Simplify(g:dir . '/eslint-test-files/react-app'))
+    \   . ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
     \   . ' -f json --stdin --stdin-filename %s',
     \ ale#handlers#eslint#GetCommand(bufnr(''))
   endif
+
+Execute(eslint.js executables can be run outside project dir):
+  " Set filename above eslint-test-files (which contains node_modules)
+  call ale#test#SetFilename('testfile.js')
+
+  " cd "..." not present, since project root not found (from node_modules)
+  AssertEqual
+  \ ale#Escape(ale#handlers#eslint#GetExecutable(bufnr('')))
+  \   . ' -f json --stdin --stdin-filename %s',
+  \ ale#handlers#eslint#GetCommand(bufnr(''))


### PR DESCRIPTION
As discussed in #2787, ESLint 6 loads all plugins/configs/parsers relative to the project root which, by default, is the directory in which ESLint is invoked, as described in [ESLint RFC 2018-simplified-package-loading].

Therefore, ALE should run ESLint from the project root, when possible, so that dependencies will load.  This PR makes the change to do so.

[ESLint RFC 2018-simplified-package-loading]: https://github.com/eslint/rfcs/blob/master/designs/2018-simplified-package-loading/README.md

Fixes: #2787

Thanks for reviewing,
Kevin