### PR TITLE
Adds column number to the verilator verilog linter

### DIFF
--- a/ale_linters/verilog/verilator.vim
+++ b/ale_linters/verilog/verilator.vim
@@ -28,21 +28,30 @@ function! ale_linters#verilog#verilator#Handle(buffer, lines) abort
     " %Warning-UNDRIVEN: test.v:3: Signal is not driven: clk
     " %Warning-UNUSED: test.v:4: Signal is not used: dout
     " %Warning-BLKSEQ: test.v:10: Blocking assignments (=) in sequential (flop or latch) block; suggest delayed assignments (<=).
-    let l:pattern = '^%\(Warning\|Error\)[^:]*:\([^:]\+\):\(\d\+\): \(.\+\)$'
+    " Since version 4.032 (04/2020) verilator linter messages also contain the column number,
+    " and look like:
+    " %Error: /tmp/test.sv:3:1: syntax error, unexpected endmodule, expecting ';'
+    "
+    " to stay compatible with old versions of the tool, the column number is
+    " optional in the researched pattern
+    let l:pattern = '^%\(Warning\|Error\)[^:]*:\([^:]\+\):\(\d\+\):\(\d\+\)\?:\? \(.\+\)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:line = l:match[3] + 0
-        let l:type = l:match[1] is# 'Error' ? 'E' : 'W'
-        let l:text = l:match[4]
+        let l:item = {
+        \   'lnum': str2nr(l:match[3]),
+        \   'text': l:match[5],
+        \   'type': l:match[1] is# 'Error' ? 'E' : 'W',
+        \}
+
+        if !empty(l:match[4])
+            let l:item.col = str2nr(l:match[4])
+        endif
+
         let l:file = l:match[2]
 
         if l:file =~# '_verilator_linted.v'
-            call add(l:output, {
-            \   'lnum': l:line,
-            \   'text': l:text,
-            \   'type': l:type,
-            \})
+            call add(l:output, l:item)
         endif
     endfor
 

--- a/test/handler/test_verilator_handler.vader
+++ b/test/handler/test_verilator_handler.vader
@@ -1,0 +1,48 @@
+Before:
+  runtime ale_linters/verilog/verilator.vim
+
+After:
+  call ale#linter#Reset()
+
+
+Execute (The verilator handler should parse legacy messages with only line numbers):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'type': 'E',
+  \     'text': 'syntax error, unexpected IDENTIFIER'
+  \   },
+  \   {
+  \     'lnum': 10,
+  \     'type': 'W',
+  \     'text': 'Blocking assignments (=) in sequential (flop or latch) block; suggest delayed assignments (<=).'
+  \   },
+  \ ],
+  \ ale_linters#verilog#verilator#Handle(bufnr(''), [
+  \ '%Error: foo_verilator_linted.v:3: syntax error, unexpected IDENTIFIER',
+  \ '%Warning-BLKSEQ: bar_verilator_linted.v:10: Blocking assignments (=) in sequential (flop or latch) block; suggest delayed assignments (<=).',
+  \ ])
+
+
+Execute (The verilator handler should parse new format messages with line and column numbers):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'col' : 1,
+  \     'type': 'E',
+  \     'text': 'syntax error, unexpected endmodule, expecting ;'
+  \   },
+  \   {
+  \     'lnum': 4,
+  \     'col' : 6,
+  \     'type': 'W',
+  \     'text': 'Signal is not used: r'
+  \   },
+  \ ],
+  \ ale_linters#verilog#verilator#Handle(bufnr(''), [
+  \ '%Error: bar_verilator_linted.v:3:1: syntax error, unexpected endmodule, expecting ;',
+  \ '%Warning-UNUSED: foo_verilator_linted.v:4:6: Signal is not used: r',
+  \ ])
+


### PR DESCRIPTION
Since version 4.032 (04/2020) verilator linter messages also contain the
column number, and look like:

%Error: /tmp/test.sv:3:1: syntax error, unexpected endmodule, expecting ';'

To stay compatible with old versions of the tool, the column number is
optional in the researched pattern regular expression.

See commit:
https://github.com/verilator/verilator/commit/81c659957e89f28861fde870f000cce2d5f76729
