### PR TITLE
enable using cpplint for c

### DIFF
--- a/ale_linters/c/cpplint.vim
+++ b/ale_linters/c/cpplint.vim
@@ -1,0 +1,20 @@
+" Author: Justin Huang <justin.y.huang@live.com>
+" Description: cpplint for c files
+
+call ale#Set('c_cpplint_executable', 'cpplint')
+call ale#Set('c_cpplint_options', '')
+
+function! ale_linters#c#cpplint#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'c_cpplint_options')
+
+    return '%e' . ale#Pad(l:options) . ' %s'
+endfunction
+
+call ale#linter#Define('c', {
+\   'name': 'cpplint',
+\   'output_stream': 'stderr',
+\   'executable': {b -> ale#Var(b, 'c_cpplint_executable')},
+\   'command': function('ale_linters#c#cpplint#GetCommand'),
+\   'callback': 'ale#handlers#cpplint#HandleCppLintFormat',
+\   'lint_file': 1,
+\})

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -223,8 +223,8 @@ g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
 
   This variable can be changed to modify flags given to cpplint.
 
-g:ale_c_cpplint_executable                       *g:ale_c_cpplint_executable*
-                                                 *b:ale_c_cpplint_executable*
+g:ale_c_cpplint_executable                          *g:ale_c_cpplint_executable*
+                                                    *b:ale_c_cpplint_executable*
   Type: |String|
   Default: `'cpplint'`
 

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -223,16 +223,16 @@ g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
 
   This variable can be changed to modify flags given to cpplint.
 
-g:ale_c_cpplint_executable                          *g:ale_c_cpplint_executable*
-                                                    *b:ale_c_cpplint_executable*
+g:ale_c_cpplint_executable                         *g:ale_c_cpplint_executable*
+                                                   *b:ale_c_cpplint_executable*
   Type: |String|
   Default: `'cpplint'`
 
   This variable can be changed to use a different executable for cpplint.
 
 
-g:ale_c_cpplint_options                             *g:ale_c_cpplint_options*
-                                                    *b:ale_c_cpplint_options*
+g:ale_c_cpplint_options                               *g:ale_c_cpplint_options*
+                                                      *b:ale_c_cpplint_options*
   Type: |String|
   Default: `''`
 

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -223,6 +223,21 @@ g:ale_cpp_cpplint_options                           *g:ale_cpp_cpplint_options*
 
   This variable can be changed to modify flags given to cpplint.
 
+g:ale_c_cpplint_executable                       *g:ale_c_cpplint_executable*
+                                                 *b:ale_c_cpplint_executable*
+  Type: |String|
+  Default: `'cpplint'`
+
+  This variable can be changed to use a different executable for cpplint.
+
+
+g:ale_c_cpplint_options                             *g:ale_c_cpplint_options*
+                                                    *b:ale_c_cpplint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to cpplint.
+
 
 ===============================================================================
 cquery                                                         *ale-cpp-cquery*


### PR DESCRIPTION
This is to create an entry for using cpplint as a C linter.
The tests should stay the same as the ones for the current cpplint.
Also updated is the help content.