### PR TITLE
improve remark text parsing

### DIFF
--- a/ale_linters/markdown/remark_lint.vim
+++ b/ale_linters/markdown/remark_lint.vim
@@ -14,7 +14,7 @@ endfunction
 function! ale_linters#markdown#remark_lint#Handle(buffer, lines) abort
     " matches: '  1:4  warning  Incorrect list-item indent: add 1 space  list-item-indent  remark-lint'
     " matches: '  18:71-19:1  error  Missing new line after list item  list-item-spacing  remark-lint',
-    let l:pattern = '^ \+\(\d\+\):\(\d\+\)\(-\(\d\+\):\(\d\+\)\)\?  \(warning\|error\)  \(.\+\)$'
+    let l:pattern = '^ \+\(\d\+\):\(\d\+\)\(-\(\d\+\):\(\d\+\)\)\?  \(warning\|error\)  \(.\{-}\) \{2,}'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_remark_lint_handler.vader
+++ b/test/handler/test_remark_lint_handler.vader
@@ -11,13 +11,13 @@ Execute(Warning and error messages should be handled correctly):
   \      'lnum': 1,
   \      'col': 4,
   \      'type': 'W',
-  \      'text': 'Incorrect list-item indent: add 1 space  list-item-indent  remark-lint',
+  \      'text': 'Incorrect list-item indent: add 1 space',
   \   },
   \   {
   \      'lnum': 3,
   \      'col': 5,
   \      'type': 'E',
-  \      'text': 'Incorrect list-item indent: remove 1 space  list-item-indent  remark-lint',
+  \      'text': 'Incorrect list-item indent: remove 1 space',
   \   },
   \   {
   \     'lnum': 18,
@@ -25,7 +25,7 @@ Execute(Warning and error messages should be handled correctly):
   \     'end_lnum': 19,
   \     'end_col': 1,
   \     'type': 'E',
-  \     'text': 'Missing new line after list item  list-item-spacing  remark-lint',
+  \     'text': 'Missing new line after list item',
   \   },
   \ ],
   \ ale_linters#markdown#remark_lint#Handle(1, [


### PR DESCRIPTION
Before, the error would be printed as:

    Incorrect list-item indent: add 1 space  list-item-indent  remark-lint

After this commit, the categorization tags are removed:

    Incorrect list-item indent: add 1 space

This would cut-off the error message if it contained two consecutive spaces, but I haven't seen that happen yet.