### PR TITLE
Elixir Credo: Support Umbrella Mix Projects

### DIFF
--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -46,7 +46,7 @@ function! ale_linters#elixir#credo#GetMode() abort
 endfunction
 
 function! ale_linters#elixir#credo#GetCommand(buffer) abort
-    let l:project_root = ale#handlers#elixir#FindMixProjectRoot(a:buffer)
+    let l:project_root = ale#handlers#elixir#FindMixUmbrellaRoot(a:buffer)
     let l:mode = ale_linters#elixir#credo#GetMode()
 
     return ale#path#CdString(l:project_root)

--- a/test/command_callback/test_elixir_credo.vader
+++ b/test/command_callback/test_elixir_credo.vader
@@ -1,6 +1,6 @@
 Before:
   call ale#assert#SetUpLinterTest('elixir', 'credo')
-  call ale#test#SetFilename('elixir_paths/mix_project/lib/app.ex')
+  call ale#test#SetFilename('elixir_paths/umbrella_project/apps/app1/lib/app.ex')
 
 
 After:
@@ -12,17 +12,17 @@ Execute(Builds credo command with --strict mode when set to 1):
   let g:ale_elixir_credo_strict = 1
 
   AssertLinter 'mix',
-  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
   \ . 'mix help credo && mix credo --strict --format=flycheck --read-from-stdin %s'
 
 Execute(Builds credo command with suggest mode by default):
   AssertLinter 'mix',
-  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
   \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
 
 Execute(Builds credo command with suggest mode when set to 0):
   let g:ale_elixir_credo_strict = 0
 
   AssertLinter 'mix',
-  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
   \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'

--- a/test/command_callback/test_elixir_credo.vader
+++ b/test/command_callback/test_elixir_credo.vader
@@ -5,24 +5,50 @@ Before:
 
 After:
   unlet! g:ale_elixir_credo_strict
-
   call ale#assert#TearDownLinterTest()
 
-Execute(Builds credo command with --strict mode when set to 1):
+Execute(When in an umbrella, builds credo command with --strict mode when set to 1):
   let g:ale_elixir_credo_strict = 1
 
   AssertLinter 'mix',
   \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
   \ . 'mix help credo && mix credo --strict --format=flycheck --read-from-stdin %s'
 
-Execute(Builds credo command with suggest mode by default):
+Execute(When in an umbrella, builds credo command with suggest mode by default):
   AssertLinter 'mix',
   \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
+  \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
+
+Execute(When in an umbrella, builds credo command with suggest mode when set to 0):
+  let g:ale_elixir_credo_strict = 0
+
+  AssertLinter 'mix',
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
+  \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
+
+Before:
+  call ale#assert#SetUpLinterTest('elixir', 'credo')
+  call ale#test#SetFilename('elixir_paths/mix_project/lib/app.ex')
+
+After:
+  unlet! g:ale_elixir_credo_strict
+  call ale#assert#TearDownLinterTest()
+
+Execute(Builds credo command with --strict mode when set to 1):
+  let g:ale_elixir_credo_strict = 1
+
+  AssertLinter 'mix',
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
+  \ . 'mix help credo && mix credo --strict --format=flycheck --read-from-stdin %s'
+
+Execute(Builds credo command with suggest mode by default):
+  AssertLinter 'mix',
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
   \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
 
 Execute(Builds credo command with suggest mode when set to 0):
   let g:ale_elixir_credo_strict = 0
 
   AssertLinter 'mix',
-  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/umbrella_project'))
+  \ ale#path#CdString(ale#path#Simplify(g:dir . '/elixir_paths/mix_project'))
   \ . 'mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'


### PR DESCRIPTION
Hello! This is my first time contributing to this project, so please let me know if I missed anything in the contributing guide and `:help ale-dev` 😄 

This PR improves the experience of using the [credo](https://github.com/rrrene/credo) linter for Elixir by adding support for [umbrella mix projects](https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html#umbrella-projects). For example, I have a project that defines a custom `.credo.exs` file at the root of the umbrella, rather than in each child application. I expect ALE to search for an umbrella root, as it does for the `elixir_ls` language server linter and fixer. What happens on `master` today is it executes `mix credo` in the child application, rather than the umbrella root, so the configuration file is not picked up.

I based this PR on the existing `elixir_ls` [implementation](https://github.com/dense-analysis/ale/blob/master/ale_linters/elixir/elixir_ls.vim#L19) and [tests](https://github.com/dense-analysis/ale/blob/master/test/command_callback/test_elixir_ls_command_callbacks.vader#L24) for determining the root of a mix project.