### PR TITLE
allow passing custom options to markdownlint

### DIFF
--- a/ale_linters/markdown/markdownlint.vim
+++ b/ale_linters/markdown/markdownlint.vim
@@ -1,11 +1,22 @@
 " Author: Ty-Lucas Kelley <tylucaskelley@gmail.com>
 " Description: Adds support for markdownlint
 
+call ale#Set('markdown_markdownlint_options', '')
+
+function! ale_linters#markdown#markdownlint#GetCommand(buffer) abort
+    let l:executable = 'markdownlint'
+
+    let l:options = ale#Var(a:buffer, 'markdown_markdownlint_options')
+
+    return ale#Escape(l:executable)
+    \ . (!empty(l:options) ? ' ' . l:options : '') . ' %s'
+endfunction
+
 call ale#linter#Define('markdown', {
 \   'name': 'markdownlint',
 \   'executable': 'markdownlint',
 \   'lint_file': 1,
 \   'output_stream': 'both',
-\   'command': 'markdownlint %s',
+\   'command': function('ale_linters#markdown#markdownlint#GetCommand'),
 \   'callback': 'ale#handlers#markdownlint#Handle'
 \})

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -3,6 +3,17 @@ ALE Markdown Integration                                 *ale-markdown-options*
 
 
 ===============================================================================
+markdownlint                                        *ale-markdown-markdownlint*
+
+g:ale_markdown_markdownlint_options       *g:ale_markdown_markdownlint_options*
+                                          *b:ale_markdown_markdownlint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to markdownlint.
+
+
+===============================================================================
 mdl                                                          *ale-markdown-mdl*
 
 g:ale_markdown_mdl_executable                   *g:ale_markdown_mdl_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2425,6 +2425,7 @@ documented in additional help files.
     luac..................................|ale-lua-luac|
     luacheck..............................|ale-lua-luacheck|
   markdown................................|ale-markdown-options|
+    markdownlint..........................|ale-markdown-markdownlint|
     mdl...................................|ale-markdown-mdl|
     prettier..............................|ale-markdown-prettier|
     remark-lint...........................|ale-markdown-remark-lint|

--- a/test/command_callback/test_markdown_markdownlint_command_callback.vader
+++ b/test/command_callback/test_markdown_markdownlint_command_callback.vader
@@ -1,0 +1,13 @@
+Before:
+  call ale#assert#SetUpLinterTest('markdown', 'markdownlint')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'markdownlint', ale#Escape('markdownlint') . ' %s'
+
+Execute(The options should be configurable):
+  let g:ale_markdown_markdownlint_options = '--config ~/custom/.markdownlintrc'
+
+  AssertLinter 'markdownlint', ale#Escape('markdownlint') . ' --config ~/custom/.markdownlintrc %s'


### PR DESCRIPTION
Allow `g:ale_markdown_markdownlint_options`