### PR TITLE
[doc/ale] Fix ALECompletion spelling in mapping doc

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2660,7 +2660,7 @@ ALEComplete                                                       *ALEComplete*
   Manually trigger LSP autocomplete and show the menu. Works only when called
   from insert mode. >
 
-    inoremap <silent> <C-Space> <C-\><C-O>:AleComplete<CR>
+    inoremap <silent> <C-Space> <C-\><C-O>:ALEComplete<CR>
 <
   A plug mapping `<Plug>(ale_complete)` is defined for this command. >
 


### PR DESCRIPTION
Seems like "ALEComplete" was misspelled in the documentation.

Signed-off-by: Morten Linderud <morten@linderud.pw>