### PR TITLE
Add linter for agda

### DIFF
--- a/ale_linters/agda/agda.vim
+++ b/ale_linters/agda/agda.vim
@@ -1,0 +1,120 @@
+" Author: Akiomi Kamakura <akiomik@gmail.com>
+" Description: Lint Agda files with Agda
+
+call ale#Set('agda_agda_executable', 'agda')
+
+function! ale_linters#agda#agda#RunWithVersionCheck(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'agda_agda_executable')
+    let l:command = ale#Escape(l:executable) . ' --version'
+
+    return ale#semver#RunWithVersionCheck(
+    \   a:buffer,
+    \   l:executable,
+    \   l:command,
+    \   function('ale_linters#agda#agda#GetCommand'),
+    \)
+endfunction
+
+function! ale_linters#agda#agda#GetCommand(buffer, version) abort
+    if ale#semver#GTE(a:version, [2, 5, 1])
+        return "echo 'IOTCM \"%t\" None Indirect (Cmd_load \"%t\" [])'"
+        \ . ' | %e --interaction'
+    endif
+
+    return 0
+endfunction
+
+function! ale_linters#agda#agda#HandleMessages(buffer, positionLine, messageLines, type) abort
+    let l:matches = ale#util#GetMatches(a:positionLine, '\v:(\d+),(\d+)-(\d+)')
+
+    if len(l:matches) == 0
+        return {}
+    endif
+
+    let l:match = l:matches[0]
+
+    return {
+    \   'lnum': str2nr(l:match[1]),
+    \   'col': str2nr(l:match[2]),
+    \   'end_col': str2nr(l:match[3]),
+    \   'text': join(a:messageLines, ' '),
+    \   'type': a:type,
+    \}
+endfunction
+
+function! ale_linters#agda#agda#HandleErrors(buffer, label, message) abort
+    let l:lines = split(a:message, '\\n')
+
+    if l:lines[0] !~# '^———— Error ————'
+        let l:type = a:label is# 'Error' ? 'E' : 'W'
+
+        return [ale_linters#agda#agda#HandleMessages(a:buffer, l:lines[0], l:lines[1:], l:type)]
+    endif
+
+    let l:output = []
+    let l:blocks = split(a:message, '\\n\\n')
+    let l:errorLines = split(l:blocks[0], '\\n')
+    call add(l:output, ale_linters#agda#agda#HandleMessages(a:buffer, l:errorLines[1], l:errorLines[2:], 'E'))
+
+    if len(l:blocks) == 2
+        let l:warnLines = split(l:blocks[1], '\\n')
+        call add(l:output, ale_linters#agda#agda#HandleMessages(a:buffer, l:warnLines[1], l:warnLines[2:], 'W'))
+    endif
+
+    return l:output
+endfunction
+
+function! ale_linters#agda#agda#HandleGoals(buffer, label, message) abort
+    let l:output = []
+    let l:blocks = split(a:message, '\\n\\n')
+
+    if len(l:blocks) == 1
+        let l:messageLines = []
+        let l:type = 'I'
+    else
+        let l:messageLines = split(l:blocks[1], '\\n')[1:]
+        let l:type = 'E'
+    endif
+
+    let l:positionLines = split(substitute(l:blocks[0], '\\n$', '', ''), '\\n')
+
+    for l:positionLine in l:positionLines
+        let l:result = ale_linters#agda#agda#HandleMessages(a:buffer, l:positionLine, l:messageLines, l:type)
+
+        if !empty(l:result)
+            call add(l:output, l:result)
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+function! ale_linters#agda#agda#Handle(buffer, lines) abort
+    let l:pattern = '\v^(Agda2\>\s*)?\(agda2-info-action "\*(Error|All Errors|All Goals|All Goals, Errors)\*" "(.*)" (t|nil)\)$'
+
+    for l:line in a:lines
+        let l:matches = ale#util#GetMatches(l:line, l:pattern)
+
+        if len(l:matches) == 0
+            continue
+        endif
+
+        let l:match = l:matches[0]
+
+        if l:match[2] is# 'Error' || l:match[2] is# 'All Errors'
+            return ale_linters#agda#agda#HandleErrors(a:buffer, l:match[2], l:match[3])
+        elseif l:match[2] is# 'All Goals' || l:match[2] is# 'All Goals, Errors'
+            return ale_linters#agda#agda#HandleGoals(a:buffer, l:match[2], l:match[3])
+        endif
+    endfor
+
+    return []
+endfunction
+
+call ale#linter#Define('agda', {
+\   'name': 'agda',
+\   'executable': {b -> ale#Var(b, 'agda_agda_executable')},
+\   'command': function('ale_linters#agda#agda#RunWithVersionCheck'),
+\   'output_stream': 'stdout',
+\   'callback': 'ale_linters#agda#agda#Handle',
+\})

--- a/doc/ale-agda.txt
+++ b/doc/ale-agda.txt
@@ -1,0 +1,17 @@
+===============================================================================
+ALE Agda Integration                                         *ale-agda-options*
+
+
+===============================================================================
+agda                                                            *ale-agda-agda*
+
+g:ale_agda_agda_executable                         *g:ale_agda_agda_executable*
+                                                   *b:ale_agda_agda_executable*
+  Type: |String|
+  Default: `'agda'`
+
+This variable can be changed to use a different executable for agda.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -15,6 +15,8 @@ Notes:
 * Ada
   * `gcc`
   * `gnatpp`
+* Agda
+  * `agda`
 * Ansible
   * `ansible-lint`
 * API Blueprint

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2267,6 +2267,8 @@ documented in additional help files.
   ada.....................................|ale-ada-options|
     gcc...................................|ale-ada-gcc|
     gnatpp................................|ale-ada-gnatpp|
+  agda....................................|ale-agda-options|
+    agda..................................|ale-agda-agda|
   ansible.................................|ale-ansible-options|
     ansible-lint..........................|ale-ansible-ansible-lint|
   asciidoc................................|ale-asciidoc-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -24,6 +24,8 @@ formatting.
 * Ada
   * [gcc](https://gcc.gnu.org)
   * [gnatpp](https://docs.adacore.com/gnat_ugn-docs/html/gnat_ugn/gnat_ugn/gnat_utility_programs.html#the-gnat-pretty-printer-gnatpp) :floppy_disk:
+* Agda
+  * [agda](http://wiki.portal.chalmers.se/agda)
 * Ansible
   * [ansible-lint](https://github.com/willthames/ansible-lint)
 * API Blueprint

--- a/test/command_callback/test_agda_agda_command_callbacks.vader
+++ b/test/command_callback/test_agda_agda_command_callbacks.vader
@@ -1,0 +1,28 @@
+Before:
+  call ale#assert#SetUpLinterTest('agda', 'agda')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The agda callbacks should return the correct default values):
+
+  " Test with supported version.
+  GivenCommandOutput ['2.5.1']
+  AssertLinter 'agda',
+  \ "echo 'IOTCM \"%t\" None Indirect (Cmd_load \"%t\" [])'"
+  \ . ' | ' . ale#Escape('agda') . ' --interaction'
+
+  " Test with unsupported version.
+  call ale#semver#ResetVersionCache()
+  GivenCommandOutput ['2.5.0']
+  AssertLinter 'agda', 0
+
+Execute(The agda executable should be configurable and it should be escaped):
+
+  call ale#semver#ResetVersionCache()
+  GivenCommandOutput ['2.5.1']
+
+  let g:ale_agda_agda_executable = 'foo bar'
+  AssertLinter 'foo bar',
+  \ "echo 'IOTCM \"%t\" None Indirect (Cmd_load \"%t\" [])'"
+  \ . ' | ' . ale#Escape('foo bar') . ' --interaction'

--- a/test/handler/test_agda_agda_handler.vader
+++ b/test/handler/test_agda_agda_handler.vader
@@ -1,0 +1,233 @@
+Before:
+  runtime ale_linters/agda/agda.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The agda handler for Agda should parse input correctly when get an error message):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 102,
+  \     'col': 2,
+  \     'end_col': 2,
+  \     'type': 'E',
+  \     'text': '/path/to/test.agda:102,2: Parse error _×_<ERROR>  (A B : Set) : Set where    ⟨_...',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2> (agda2-info-action \"*Error*\" \"/path/to/test.agda:102,2-2\\n/path/to/test.agda:102,2: Parse error\\n_×_<ERROR>\\n (A B : Set) : Set where\\n\\n  ⟨_...\" nil)",
+  \   "((last . 3) . (agda2-maybe-goto '(\"/path/to/test.agda\" . 2230)))",
+  \   "(agda2-highlight-load-and-delete-action \"/path/to/tmp\")",
+  \   "(agda2-status-action \"\")",
+  \ ])
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 177,
+  \     'col': 21,
+  \     'end_col': 21,
+  \     'type': 'E',
+  \     'text': '/path/to/test.agda:177,21: expected sequence of bound identifiers }<ERROR>      ; from = λ{ }     ; from∘...',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2> (agda2-info-action \"*Error*\" \"/path/to/test.agda:177,21-21\\n/path/to/test.agda:177,21: expected sequence of bound identifiers\\n}<ERROR>\\n\\n    ; from = λ{ }\\n    ; from∘...\" nil)",
+  \   "((last . 3) . (agda2-maybe-goto '(\"/path/to/test.agda\" . 3635)))",
+  \   "(agda2-highlight-load-and-delete-action \"/path/to/tmp\")",
+  \   "(agda2-status-action \"\")",
+  \ ])
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 4,
+  \     'col': 6,
+  \     'end_col': 13,
+  \     'type': 'E',
+  \     'text': 'Multiple definitions of ℕ. Previous definition at /path/to/Nat.agda:8,6-9 when scope checking the declaration   data ℕ : Set',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking test (/path/to/test.agda).\\n\" t)",
+  \   "(agda2-info-action \"*Error*\" \"/path/to/test.agda:4,6-13\\nMultiple definitions of ℕ. Previous definition at\\n/path/to/Nat.agda:8,6-9\\nwhen scope checking the declaration\\n  data ℕ : Set\" nil)",
+  \   "((last . 3) . (agda2-maybe-goto '(\"/path/to/test.agda\" . 83)))",
+  \   "(agda2-highlight-load-and-delete-action \"/path/to/tmp\")",
+  \   "(agda2-status-action \"\")",
+  \   "Agda2>",
+  \ ])
+
+Execute(The agda handler for Agda should parse input correctly when get a warning message):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 159,
+  \     'col': 1,
+  \     'end_col': 163,
+  \     'type': 'W',
+  \     'text': 'The following names are declared but not accompanied by a definition: <-trans',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking relations (/path/to/test.agda).\\n\" t)",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*All Errors*\" \"/path/to/test.agda:159,1-163,10\\nThe following names are declared but not accompanied by a\\ndefinition: <-trans\\n\" nil)",
+  \   "((last . 1) . (agda2-goals-action '()))",
+  \   "Agda2>",
+  \ ])
+
+Execute(The agda handler for Agda should parse input correctly when get multiple messages):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 164,
+  \     'col': 1,
+  \     'end_col': 168,
+  \     'type': 'E',
+  \     'text': 'Multiple definitions of ≤-trans. Previous definition at /path/to/test.agda:43,1-8 when scope checking the declaration   ≤-trans : {m n p : ℕ} → m < n → n < p → m < p',
+  \   },
+  \   {
+  \     'lnum': 159,
+  \     'col': 1,
+  \     'end_col': 175,
+  \     'type': 'W',
+  \     'text': 'The following names are declared but not accompanied by a definition: <-trans, <-trans′',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking relations (/path/to/test.agda).\\n\" t)",
+  \   "(agda2-info-action \"*Error*\" \"———— Error —————————————————————————————————————————————————\\n/path/to/test.agda:164,1-168,10\\nMultiple definitions of ≤-trans. Previous definition at\\n/path/to/test.agda:43,1-8\\nwhen scope checking the declaration\\n  ≤-trans : {m n p : ℕ} → m < n → n < p → m < p\\n\\n———— Warning(s) ————————————————————————————————————————————\\n/path/to/test.agda:159,1-175,10\\nThe following names are declared but not accompanied by a\\ndefinition: <-trans, <-trans′\" nil)",
+  \   "((last . 3) . (agda2-maybe-goto '(\"/path/to/test.agda\" . 3499)))",
+  \   "(agda2-highlight-load-and-delete-action \"/path/to/tmp\")",
+  \   "(agda2-status-action \"\")",
+  \   "Agda2>",
+  \ ])
+
+Execute(The agda handler for Agda should parse input correctly when get goal messages):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 42,
+  \     'col': 45,
+  \     'end_col': 46,
+  \     'type': 'I',
+  \     'text': '',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking test (/path/to/test.agda).\\n\" t)",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*All Goals*\" \"_snd_23 : C  [ at /path/to/test.agda:42,45-46 ]\\n\" nil)",
+  \   "((last . 1) . (agda2-goals-action '()))",
+  \   "Agda2>",
+  \ ])
+
+  AssertEqual
+  \ [],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking irreflexive (/path/to/test.agda).\n\" t)",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*All Goals*\" \"?0 : ¬ n < n\n\" nil)",
+  \   "((last . 1) . (agda2-goals-action '(0)))",
+  \   "Agda2>",
+  \ ])
+
+Execute(The agda handler for Agda should parse input correctly when get goal and error messages):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 42,
+  \     'col': 45,
+  \     'end_col': 46,
+  \     'type': 'E',
+  \     'text': 'Failed to solve the following constraints:   _snd_23 (a = a) = c : C',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking test (/path/totest.agda).\\n\" t)",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*All Goals, Errors*\" \"_snd_23 : C  [ at /path/to/test.agda:42,45-46 ]\\n\\n———— Errors ————————————————————————————————————————————————\\nFailed to solve the following constraints:\\n  _snd_23 (a = a) = c : C\\n\" nil)",
+  \   "((last . 1) . (agda2-goals-action '()))",
+  \   "Agda2>",
+  \ ])
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 44,
+  \     'col': 14,
+  \     'end_col': 62,
+  \     'type': 'E',
+  \     'text': 'Unsolved constraints',
+  \   },
+  \   {
+  \     'lnum': 44,
+  \     'col': 14,
+  \     'end_col': 62,
+  \     'type': 'E',
+  \     'text': 'Unsolved constraints',
+  \   },
+  \   {
+  \     'lnum': 44,
+  \     'col': 14,
+  \     'end_col': 62,
+  \     'type': 'E',
+  \     'text': 'Unsolved constraints',
+  \   },
+  \   {
+  \     'lnum': 45,
+  \     'col': 16,
+  \     'end_col': 64,
+  \     'type': 'E',
+  \     'text': 'Unsolved constraints',
+  \   },
+  \   {
+  \     'lnum': 45,
+  \     'col': 16,
+  \     'end_col': 64,
+  \     'type': 'E',
+  \     'text': 'Unsolved constraints',
+  \   },
+  \   {
+  \     'lnum': 45,
+  \     'col': 16,
+  \     'end_col': 64,
+  \     'type': 'E',
+  \     'text': 'Unsolved constraints',
+  \   },
+  \ ],
+  \ ale_linters#agda#agda#Handle(0, [
+  \   "Agda2>",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*Type-checking*\" \"\" nil)",
+  \   "(agda2-highlight-clear)",
+  \   "(agda2-info-action \"*Type-checking*\" \"Checking test (/path/to/test.agda).\\n\" t)",
+  \   "(agda2-status-action \"\")",
+  \   "(agda2-info-action \"*All Goals, Errors*\" \"Sort _60  [ at /path/to/test.agda:44,14-62 ]\\n_61 : _60  [ at /path/to/test.agda:44,14-62 ]\\n_63 : _61  [ at /path/to/test.agda:44,14-62 ]\\nSort _66  [ at /path/to/test.agda:45,16-64 ]\\n_67 : _66  [ at /path/to/test.agda:45,16-64 ]\\n_69 : _67  [ at /path/to/test.agda:45,16-64 ]\\n\\n———— Errors ————————————————————————————————————————————————\\nUnsolved constraints\\n\" nil)",
+  \   "((last . 1) . (agda2-goals-action '()))",
+  \   "Agda2>",
+  \ ])


### PR DESCRIPTION
This PR adds `agda` linter for agda files.
This linter uses Agda compiler′s code loading feature by [`--interaction` mode](https://agda.readthedocs.io/en/latest/tools/command-line-options.html#cmdoption-interaction).

A related issue: #2080