### PR TITLE
Run `make -Bn` instead of `make -n`

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -358,7 +358,7 @@ function! ale#c#GetMakeCommand(buffer) abort
         let l:makefile_path = ale#path#FindNearestFile(a:buffer, 'Makefile')
 
         if !empty(l:makefile_path)
-            return 'cd '. fnamemodify(l:makefile_path, ':p:h') . ' && make -n'
+            return 'cd '. fnamemodify(l:makefile_path, ':p:h') . ' && make -Bn'
         endif
     endif
 


### PR DESCRIPTION
Currently, `make -n` is run to obtain the flags. 
But if the default target is already built, make will exit saying something like `make: Nothing to be done for 'all'.`
By using `-B` flag which is short for `--always-build`, make will try to build every file and prepare command lines for them.
Since we also specify `-n` which is short for `--dry-run`, no commands will be executed.
Instead all the commands that were to be executed will be printed, which is then used by this script to determine the `CFLAGS`.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
