### PR TITLE
Fix 3011 - not catching kotlinc output on stderr

### DIFF
--- a/ale_linters/kotlin/kotlinc.vim
+++ b/ale_linters/kotlin/kotlinc.vim
@@ -174,6 +174,7 @@ endfunction
 call ale#linter#Define('kotlin', {
 \   'name': 'kotlinc',
 \   'executable': 'kotlinc',
+\   'output_stream': 'stderr',
 \   'command': function('ale_linters#kotlin#kotlinc#RunWithImportPaths'),
 \   'callback': 'ale_linters#kotlin#kotlinc#Handle',
 \   'lint_file': 1,


### PR DESCRIPTION
Fix #3011: `kotlinc` output warnings and errors to `stderr` which are not captured by ALE.