### PR TITLE
Elixir Mix Format: Execute in Mix project root

### DIFF
--- a/autoload/ale/fixers/mix_format.vim
+++ b/autoload/ale/fixers/mix_format.vim
@@ -9,10 +9,13 @@ function! ale#fixers#mix_format#GetExecutable(buffer) abort
 endfunction
 
 function! ale#fixers#mix_format#GetCommand(buffer) abort
+    let l:project_root = ale#handlers#elixir#FindMixUmbrellaRoot(a:buffer)
     let l:executable = ale#Escape(ale#fixers#mix_format#GetExecutable(a:buffer))
     let l:options = ale#Var(a:buffer, 'elixir_mix_format_options')
 
-    return l:executable . ' format'
+    return ale#path#CdString(l:project_root)
+    \   . l:executable
+    \   . ' format'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' %t'
 endfunction

--- a/test/fixers/test_mix_format_fixer_callback.vader
+++ b/test/fixers/test_mix_format_fixer_callback.vader
@@ -18,7 +18,7 @@ Execute(The mix_format callback should return the correct default values):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': 'cd ''.'' && '
+  \   'command': ale#path#CdString('.')
   \     . ale#Escape('xxxinvalid')
   \     . ' format %t',
   \ },
@@ -31,7 +31,7 @@ Execute(The mix_format callback should include the correct format options):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': 'cd ''.'' && '
+  \   'command': ale#path#CdString('.')
   \     . ale#Escape('xxxinvalid')
   \     . ' format invalid_options %t',
   \ },

--- a/test/fixers/test_mix_format_fixer_callback.vader
+++ b/test/fixers/test_mix_format_fixer_callback.vader
@@ -18,7 +18,8 @@ Execute(The mix_format callback should return the correct default values):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
+  \   'command': 'cd ''.'' && '
+  \     . ale#Escape('xxxinvalid')
   \     . ' format %t',
   \ },
   \ ale#fixers#mix_format#Fix(bufnr(''))
@@ -30,7 +31,8 @@ Execute(The mix_format callback should include the correct format options):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
+  \   'command': 'cd ''.'' && '
+  \     . ale#Escape('xxxinvalid')
   \     . ' format invalid_options %t',
   \ },
   \ ale#fixers#mix_format#Fix(bufnr(''))


### PR DESCRIPTION
This PR improves the experience of using the `mix_format` fixer for Elixir by ensuring execution the `mix format` command in the root of the Mix project. This change guarantees that `mix format` will read the `.formatter.exs` file if present.

This implementation is how the [official documentation](https://hexdocs.pm/mix/Mix.Tasks.Format.html#module-when-to-format-code) suggests integrating `mix format` with editors.