### PR TITLE
Add stdin option for supported vint versions

### DIFF
--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -13,12 +13,17 @@ function! ale_linters#vim#vint#GetCommand(buffer, version) abort
 
     let l:warning_flag = ale#Var(a:buffer, 'vim_vint_show_style_issues') ? '-s' : '-w'
 
+    " Use the --stdin-display-name argument if supported, temp file otherwise.
+    let l:stdin_or_temp = ale#semver#GTE(a:version, [0, 4, 0])
+    \   ? ' --stdin-display-name %s -'
+    \   : ' %t'
+
     return '%e'
     \   . ' ' . l:warning_flag
     \   . (l:can_use_no_color_flag ? ' --no-color' : '')
     \   . s:enable_neovim
     \   . ' ' . s:format
-    \   . ' %t'
+    \   . l:stdin_or_temp
 endfunction
 
 let s:word_regex_list = [


### PR DESCRIPTION
Fixes #2935

The full release of vint 0.4 isn't out yet, but the alpha is available and usable with added `--stdin-display-name` support (which will solve https://github.com/dense-analysis/ale/issues/2935). This PR switches to using stdin for these versions of vint and (theoretically) the 0.4.0+ release.

- If you want to hold off until the full release to merge, I get it.
- A test would just be testing whether the conditional is written correctly, but let me know if you want me to chuck it in anyway.