### PR TITLE
Add Apple's swift-format as a linter

### DIFF
--- a/ale_linters/swift/swiftformat.vim
+++ b/ale_linters/swift/swiftformat.vim
@@ -1,0 +1,62 @@
+" Author: Klaas Pieter Annema <https://github.com/klaaspieter>
+" Description: Support for swift-format https://github.com/apple/swift-format
+
+let s:default_executable = 'swift-format'
+call ale#Set('swift_swiftformat_executable', s:default_executable)
+
+function! ale_linters#swift#swiftformat#UseSwift(buffer) abort
+    let l:swift_config = ale#path#FindNearestFile(a:buffer, 'Package.swift')
+    let l:executable = ale#Var(a:buffer, 'swift_swiftformat_executable')
+
+    return !empty(l:swift_config) && l:executable is# s:default_executable
+endfunction
+
+function! ale_linters#swift#swiftformat#GetExecutable(buffer) abort
+    if ale_linters#swift#swiftformat#UseSwift(a:buffer)
+        return 'swift'
+    endif
+
+    return ale#Var(a:buffer, 'swift_swiftformat_executable')
+endfunction
+
+function! ale_linters#swift#swiftformat#GetCommand(buffer) abort
+    let l:executable = ale_linters#swift#swiftformat#GetExecutable(a:buffer)
+    let l:args = '--mode lint %t'
+
+    if ale_linters#swift#swiftformat#UseSwift(a:buffer)
+        let l:args = 'run swift-format' . ' ' . l:args
+    endif
+
+    return ale#Escape(l:executable) . ' ' . l:args
+endfunction
+
+function! ale_linters#swift#swiftformat#Handle(buffer, lines) abort
+    " Matches lines of the following pattern:
+    "
+    " Sources/main.swift:4:21: warning: [DoNotUseSemicolons]: remove ';' and move the next statement to the new line
+    " Sources/main.swift:3:12: warning: [Spacing]: remove 1 space
+    let l:pattern = '\v^.*:(\d+):(\d+): (\S+) \[(\S+)\]: (.*)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:match[3] is# 'error' ? 'E' : 'W',
+        \   'code': l:match[4],
+        \   'text': l:match[5],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+
+call ale#linter#Define('swift', {
+\   'name': 'swift-format',
+\   'executable': function('ale_linters#swift#swiftformat#GetExecutable'),
+\   'command': function('ale_linters#swift#swiftformat#GetCommand'),
+\   'output_stream': 'stderr',
+\   'language': 'swift',
+\   'callback': 'ale_linters#swift#swiftformat#Handle'
+\})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -445,6 +445,7 @@ Notes:
 * Swift
   * `sourcekit-lsp`
   * `swiftformat`
+  * `swift-format`
   * `swiftlint`
 * Tcl
   * `nagelfar`!!

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -454,6 +454,7 @@ formatting.
 * Swift
   * [sourcekit-lsp](https://github.com/apple/sourcekit-lsp)
   * [swiftformat](https://github.com/nicklockwood/SwiftFormat)
+  * [swift-format](https://github.com/apple/swift-format)
   * [swiftlint](https://github.com/realm/SwiftLint)
 * Tcl
   * [nagelfar](http://nagelfar.sourceforge.net) :floppy_disk:

--- a/test/command_callback/test_swift_swiftformat_command_callbacks.vader
+++ b/test/command_callback/test_swift_swiftformat_command_callbacks.vader
@@ -1,0 +1,25 @@
+Before:
+  call ale#assert#SetUpLinterTest('swift', 'swiftformat')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(Should use default command when not in a swift package):
+  call ale#test#SetFilename('../swift-test-files/non-swift-package-project/src/folder/dummy.swift')
+
+  AssertLinter 'swift-format',
+  \ ale#Escape('swift-format') . ' --mode lint %t'
+
+Execute(Should use swift run when in a swift package):
+  call ale#test#SetFilename('../swift-test-files/swift-package-project/src/folder/dummy.swift')
+
+  AssertLinter 'swift',
+  \ ale#Escape('swift') . ' run swift-format --mode lint %t'
+
+Execute(Should let users configure a global executable and override local paths):
+  call ale#test#SetFilename('../swift-test-files/swift-package-project/src/folder/dummy.swift')
+
+  let g:ale_swift_swiftformat_executable = '/path/to/custom/swift-format'
+
+  AssertLinter '/path/to/custom/swift-format',
+  \ ale#Escape('/path/to/custom/swift-format') . ' --mode lint %t'

--- a/test/handler/test_swiftformat_handler.vader
+++ b/test/handler/test_swiftformat_handler.vader
@@ -1,0 +1,28 @@
+Before:
+  runtime ale_linters/swift/swiftformat.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The swiftformat handler should parse lines correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 4,
+  \     'col': 21,
+  \     'type': 'W',
+  \     'code': 'DoNotUseSemicolons',
+  \     'text': 'remove '';'' and move the next statement to the new line',
+  \   },
+  \   {
+  \     'lnum': 3,
+  \     'col': 12,
+  \     'type': 'W',
+  \     'code': 'Spacing',
+  \     'text': 'remove 1 space'
+  \   },
+  \ ],
+  \ ale_linters#swift#swiftformat#Handle(bufnr(''), [
+  \   'Sources/main.swift:4:21: warning: [DoNotUseSemicolons]: remove '';'' and move the next statement to the new line',
+  \   'Sources/main.swift:3:12: warning: [Spacing]: remove 1 space',
+  \ ])


### PR DESCRIPTION
Adds [swift-format](https://github.com/apple/swift-format) as a linter.

There are a couple of trade-offs to be aware of:

1. This uses `swift run swift-format` when inside a Swift package. Using `swift run` means it'll build the package and then run `swift-format`. This can potentially take a while and I've seen it break when the build was interupted. The alternative is to look for swift-format in `./build/debug/swift-format` but it won't exist if the package hasn't been built.
2. Related to 1, if a package doesn't have swift-format as a dependency the linter will simply fail to run. Suggestions on how to imrove this and/or communicate this with the user are welcome 🙏 . I tried showing a generic error in `ale_linters#swift#swiftformat#Handle` but it doesn't seem to get called when `swift run` fails.
3. `swift-format` generally isn't installed in `$PATH` which means most users will have to set `swift_swiftformat_executable`. The version of `swift-format` that is installed by the default (outside of `$PATH`) is very out of date and is not compatible with this linter implementation.