### PR TITLE
Allow popup to be used instead of preview in completeopt

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -261,6 +261,8 @@ function! s:ReplaceCompletionOptions() abort
 
         if &l:completeopt =~# 'preview'
             let &l:completeopt = 'menu,menuone,preview,noselect,noinsert'
+        elseif &l:completeopt =~# 'popup'
+            let &l:completeopt = 'menu,menuone,popup,noselect,noinsert'
         else
             let &l:completeopt = 'menu,menuone,noselect,noinsert'
         endif


### PR DESCRIPTION
Some language servers send additional info (e.g. documentation, see https://github.com/dense-analysis/ale/issues/2905) along with auto-completion which is displayed in a preview window or not displayed at all, depending on whether `preview` is present in `completeopt`. For certain language severs (e.g. `pyls`), the `preview` option causes the window content to move which is very annoying (see https://github.com/dense-analysis/ale/issues/2463). However, the user may still want to see the extra info by using the `popup` option for `completeopt`, but since `completeopt` is overwritten by `ALE` before calling the auto-complete, this is not currently possible. This PR makes `ALE` respect the `popup` setting if the user has set it.