### PR TITLE
Alias ps1 filetype to powershell

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -14,6 +14,7 @@ let s:default_ale_linter_aliases = {
 \   'csh': 'sh',
 \   'javascriptreact': ['javascript', 'jsx'],
 \   'plaintex': 'tex',
+\   'ps1': 'powershell',
 \   'rmarkdown': 'r',
 \   'rmd': 'r',
 \   'systemverilog': 'verilog',

--- a/doc/ale-powershell.txt
+++ b/doc/ale-powershell.txt
@@ -25,13 +25,6 @@ Installation
 
 Install PSScriptAnalyzer by any means, so long as it can be automatically
 imported in PowerShell.
-Some PowerShell plugins set the filetype of files to `ps1`. To continue using
-these plugins, use the ale_linter_aliases global to alias `ps1` to `powershell`
-
->
-  " Allow ps1 filetype to work with powershell linters
-  let g:ale_linter_aliases = {'ps1': 'powershell'}
-<
 
 g:ale_powershell_psscriptanalyzer_executable
 *g:ale_powershell_psscriptanalyzer_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1188,6 +1188,7 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
   \   'csh': 'sh',
   \   'javascriptreact': ['javascript', 'jsx'],
   \   'plaintex': 'tex',
+  \   'ps1': 'powershell',
   \   'rmarkdown': 'r',
   \   'rmd': 'r',
   \   'systemverilog': 'verilog',


### PR DESCRIPTION
Thanks for writing a linter for PSScriptAnalyzer @zigford!  I was surprised that it isn't used by default with [vim-ps1] due to requiring manual configuration to alias the `ps1` filetype to `powershell`.  Is there a reason you chose not to include it in `s:default_ale_linter_aliases`?

Since [vim-ps1] is a popular (the only?) PowerShell ftplugin and there do not appear to be any other uses of the `ps1` filetype on vim.org, this seems like a safe and reasonable default.  This PR would add it, assuming there wasn't a specific reason to avoid it.

Thanks again,
Kevin

[vim-ps1]: http://www.vim.org/scripts/script.php?script_id=1327
