### PR TITLE
Make sourcekitlsp configuration discoverable

### DIFF
--- a/ale_linters/swift/sourcekitlsp.vim
+++ b/ale_linters/swift/sourcekitlsp.vim
@@ -1,12 +1,25 @@
 " Author: Dan Loman <https://github.com/namolnad>
 " Description: Support for sourcekit-lsp https://github.com/apple/sourcekit-lsp
 
-call ale#Set('sourcekit_lsp_executable', 'sourcekit-lsp')
+let s:default_executable = 'sourcekit-lsp'
+
+call ale#Set('sourcekit_lsp_executable', s:default_executable)
+call ale#Set('swift_sourcekit_lsp_executable', s:default_executable)
+
+function! ale_linters#swift#sourcekitlsp#GetExecutable(buffer) abort
+    if ale#Var(a:buffer, 'sourcekit_lsp_executable') isnot# s:default_executable
+        execute 'echom ''sourcekit_lsp_executable is deprecated. Use `let swift_sourcekitlsp_executable instead`'''
+
+        return ale#Var(a:buffer, 'sourcekit_lsp_executable')
+    endif
+
+    return ale#Var(a:buffer, 'swift_sourcekit_lsp_executable')
+endfunction
 
 call ale#linter#Define('swift', {
 \   'name': 'sourcekitlsp',
 \   'lsp': 'stdio',
-\   'executable': {b -> ale#Var(b, 'sourcekit_lsp_executable')},
+\   'executable': function('ale_linters#swift#sourcekitlsp#GetExecutable'),
 \   'command': '%e',
 \   'project_root': function('ale#swift#FindProjectRoot'),
 \   'language': 'swift',

--- a/doc/ale-swift.txt
+++ b/doc/ale-swift.txt
@@ -9,8 +9,8 @@ To enable the SourceKit-LSP you need to install and build the executable as
 described here: https://github.com/apple/sourcekit-lsp#building-sourcekit-lsp
 
 
-g:ale_sourcekit_lsp_executable                 *g:ale_sourcekit_lsp_executable*
-                                               *b:ale_sourcekit_lsp_executable*
+g:ale_swift_sourcekit_lsp_executable     *g:ale_swift_sourcekit_lsp_executable*
+                                         *b:ale_swift_sourcekit_lsp_executable*
   Type: |String|
   Default: `'sourcekit-lsp'`
 

--- a/test/command_callback/test_swift_sourcekitlsp_command_callbacks.vader
+++ b/test/command_callback/test_swift_sourcekitlsp_command_callbacks.vader
@@ -2,6 +2,8 @@ Before:
   call ale#assert#SetUpLinterTest('swift', 'sourcekitlsp')
 
 After:
+  let g:ale_swift_sourcekit_lsp_executable = 'sourcekit-lsp'
+  let g:ale_sourcekit_lsp_executable = 'sourcekit-lsp'
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
@@ -10,6 +12,15 @@ Execute(The default executable path should be correct):
   AssertLinter 'sourcekit-lsp', ale#Escape('sourcekit-lsp')
 
 Execute(Should let users configure a global executable and override local paths):
+  call ale#test#SetFilename('../swift-test-files/swift-package-project/src/folder/dummy.swift')
+
+  let g:ale_swift_sourcekit_lsp_executable = '/path/to/custom/sourcekitlsp'
+
+  AssertLinter '/path/to/custom/sourcekitlsp',
+  \ ale#Escape('/path/to/custom/sourcekitlsp')
+
+
+Execute(Should support deprecated global executable configuration):
   call ale#test#SetFilename('../swift-test-files/swift-package-project/src/folder/dummy.swift')
 
   let g:ale_sourcekit_lsp_executable = '/path/to/custom/sourcekitlsp'


### PR DESCRIPTION
While working on #3007 I noticed that unlike swiftlint, sourcekit-lsp variables weren't shown in `ALEInfo`. This prefixes all sourcekitlsp variables with `swift` so they show up under “Linter variables” when linting swift files.

Because the previous variable is in use already I opted to print a message suggesting the new variable when it's use is detected.