### PR TITLE
Fix sqlfmt fixer

### DIFF
--- a/autoload/ale/fixers/sqlfmt.vim
+++ b/autoload/ale/fixers/sqlfmt.vim
@@ -7,7 +7,6 @@ function! ale#fixers#sqlfmt#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' -w'
     \       . (empty(l:options) ? '' : ' ' . l:options),
     \}
 endfunction

--- a/test/fixers/test_sqlfmt_fixer_callback.vader
+++ b/test/fixers/test_sqlfmt_fixer_callback.vader
@@ -9,7 +9,6 @@ Execute(The sqlfmt callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape('sqlfmt')
-  \     . ' -w',
   \ },
   \ ale#fixers#sqlfmt#Fix(bufnr(''))
 
@@ -20,7 +19,6 @@ Execute(The sqlfmt executable and options should be configurable):
   AssertEqual
   \ {
   \   'command': ale#Escape('/path/to/sqlfmt')
-  \     . ' -w'
   \     . ' -u',
   \ },
   \ ale#fixers#sqlfmt#Fix(bufnr(''))


### PR DESCRIPTION
ISSUE:
Running the sqlfmt fixer just replaced my current file with the text:
`unknown shorthand flag: 'w' in -w`

SOLUTION: 
Remove the -w flag, that no longer seems to be supported in sqlfmt.