### PR TITLE
Fix 2816 - Standard fix does not work.

### DIFF
--- a/autoload/ale/fixers/standard.vim
+++ b/autoload/ale/fixers/standard.vim
@@ -27,7 +27,7 @@ function! ale#fixers#standard#Fix(buffer) abort
     return {
     \   'command': ale#node#Executable(a:buffer, l:executable)
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \       . ' --fix %t',
+    \       . ' --fix --stdin < %s > %t',
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_standard_fixer_callback.vader
+++ b/test/fixers/test_standard_fixer_callback.vader
@@ -15,7 +15,7 @@ Execute(The executable path should be correct):
   \   'read_temporary_file': 1,
   \   'command': (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/standard/bin/cmd.js'))
-  \     . ' --fix %t',
+  \     . ' --fix --stdin < %s > %t',
   \ },
   \ ale#fixers#standard#Fix(bufnr(''))
 
@@ -26,6 +26,6 @@ Execute(Custom options should be supported):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': ale#Escape('standard') . ' --foo-bar --fix %t',
+  \   'command': ale#Escape('standard') . ' --foo-bar --fix --stdin < %s > %t',
   \ },
   \ ale#fixers#standard#Fix(bufnr(''))


### PR DESCRIPTION
The standard linter --fix fails if the file being input is not relative
to the project root (https://github.com/standard/standard/issues/1384).

This MR attempts to fix this by changing the command so the input file
is relative to the project root and the output is to a temporary file.

Preliminary tests with toy javascript projects seem to indicate this
works fine.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
