### PR TITLE
Add variable to allow users to change phpmd suffixes

### DIFF
--- a/ale_linters/php/phpmd.vim
+++ b/ale_linters/php/phpmd.vim
@@ -11,12 +11,15 @@ let g:ale_php_phpmd_ruleset = get(g:, 'ale_php_phpmd_ruleset', 'cleancode,codesi
 
 function! ale_linters#php#phpmd#GetCommand(buffer) abort
     let l:suffixes = ale#Var(a:buffer, 'php_phpmd_suffixes')
-    if (empty(l:suffixes) && &filetype is# 'php')
-      let l:suffixes = expand('#' . a:buffer . ':e')
+
+    if empty(l:suffixes) && &filetype is# 'php'
+        let l:suffixes = expand('#' . a:buffer . ':e')
     endif
+
     let l:suffixes_option = !empty(l:suffixes)
     \   ? ' --suffixes ' . l:suffixes
     \   : ''
+
     return '%e %s text'
     \   . ale#Pad(ale#Var(a:buffer, 'php_phpmd_ruleset'))
     \   . l:suffixes_option

--- a/ale_linters/php/phpmd.vim
+++ b/ale_linters/php/phpmd.vim
@@ -3,12 +3,23 @@
 
 let g:ale_php_phpmd_executable = get(g:, 'ale_php_phpmd_executable', 'phpmd')
 
+" Set to tell phpmd files with which suffixes to check
+let g:ale_php_phpmd_suffixes = get(g:, 'ale_php_phpmd_suffixes', '')
+
 " Set to change the ruleset
 let g:ale_php_phpmd_ruleset = get(g:, 'ale_php_phpmd_ruleset', 'cleancode,codesize,controversial,design,naming,unusedcode')
 
 function! ale_linters#php#phpmd#GetCommand(buffer) abort
+    let l:suffixes = ale#Var(a:buffer, 'php_phpmd_suffixes')
+    if (empty(l:suffixes) && &filetype is# 'php')
+      let l:suffixes = expand('#' . a:buffer . ':e')
+    endif
+    let l:suffixes_option = !empty(l:suffixes)
+    \   ? ' --suffixes ' . l:suffixes
+    \   : ''
     return '%e %s text'
     \   . ale#Pad(ale#Var(a:buffer, 'php_phpmd_ruleset'))
+    \   . l:suffixes_option
     \   . ' --ignore-violations-on-exit %t'
 endfunction
 

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -141,6 +141,14 @@ g:ale_php_phpmd_ruleset                               *g:ale_php_phpmd_ruleset*
   the available phpmd rulesets
 
 
+g:ale_php_phpmd_suffixes                              *g:ale_php_phpmd_suffixes*
+                                                      *b:ale_php_phpmd_suffixes*
+  Type: |String|
+  Default: `''`
+
+  This variable controls the suffixes used by phpmd.
+
+
 ===============================================================================
 phpstan                                                       *ale-php-phpstan*
 

--- a/test/command_callback/test_phpmd_command_callbacks.vader
+++ b/test/command_callback/test_phpmd_command_callbacks.vader
@@ -10,3 +10,18 @@ Execute(Custom executables should be used for the executable and command):
   AssertLinter 'phpmd_test',
   \ ale#Escape('phpmd_test')
   \ . ' %s text cleancode,codesize,controversial,design,naming,unusedcode --ignore-violations-on-exit %t'
+
+Execute(User provided options should be used):
+  let g:ale_php_phpmd_suffixes = 'module,inc'
+
+  AssertLinter 'phpmd',
+  \ ale#Escape('phpmd')
+  \ . ' %s text cleancode,codesize,controversial,design,naming,unusedcode --suffixes module,inc --ignore-violations-on-exit %t'
+
+Given php(An empty PHP file):
+Execute(Current file extension should be used as the suffix):
+  let extension = expand('#' . bufnr('') . ':e')
+
+  AssertLinter 'phpmd',
+  \ ale#Escape('phpmd')
+  \ . ' %s text cleancode,codesize,controversial,design,naming,unusedcode --suffixes ' . extension . ' --ignore-violations-on-exit %t'


### PR DESCRIPTION
Building off #1799.

I like the idea of allowing the user to set suffixes or to use the current file's suffix as a fallback. However, I think it should still be limited to the current file having a PHP filetype. That way if the user doesn't set the suffixes variable it won't run on every kind of file they open. Let me know what you think.