### PR TITLE
Keep -iframework if present in parsed C/C++ flags

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -83,6 +83,7 @@ function! ale#c#ParseCFlags(path_prefix, cflag_line) abort
         \ || stridx(l:option, '-iquote') == 0
         \ || stridx(l:option, '-isystem') == 0
         \ || stridx(l:option, '-idirafter') == 0
+        \ || stridx(l:option, '-iframework') == 0
             if stridx(l:option, '-I') == 0 && l:option isnot# '-I'
                 let l:arg = join(split(l:option, '\zs')[2:], '')
                 let l:option = '-I'

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -340,6 +340,7 @@ Execute(CFlags we want to pass):
   \ . ' -iquote ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incquote'))
   \ . ' -isystem ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incsystem'))
   \ . ' -idirafter ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incafter'))
+  \ . ' -iframework ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incframework'))
   \ . ' -Dmacro=value -D macro2 -Bbdir -B bdir2'
   \ . ' -iprefix prefix -iwithprefix prefix2 -iwithprefixbefore prefix3'
   \ . ' -isysroot sysroot --sysroot=test --no-sysroot-suffix -imultilib multidir'
@@ -349,7 +350,7 @@ Execute(CFlags we want to pass):
   \ ale#c#ParseCFlags(
   \   ale#path#Simplify(g:dir. '/test_c_projects/makefile_project'),
   \   'gcc'
-  \ . ' -Iinc -I include -iquote incquote -isystem incsystem -idirafter incafter'
+  \ . ' -Iinc -I include -iquote incquote -isystem incsystem -idirafter incafter -iframework incframework'
   \ . ' -Dmacro=value -D macro2 -Bbdir -B bdir2'
   \ . ' -iprefix prefix -iwithprefix prefix2 -iwithprefixbefore prefix3'
   \ . ' -isysroot sysroot --sysroot=test --no-sysroot-suffix -imultilib multidir'


### PR DESCRIPTION
`-iframework` appears to implicitly add some header search paths to the
set specified using the `-isystem`, `-I`, and `-isysroot` flags. This means
that leaving out `-iframework` can result in invalid errors being
displayed.

For example, given a CMake project with this CMakeLists.txt:
```cmake
    project(test)
    set(Qt5_DIR "/usr/local/opt/qt5/lib/cmake/Qt5")
    find_package(Qt5 5.9 REQUIRED COMPONENTS Widgets)
    add_executable(foo foo.cpp)
    target_link_libraries(foo PRIVATE Qt5::Widgets)
```
and foo.cpp:
```cpp
    #include <QWidget>
    int main() {}
```
If `g:ale_c_parse_compile_commands` is set, then ALE executes something
along these lines:

    clang++ -S -x c++ -fsyntax-only -std=gnu++11 -isystem /usr/local/opt/qt5/lib/QtWidgets.framework/Headers - < foo.cpp

Resulting in this output:

    In file included from <stdin>:1:
    In file included from /usr/local/opt/qt5/lib/QtWidgets.framework/Headers/QWidget:1:
    /usr/local/opt/qt5/lib/QtWidgets.framework/Headers/qwidget.h:43:10: fatal error: 'QtWidgets/qtwidgetsglobal.h' file not found
    #include <QtWidgets/qtwidgetsglobal.h>
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.

Because the header is in a subdirectory of the path denoted by -isystem
(/usr/local/opt/qt5/lib/QtWidgets.framework/Headers/5.14.1/QtWidgets/qtwidgetsglobal.h),
clang fails to find it and exits.

If -iframework is included, ALE executes something along these lines:

    clang++ -S -x c++ -fsyntax-only -std=gnu++11 -iframework /usr/local/opt/qt5/lib -isystem /usr/local/opt/qt5/lib/QtWidgets.framework/Headers - < foo.cpp

And compilation completes successfully.