### PR TITLE
Remove --stdin from prettier config for prettier v2 change

### DIFF
--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -96,11 +96,19 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
 
     " 1.4.0 is the first version with --stdin-filepath
     if ale#semver#GTE(a:version, [1, 4, 0])
+        if ale#semver#GTE(a:version, [2, 0, 0])
+            " --stdin was removed at v2
+            " https://github.com/prettier/prettier/pull/7668
+            let l:stdin_flag = ''
+        else
+            let l:stdin_flag = ' --stdin'
+        endif
+
         return {
         \   'command': ale#path#BufferCdString(a:buffer)
         \       . ale#Escape(l:executable)
         \       . (!empty(l:options) ? ' ' . l:options : '')
-        \       . ' --stdin-filepath %s --stdin',
+        \       . ' --stdin-filepath %s' . l:stdin_flag
         \}
     endif
 

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -294,6 +294,20 @@ Execute(Should set --parser for experimental language, Handlebars):
   \     . ' --stdin-filepath %s --stdin',
   \ }
 
+Execute(Should drop --stdin option >= v2.0.0):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=javascript
+
+  GivenCommandOutput ['2.0.0']
+  AssertFixer
+  \ {
+  \   'command': ale#path#CdString(expand('%:p:h'))
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser babel'
+  \     . ' --stdin-filepath %s',
+  \ }
+
 Execute(The prettier_d post-processor should permit regular JavaScript content):
   AssertEqual
   \ [


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

From prettier v2, `--stdin` was removed.

https://github.com/prettier/prettier/pull/7668

This PR removes the flag when applying Prettier fixer. I'm not familiar with prettier-eslint and prettier_d. So this PR fixes only standard `prettier` CLI.
