### PR TITLE
Issue 2958: Addtional ^M characters on Windows

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -263,6 +263,8 @@ function! ale#GetLocItemMessage(item, format_string) abort
     let l:msg = substitute(l:msg, '\v\%([^\%]*)code([^\%]*)\%', l:code_repl, 'g')
     " Replace %s with the text.
     let l:msg = substitute(l:msg, '\V%s', '\=a:item.text', 'g')
+    " Windows may insert carriage return line endings (^M), strip these characters.
+    let l:msg = substitute(l:msg, '\r', '', 'g')
 
     return l:msg
 endfunction


### PR DESCRIPTION
**Issue #2958**

Windows may insert carriage return line endings, which ALE does not handle
well. These characters should not be displayed.

Adds a line to remove these characters for all messages.

> Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

> Seriously, read `:help ale-dev` and write tests.

Tests are still needed.

I'm not familiar with this code base. If this looks like a reasonable approach, let me know and I will write some tests.