### PR TITLE
Add sql-lint as linter

### DIFF
--- a/ale_linters/sql/sqllint.vim
+++ b/ale_linters/sql/sqllint.vim
@@ -1,0 +1,32 @@
+" ale_linters/sql/sqllint.vim
+" Author: Joe Reynolds <joereynolds952@gmail.co>
+" Description: sql-lint for SQL files.
+"              sql-lint can be found at
+"              https://www.npmjs.com/package/sql-lint
+"              https://github.com/joereynolds/sql-lint
+
+function! ale_linters#sql#sqllint#Handle(buffer, lines) abort
+    " Matches patterns like the following:
+    "
+    " stdin:1 [ER_NO_DB_ERROR] No database selected
+    let l:pattern = '\v^[^:]+:(\d+) (.*)'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:match[3][0],
+        \   'text': l:match[0],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('sql', {
+\   'name': 'sqllint',
+\   'executable': 'sql-lint',
+\   'command': 'sql-lint',
+\   'callback': 'ale_linters#sql#sqllint#Handle',
+\})

--- a/test/command_callback/test_sqllint_command_callback.vader
+++ b/test/command_callback/test_sqllint_command_callback.vader
@@ -1,0 +1,12 @@
+Before:
+  " Load the linter and set up a series of commands, reset linter variables,
+  " clear caches, etc.
+  "
+  " Vader's 'Save' command will be called here for linter variables.
+  call ale#assert#SetUpLinterTest('sql', 'sqllint')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'sql-lint', ['sql-lint']

--- a/test/handler/test_sqllint_handler.vader
+++ b/test/handler/test_sqllint_handler.vader
@@ -1,0 +1,23 @@
+Before:
+    " Load the file which defines the linter.
+  runtime ale_linters/sql/sqllint.vim
+
+After:
+    " Unload all linters again.
+  call ale#linter#Reset()
+
+Execute (The output should be correct):
+
+  " Test that the right loclist items are parsed from the handler.
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col': 0,
+  \     'type': '',
+  \     'text': 'stdin:1 [ER_NO_DB_ERROR] No database selected'
+  \   },
+  \ ],
+  \ ale_linters#sql#sqllint#Handle(bufnr(''), [
+  \  'stdin:1 [ER_NO_DB_ERROR] No database selected'
+  \ ])


### PR DESCRIPTION
Hey, 
This adds support for the sql-linter [sql-lint](https://github.com/joereynolds/sql-lint).

There was a [previous pr](https://github.com/dense-analysis/ale/pull/2221) however I'm closing it as the branch had gone away as I did some cleaning of my laptop/github.

I've addressed the comments that were posted on there. 

- Tests have been added 
- The linter is no longer MySQL specific so the other comment about detecting if it's MySQL only is no longer valid

Thanks!

