### PR TITLE
Fix vim sign priority patch check

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -23,7 +23,7 @@ let g:ale_sign_offset = get(g:, 'ale_sign_offset', 1000000)
 let g:ale_sign_column_always = get(g:, 'ale_sign_column_always', 0)
 let g:ale_sign_highlight_linenrs = get(g:, 'ale_sign_highlight_linenrs', 0)
 
-let s:supports_sign_groups = has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+let s:supports_sign_groups = has('nvim-0.4.2') || has('patch-8.1.614')
 
 if !hlexists('ALEErrorSign')
     highlight link ALEErrorSign error

--- a/test/sign/test_linting_sets_signs.vader
+++ b/test/sign/test_linting_sets_signs.vader
@@ -32,7 +32,7 @@ Before:
 
   function! CollectSigns()
     redir => l:output
-      if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+      if has('nvim-0.4.2') || has('patch-8.1.614')
         silent exec 'sign place group=ale'
       else
         silent exec 'sign place'

--- a/test/sign/test_sign_parsing.vader
+++ b/test/sign/test_sign_parsing.vader
@@ -1,5 +1,5 @@
 Execute (Parsing English signs should work):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[9, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns([
@@ -16,7 +16,7 @@ Execute (Parsing English signs should work):
   endif
 
 Execute (Parsing Russian signs should work):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[1, 1000001, 'ALEErrorSign']]],
     \ ale#sign#ParseSigns(['    строка=1  id=1000001  группа=ale  имя=ALEErrorSign'])
@@ -27,7 +27,7 @@ Execute (Parsing Russian signs should work):
   endif
 
 Execute (Parsing Japanese signs should work):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns(['    行=1  識別子=1000001  グループ=ale  名前=ALEWarningSign'])
@@ -38,7 +38,7 @@ Execute (Parsing Japanese signs should work):
   endif
 
 Execute (Parsing Spanish signs should work):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[12, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns(['    línea=12 id=1000001  grupo=ale  nombre=ALEWarningSign'])
@@ -49,7 +49,7 @@ Execute (Parsing Spanish signs should work):
   endif
 
 Execute (Parsing Italian signs should work):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns(['    riga=1 id=1000001, gruppo=ale  nome=ALEWarningSign'])
@@ -60,7 +60,7 @@ Execute (Parsing Italian signs should work):
   endif
 
 Execute (Parsing German signs should work):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[235, 1000001, 'ALEErrorSign']]],
     \ ale#sign#ParseSigns(['    Zeile=235  id=1000001 Gruppe=ale  Name=ALEErrorSign'])
@@ -71,7 +71,7 @@ Execute (Parsing German signs should work):
   endif
 
 Execute (The sign parser should indicate if the dummy sign is set):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [1, [[1, 1000001, 'ALEErrorSign']]],
     \ ale#sign#ParseSigns([

--- a/test/sign/test_sign_placement.vader
+++ b/test/sign/test_sign_placement.vader
@@ -68,7 +68,7 @@ Before:
 
   function! ParseSigns()
     redir => l:output
-      if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+      if has('nvim-0.4.2') || has('patch-8.1.614')
         silent sign place group=ale
       else
         silent sign place
@@ -152,7 +152,7 @@ Execute(The current signs should be set for running a job):
   \ ParseSigns()
 
 Execute(Loclist items with sign_id values should be kept):
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     exec 'sign place 1000347 group=ale line=3 name=ALEErrorSign buffer=' . bufnr('')
     exec 'sign place 1000348 group=ale line=15 name=ALEErrorSign buffer=' . bufnr('')
     exec 'sign place 1000349 group=ale line=16 name=ALEWarningSign buffer=' . bufnr('')
@@ -297,7 +297,7 @@ Execute(No exceptions should be thrown when setting signs for invalid buffers):
 Execute(Signs should be removed when lines have multiple sign IDs on them):
   " We can fail to remove signs if there are multiple signs on one line,
   " say after deleting lines in Vim, etc.
-  if has('nvim-0.4.2') || (v:version >= 801 && has('patch614'))
+  if has('nvim-0.4.2') || has('patch-8.1.614')
     exec 'sign place 1000347 group=ale line=3 name=ALEErrorSign buffer=' . bufnr('')
     exec 'sign place 1000348 group=ale line=3 name=ALEWarningSign buffer=' . bufnr('')
     exec 'sign place 1000349 group=ale line=10 name=ALEErrorSign buffer=' . bufnr('')


### PR DESCRIPTION
With Vim 8.2 released, the previous check method is not accurate enough.

Refer: https://github.com/dense-analysis/ale/issues/569#issuecomment-576613818
