### PR TITLE
run govet on single files instead of the whole package

### DIFF
--- a/ale_linters/go/govet.vim
+++ b/ale_linters/go/govet.vim
@@ -14,7 +14,7 @@ function! ale_linters#go#govet#GetCommand(buffer) abort
     \   . ale#go#EnvString(a:buffer)
     \   . ale#Var(a:buffer, 'go_go_executable') . ' vet '
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' .'
+    \   . ' %t'
 endfunction
 
 call ale#linter#Define('go', {


### PR DESCRIPTION
Currently `go vet` runs on the whole package, like this: `go vet .` instead of the single file. If there's another error in a file in the same package, govet outputs that error, and doesn't show the error in the open file at all.

For example, if `fileA.go` has an error, and user opens `fileB.go` in vim and works on that file, ALE might not be able to show the errors in that file.

This PR makes govet run on single files instead of the whole package.