### PR TITLE
Run ESLint fixer from project root, where possible

### DIFF
--- a/autoload/ale/fixers/eslint.vim
+++ b/autoload/ale/fixers/eslint.vim
@@ -53,7 +53,8 @@ function! ale#fixers#eslint#ApplyFixForVersion(buffer, version) abort
     " Use --fix-to-stdout with eslint_d
     if l:executable =~# 'eslint_d$' && ale#semver#GTE(a:version, [3, 19, 0])
         return {
-        \   'command': ale#node#Executable(a:buffer, l:executable)
+        \   'command': ale#handlers#eslint#GetCdString(a:buffer)
+        \       . ale#node#Executable(a:buffer, l:executable)
         \       . ale#Pad(l:options)
         \       . ' --stdin-filename %s --stdin --fix-to-stdout',
         \   'process_with': 'ale#fixers#eslint#ProcessEslintDOutput',
@@ -63,7 +64,8 @@ function! ale#fixers#eslint#ApplyFixForVersion(buffer, version) abort
     " 4.9.0 is the first version with --fix-dry-run
     if ale#semver#GTE(a:version, [4, 9, 0])
         return {
-        \   'command': ale#node#Executable(a:buffer, l:executable)
+        \   'command': ale#handlers#eslint#GetCdString(a:buffer)
+        \       . ale#node#Executable(a:buffer, l:executable)
         \       . ale#Pad(l:options)
         \       . ' --stdin-filename %s --stdin --fix-dry-run --format=json',
         \   'process_with': 'ale#fixers#eslint#ProcessFixDryRunOutput',
@@ -71,7 +73,8 @@ function! ale#fixers#eslint#ApplyFixForVersion(buffer, version) abort
     endif
 
     return {
-    \   'command': ale#node#Executable(a:buffer, l:executable)
+    \   'command': ale#handlers#eslint#GetCdString(a:buffer)
+    \       . ale#node#Executable(a:buffer, l:executable)
     \       . ale#Pad(l:options)
     \       . (!empty(l:config) ? ' -c ' . ale#Escape(l:config) : '')
     \       . ' --fix %t',

--- a/test/fixers/test_eslint_fixer_callback.vader
+++ b/test/fixers/test_eslint_fixer_callback.vader
@@ -13,7 +13,9 @@ Execute(The executable path should be correct):
   AssertFixer
   \ {
   \   'read_temporary_file': 1,
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' -c ' . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/.eslintrc.js'))
   \     . ' --fix %t',
@@ -150,7 +152,9 @@ Execute(The lower priority configuration file in a nested directory should be pr
   AssertFixer
   \ {
   \   'read_temporary_file': 1,
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' -c ' . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/subdir-with-config/.eslintrc'))
   \     . ' --fix %t',
@@ -164,7 +168,9 @@ Execute(--config in options should override configuration file detection for old
   AssertFixer
   \ {
   \   'read_temporary_file': 1,
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' --config /foo.cfg'
   \     . ' --fix %t',
@@ -175,7 +181,9 @@ Execute(--config in options should override configuration file detection for old
   AssertFixer
   \ {
   \   'read_temporary_file': 1,
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' -c /foo.cfg'
   \     . ' --fix %t',
@@ -187,7 +195,9 @@ Execute(package.json should be used as a last resort):
   AssertFixer
   \ {
   \   'read_temporary_file': 1,
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' -c ' . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/.eslintrc.js'))
   \     . ' --fix %t',
@@ -199,7 +209,8 @@ Execute(package.json should be used as a last resort):
   \ {
   \   'read_temporary_file': 1,
   \   'command':
-  \     ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/node_modules/.bin/eslint'))
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files'))
+  \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/node_modules/.bin/eslint'))
   \     . ' -c ' . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/package.json'))
   \     . ' --fix %t',
   \ }
@@ -214,7 +225,9 @@ Execute(The version check should be correct):
   \   . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \   . ' --version',
   \ {
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' --stdin-filename %s --stdin --fix-dry-run --format=json',
   \   'process_with': 'ale#fixers#eslint#ProcessFixDryRunOutput',
@@ -223,7 +236,9 @@ Execute(The version check should be correct):
 
   AssertFixer [
   \ {
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' --stdin-filename %s --stdin --fix-dry-run --format=json',
   \   'process_with': 'ale#fixers#eslint#ProcessFixDryRunOutput',
@@ -236,7 +251,9 @@ Execute(--fix-dry-run should be used for 4.9.0 and up):
   GivenCommandOutput ['4.9.0']
   AssertFixer
   \ {
-  \   'command': (has('win32') ? 'node.exe ' : '')
+  \   'command':
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app'))
+  \     . (has('win32') ? 'node.exe ' : '')
   \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
   \     . ' --stdin-filename %s --stdin --fix-dry-run --format=json',
   \   'process_with': 'ale#fixers#eslint#ProcessFixDryRunOutput',
@@ -249,7 +266,8 @@ Execute(--fix-to-stdout should be used for eslint_d):
   \ {
   \   'read_temporary_file': 1,
   \   'command':
-  \     ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'))
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d'))
+  \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'))
   \     . ' -c ' . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/package.json'))
   \     . ' --fix %t',
   \ }
@@ -260,7 +278,8 @@ Execute(--fix-to-stdout should be used for eslint_d):
   AssertFixer
   \ {
   \   'command':
-  \     ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'))
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d'))
+  \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'))
   \     . ' --stdin-filename %s --stdin --fix-to-stdout',
   \   'process_with': 'ale#fixers#eslint#ProcessEslintDOutput',
   \ }
@@ -270,7 +289,8 @@ Execute(--fix-to-stdout should be used for eslint_d):
   AssertFixer
   \ {
   \   'command':
-  \     ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'))
+  \     ale#path#CdString(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d'))
+  \     . ale#Escape(ale#path#Simplify(g:dir . '/../eslint-test-files/app-with-eslint-d/node_modules/.bin/eslint_d'))
   \     . ' --stdin-filename %s --stdin --fix-to-stdout',
   \   'process_with': 'ale#fixers#eslint#ProcessEslintDOutput',
   \ }


### PR DESCRIPTION
To match the ESLint linter, as changed in 9ee57d43 (#2937 - which I forgot to apply to the fixer, whoops).

Fixes: #3094
Closes: #3095

Thanks for considering,
Kevin

P.S. Sorry @hjwp for creating a competing PR.  I hadn't seen the issue+PR until I was preparing to submit this one and figured it might be useful since you hadn't updated the tests yet.  Feel free to continue working on it and/or incorporate changes from this one, if they are useful.  Either works for me.