### PR TITLE
Add a language option "-l" to known filetypes for uncrustify

### DIFF
--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -3,10 +3,24 @@
 
 call ale#Set('c_uncrustify_executable', 'uncrustify')
 call ale#Set('c_uncrustify_options', '')
+call ale#Set('c_uncrustify_language_mappings', {
+\   'c'      : 'c',
+\   'cpp'    : 'cpp',
+\   'objc'   : 'oc',
+\   'objcpp' : 'oc+',
+\   'cs'     : 'cs',
+\   'java'   : 'java'
+\ })
 
 function! ale#fixers#uncrustify#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'c_uncrustify_executable')
     let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
+    let l:language_mappings = ale#Var(a:buffer, 'c_uncrustify_language_mappings')
+
+    if type(l:language_mappings) is v:t_dict && has_key(l:language_mappings, &filetype)
+        let l:options = l:options
+        \   . ' -l ' . l:language_mappings[&filetype]
+    endif
 
     return {
     \   'command': ale#Escape(l:executable)

--- a/test/fixers/test_uncrustify_fixer_callback.vader
+++ b/test/fixers/test_uncrustify_fixer_callback.vader
@@ -14,7 +14,7 @@ After:
 
   call ale#test#RestoreDirectory()
 
-Execute(The clang-format callback should return the correct default values):
+Execute(The uncrustify callback should return the correct default values):
   call ale#test#SetFilename('c_paths/dummy.c')
 
   AssertEqual


### PR DESCRIPTION
This change adds a `-l <language>` parameter to the final uncrustify
command that is executed via ale_fix().

ALE passes the current buffer to uncrustify via an input stream without
providing a language parameter. This causes an issue where some of the
uncrustify configuration options are ignored and the output is different
than expected.

This change introduces a global `g:ale_c_uncrustify_language_mappings`
that is a dictionary of mappings between vim filetypes and uncrustify
recognized languages.

