### PR TITLE
Add per-language options to Uncrustify fixer

### DIFF
--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -1,50 +1,50 @@
 " Author: Derek P Sifford <dereksifford@gmail.com>
 " Description: Fixer for C, C++, C#, ObjectiveC, D, Java, Pawn, and VALA.
 
-call ale#Set('uncrustify_per_type', 0)
-call ale#Set('uncrustify_force_filetype', 0)
+call ale#Set('uncrustify_vim_filetype', 1)
 call ale#Set('uncrustify_global_options', '')
 call ale#Set('uncrustify_executable', 'uncrustify')
+call ale#Set('uncrustify_c_options', '')
+call ale#Set('uncrustify_cpp_options', '')
+call ale#Set('uncrustify_cs_options', '')
+call ale#Set('uncrustify_objc_options', '')
+call ale#Set('uncrustify_d_options', '')
+call ale#Set('uncrustify_java_options', '')
+call ale#Set('uncrustify_pawn_options', '')
+call ale#Set('uncrustify_vala_options', '')
+call ale#Set('c_uncrustify_executable', '')
 call ale#Set('c_uncrustify_options', '')
-call ale#Set('cpp_uncrustify_options', '')
-call ale#Set('cs_uncrustify_options', '')
-call ale#Set('objc_uncrustify_options', '')
-call ale#Set('d_uncrustify_options', '')
-call ale#Set('java_uncrustify_options', '')
-call ale#Set('pawn_uncrustify_options', '')
-call ale#Set('vala_uncrustify_options', '')
 
 function! ale#fixers#uncrustify#Fix(buffer) abort
+    let l:uncrustify_filetype_names = {'c': 'C', 'cpp': 'CPP', 'd': 'D', 'cs': 'CS', 'java': 'JAVA', 'pawn': 'PAWN', 'objc': 'OC', 'objcpp': 'OCP', 'vala': 'VALA'}
     let l:executable = ale#Var(a:buffer, 'uncrustify_executable')
-    let ft = getbufvar(a:buffer, '&filetype')
-    if empty(ft)
-        let ft_options = ''
-    else
-        let ft_options = ale#Var(a:buffer, ft . '_uncrustify_options')
-endif
-    let all_options = ale#Var(a:buffer, 'uncrustify_global_options')
 
-    if !ale#Var(a:buffer, 'uncrustify_per_type')
-        let ft_options = ''
-        " For backwards compatibility, use C options if
-        " all_options is empty and not using per_type
-        if empty(all_options)
-            let all_options = ale#Var(a:buffer, 'c_uncrustify_options')
+    if l:executable is? 'uncrustify'
+        let l:backward_compat_executable = ale#Var(a:buffer, 'c_uncrustify_executable')
+
+        if !empty(l:backward_compat_executable)
+            let l:executable = l:backward_compat_executable
         endif
     endif
 
-    if empty(all_options)
-        let l:options = ft_options
-    elseif empty(ft_options)
-        let l:options = all_options
-    else
-        "Put ft_options before all_options since uncrustify uses the first
-        "occurrence of each flag
-        let l:options = ft_options . ' ' . all_options
+    let l:ft = getbufvar(a:buffer, '&filetype')
+    let l:global_options = ale#Var(a:buffer, 'uncrustify_global_options')
+
+    try
+        let l:options = ale#Var(a:buffer, 'uncrustify_' . l:ft . '_options')
+        " Pass filetype before global options since uncrustify uses the first occurrence of each flag
+        let l:options = l:options . (empty(l:global_options) || empty(l:options) ? '' : ' ') . l:global_options
+    catch
+        let l:options = l:global_options
+    endtry
+
+    " If no options provided, try using C options for backward compatibility
+    if empty(l:options)
+        let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
     endif
 
-    if ale#Var(a:buffer, 'uncrustify_force_filetype')
-        let l:options = '-l ' . ft . (empty(l:options) ? '' : ' ' . l:options)
+    if ale#Var(a:buffer, 'uncrustify_vim_filetype') && has_key(l:uncrustify_filetype_names, l:ft)
+        let l:options = '-l ' . l:uncrustify_filetype_names[l:ft] . (empty(l:options) ? '' : ' ' . l:options)
     endif
 
     return {

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -1,4 +1,5 @@
-" Author: Derek P Sifford <dereksifford@gmail.com>
+" Author: Derek P Sifford <dereksifford@gmail.com>,
+"         Alexander French <afrench17@gmail.com>
 " Description: Fixer for C, C++, C#, ObjectiveC, D, Java, Pawn, and VALA.
 
 call ale#Set('uncrustify_vim_filetype', 1)
@@ -16,7 +17,7 @@ call ale#Set('c_uncrustify_executable', '')
 call ale#Set('c_uncrustify_options', '')
 
 function! ale#fixers#uncrustify#Fix(buffer) abort
-    let l:uncrustify_filetype_names = {'c': 'C', 'cpp': 'CPP', 'd': 'D', 'cs': 'CS', 'java': 'JAVA', 'pawn': 'PAWN', 'objc': 'OC', 'objcpp': 'OCP', 'vala': 'VALA'}
+    let l:uncrustify_filetype_names = {'c': 'C', 'cpp': 'CPP', 'd': 'D', 'cs': 'CS', 'java': 'JAVA', 'pawn': 'PAWN', 'objc': 'OC', 'vala': 'VALA'}
     let l:executable = ale#Var(a:buffer, 'uncrustify_executable')
 
     if l:executable is? 'uncrustify'
@@ -30,21 +31,23 @@ function! ale#fixers#uncrustify#Fix(buffer) abort
     let l:ft = getbufvar(a:buffer, '&filetype')
     let l:global_options = ale#Var(a:buffer, 'uncrustify_global_options')
 
-    try
+    if has_key(l:uncrustify_filetype_names, l:ft)
         let l:options = ale#Var(a:buffer, 'uncrustify_' . l:ft . '_options')
         " Pass filetype before global options since uncrustify uses the first occurrence of each flag
         let l:options = l:options . (empty(l:global_options) || empty(l:options) ? '' : ' ') . l:global_options
-    catch
-        let l:options = l:global_options
-    endtry
 
-    " If no options provided, try using C options for backward compatibility
-    if empty(l:options)
-        let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
-    endif
+        " Support deprecated global options variable
+        if empty(l:options)
+            let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
+        endif
 
-    if ale#Var(a:buffer, 'uncrustify_vim_filetype') && has_key(l:uncrustify_filetype_names, l:ft)
-        let l:options = '-l ' . l:uncrustify_filetype_names[l:ft] . (empty(l:options) ? '' : ' ' . l:options)
+        " Put vim filetype before other options since uncrustify uses the first occurence of each flag
+        if ale#Var(a:buffer, 'uncrustify_vim_filetype')
+            let l:options = '-l ' . l:uncrustify_filetype_names[l:ft] . (empty(l:options) ? '' : ' ' . l:options)
+        endif
+    else
+        " Use just global options if filetype is unknown, supporting deprecated global options variable
+        let l:options = empty(l:global_options) ? ale#Var(a:buffer, 'c_uncrustify_options') : l:global_options
     endif
 
     return {

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -2,11 +2,25 @@
 " Description: Fixer for C, C++, C#, ObjectiveC, D, Java, Pawn, and VALA.
 
 call ale#Set('c_uncrustify_executable', 'uncrustify')
+call ale#Set('all_uncrustify_options', '')
 call ale#Set('c_uncrustify_options', '')
+call ale#Set('cpp_uncrustify_options', '')
+call ale#Set('cs_uncrustify_options', '')
+call ale#Set('objc_uncrustify_options', '')
+call ale#Set('d_uncrustify_options', '')
+call ale#Set('java_uncrustify_options', '')
+call ale#Set('pawn_uncrustify_options', '')
+call ale#Set('vala_uncrustify_options', '')
 
 function! ale#fixers#uncrustify#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'c_uncrustify_executable')
-    let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
+    let ft_options = ale#Var(a:buffer, getbufvar(a:buffer, '&filetype') . '_uncrustify_options')
+    let all_options = ale#Var(a:buffer, 'all_uncrustify_options')
+    if empty(all_options)
+        let l:options = ft_options
+    else
+        let l:options = all_options . ' ' . ft_options
+    endif
 
     return {
     \   'command': ale#Escape(l:executable)

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -15,15 +15,22 @@ call ale#Set('pawn_uncrustify_options', '')
 call ale#Set('vala_uncrustify_options', '')
 
 function! ale#fixers#uncrustify#Fix(buffer) abort
-    let l:executable = ale#Var(a:buffer, 'c_uncrustify_executable')
+    let l:executable = ale#Var(a:buffer, 'uncrustify_executable')
     let ft = getbufvar(a:buffer, '&filetype')
-    let ft_options = ale#Var(a:buffer, ft . '_uncrustify_options')
-    let all_options = ale#Var(a:buffer, 'c_uncrustify_global_options')
+    if empty(ft)
+        let ft_options = ''
+    else
+        let ft_options = ale#Var(a:buffer, ft . '_uncrustify_options')
+endif
+    let all_options = ale#Var(a:buffer, 'uncrustify_global_options')
 
-    " For backwards compatibility, use C options if
-    " all_options is empty and not using per_type
-    if !ale#Var('uncrustify_per_type') && empty(all_options)
-        let ft = 'c'
+    if !ale#Var(a:buffer, 'uncrustify_per_type')
+        let ft_options = ''
+        " For backwards compatibility, use C options if
+        " all_options is empty and not using per_type
+        if empty(all_options)
+            let all_options = ale#Var(a:buffer, 'c_uncrustify_options')
+        endif
     endif
 
     if empty(all_options)
@@ -43,6 +50,6 @@ function! ale#fixers#uncrustify#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' --no-backup'
-    \       . ale#Escape(empty(l:options) ? '' : ' ' . l:options)
+    \       . (empty(l:options) ? '' : ' ' . ale#Escape(l:options))
     \}
 endfunction

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -3,9 +3,7 @@
 
 call ale#Set('c_uncrustify_executable', 'uncrustify')
 call ale#Set('c_uncrustify_force_filetype', 0)
-call ale#Set('c_uncrustify_options', '')
-call ale#Set('cpp_uncrustify_options', '')
-call ale#Set('cs_global_uncrustify_options', '')
+call ale#Set('c_uncrustify_global_options', '')
 call ale#Set('c_uncrustify_options', '')
 call ale#Set('cpp_uncrustify_options', '')
 call ale#Set('cs_uncrustify_options', '')
@@ -33,7 +31,7 @@ function! ale#fixers#uncrustify#Fix(buffer) abort
     endif
 
     if ale#Var(a:buffer, 'c_uncrustify_force_filetype')
-        l:options = '-l ' . ft . (empty(l:options) ? '' : ' ' . l:options)
+        let l:options = '-l ' . ft . (empty(l:options) ? '' : ' ' . l:options)
     endif
 
     return {

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -1,9 +1,10 @@
 " Author: Derek P Sifford <dereksifford@gmail.com>
 " Description: Fixer for C, C++, C#, ObjectiveC, D, Java, Pawn, and VALA.
 
-call ale#Set('c_uncrustify_executable', 'uncrustify')
-call ale#Set('c_uncrustify_force_filetype', 0)
-call ale#Set('c_uncrustify_global_options', '')
+call ale#Set('uncrustify_per_type', 0)
+call ale#Set('uncrustify_force_filetype', 0)
+call ale#Set('uncrustify_global_options', '')
+call ale#Set('uncrustify_executable', 'uncrustify')
 call ale#Set('c_uncrustify_options', '')
 call ale#Set('cpp_uncrustify_options', '')
 call ale#Set('cs_uncrustify_options', '')
@@ -18,25 +19,30 @@ function! ale#fixers#uncrustify#Fix(buffer) abort
     let ft = getbufvar(a:buffer, '&filetype')
     let ft_options = ale#Var(a:buffer, ft . '_uncrustify_options')
     let all_options = ale#Var(a:buffer, 'c_uncrustify_global_options')
-    let l:options = ft_options
 
-    "Put ft_options before all_options since uncrustify uses the first
-    "occurrence of each flag
-    if empty(ft_options)
+    " For backwards compatibility, use C options if
+    " all_options is empty and not using per_type
+    if !ale#Var('uncrustify_per_type') && empty(all_options)
+        let ft = 'c'
+    endif
+
+    if empty(all_options)
+        let l:options = ft_options
+    elseif empty(ft_options)
         let l:options = all_options
-    elseif empty(all_options)
-        let l:options = ''
     else
+        "Put ft_options before all_options since uncrustify uses the first
+        "occurrence of each flag
         let l:options = ft_options . ' ' . all_options
     endif
 
-    if ale#Var(a:buffer, 'c_uncrustify_force_filetype')
+    if ale#Var(a:buffer, 'uncrustify_force_filetype')
         let l:options = '-l ' . ft . (empty(l:options) ? '' : ' ' . l:options)
     endif
 
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' --no-backup'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ale#Escape(empty(l:options) ? '' : ' ' . l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -2,7 +2,10 @@
 " Description: Fixer for C, C++, C#, ObjectiveC, D, Java, Pawn, and VALA.
 
 call ale#Set('c_uncrustify_executable', 'uncrustify')
-call ale#Set('all_uncrustify_options', '')
+call ale#Set('c_uncrustify_force_filetype', 0)
+call ale#Set('c_uncrustify_options', '')
+call ale#Set('cpp_uncrustify_options', '')
+call ale#Set('cs_global_uncrustify_options', '')
 call ale#Set('c_uncrustify_options', '')
 call ale#Set('cpp_uncrustify_options', '')
 call ale#Set('cs_uncrustify_options', '')
@@ -14,12 +17,23 @@ call ale#Set('vala_uncrustify_options', '')
 
 function! ale#fixers#uncrustify#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'c_uncrustify_executable')
-    let ft_options = ale#Var(a:buffer, getbufvar(a:buffer, '&filetype') . '_uncrustify_options')
-    let all_options = ale#Var(a:buffer, 'all_uncrustify_options')
-    if empty(all_options)
-        let l:options = ft_options
+    let ft = getbufvar(a:buffer, '&filetype')
+    let ft_options = ale#Var(a:buffer, ft . '_uncrustify_options')
+    let all_options = ale#Var(a:buffer, 'c_uncrustify_global_options')
+    let l:options = ft_options
+
+    "Put ft_options before all_options since uncrustify uses the first
+    "occurrence of each flag
+    if empty(ft_options)
+        let l:options = all_options
+    elseif empty(all_options)
+        let l:options = ''
     else
-        let l:options = all_options . ' ' . ft_options
+        let l:options = ft_options . ' ' . all_options
+    endif
+
+    if ale#Var(a:buffer, 'c_uncrustify_force_filetype')
+        l:options = '-l ' . ft . (empty(l:options) ? '' : ' ' . l:options)
     endif
 
     return {

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -282,15 +282,13 @@ g:ale_c_gcc_options                                       *g:ale_c_gcc_options*
 ===============================================================================
 uncrustify                                                   *ale-c-uncrustify*
 
-g:ale_c_uncrustify_options                         *g:ale_c_uncrustify_options*
-                                                   *b:ale_c_uncrustify_options*
+g:ale_uncrustify_c_options                         *g:ale_uncrustify_c_options*
+                                                   *b:ale_uncrustify_c_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for C
-  files. |g:ale_uncrustify_per_type| must be enabled for this to take effect.
-  If |g:ale_uncrustify_per_type| is 0 and |g:ale_uncrustify_global_options| is
-  empty, then this option is used for all filetypes instead of just C files.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -289,13 +289,31 @@ g:ale_c_uncrustify_executable                   *g:ale_c_uncrustify_executable*
 
   This variable can be changed to use a different executable for uncrustify.
 
+g:ale_c_uncrustify_force_filetype           *g:ale_c_uncrustify_force_filetype*
+                                            *b:ale_c_uncrustify_force_filetype*
+  Type: |Number|
+  Default: `0`
+
+  This variable can be changed to force uncrustify to parse files as the
+  filetype reported in Vim.
+
+
+g:ale_c_uncrustify_global_options           *g:ale_c_uncrustify_global_options*
+                                            *b:ale_c_uncrustify_force_filetype*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to uncrustify for
+  files of any type. Per-language options override these options.
+
 
 g:ale_c_uncrustify_options                         *g:ale_c_uncrustify_options*
                                                    *b:ale_c_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify.
+  This variable can be changed to modify flags given to uncrustify for C
+  files.
 
 
 ===============================================================================

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -282,38 +282,18 @@ g:ale_c_gcc_options                                       *g:ale_c_gcc_options*
 ===============================================================================
 uncrustify                                                   *ale-c-uncrustify*
 
-g:ale_c_uncrustify_executable                   *g:ale_c_uncrustify_executable*
-                                                *b:ale_c_uncrustify_executable*
-  Type: |String|
-  Default: `'uncrustify'`
-
-  This variable can be changed to use a different executable for uncrustify.
-
-g:ale_c_uncrustify_force_filetype           *g:ale_c_uncrustify_force_filetype*
-                                            *b:ale_c_uncrustify_force_filetype*
-  Type: |Number|
-  Default: `0`
-
-  This variable can be changed to force uncrustify to parse files as the
-  filetype reported in Vim.
-
-
-g:ale_c_uncrustify_global_options           *g:ale_c_uncrustify_global_options*
-                                            *b:ale_c_uncrustify_force_filetype*
-  Type: |String|
-  Default: `''`
-
-  This variable can be changed to modify flags given to uncrustify for
-  files of any type. Per-language options override these options.
-
-
 g:ale_c_uncrustify_options                         *g:ale_c_uncrustify_options*
                                                    *b:ale_c_uncrustify_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for C
-  files.
+  files. |g:ale_uncrustify_per_type| must be enabled for this to take effect.
+  If |g:ale_uncrustify_per_type| is 0 and |g:ale_uncrustify_global_options| is
+  empty, then this option is used for all filetypes instead of just C files.
+
+
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -291,15 +291,15 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 
 
 ===============================================================================
-uncrustify                                                 *ale-cpp-uncrustify*
+uncrustify                                                  *ale-cpp-uncrustify*
 
-g:ale_cpp_uncrustify_options                    *g:ale_cpp_uncrustify_options*
-                                                *b:ale_cpp_uncrustify_options*
+g:ale_uncrustify_cpp_options                     *g:ale_uncrustify_cpp_options*
+                                                 *b:ale_uncrustify_cpp_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for C++
-  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take effect.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -293,7 +293,16 @@ g:ale_cpp_gcc_options                                   *g:ale_cpp_gcc_options*
 ===============================================================================
 uncrustify                                                 *ale-cpp-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_cpp_uncrustify_options                    *g:ale_cpp_uncrustify_options*
+                                                *b:ale_cpp_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for C++
+  files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -298,11 +298,11 @@ g:ale_cpp_uncrustify_options                    *g:ale_cpp_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for C++
-  files.
+  This variable can be changed to modify flags given to uncrustify for C++
+  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -190,14 +190,13 @@ g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
 ===============================================================================
 uncrustify                                                  *ale-cs-uncrustify*
 
-g:ale_cs_uncrustify_options                       *g:ale_cs_uncrustify_options*
-                                                  *b:ale_cs_uncrustify_options*
+g:ale_uncrustify_cs_options                       *g:ale_uncrustify_cs_options*
+                                                  *b:ale_uncrustify_cs_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for C#
-  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take
-  effect.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -190,7 +190,16 @@ g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
 ===============================================================================
 uncrustify                                                  *ale-cs-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_cs_uncrustify_options                       *g:ale_cs_uncrustify_options*
+                                                  *b:ale_cs_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for C#
+  files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -195,11 +195,12 @@ g:ale_cs_uncrustify_options                       *g:ale_cs_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for C#
-  files.
+  This variable can be changed to modify flags given to uncrustify for C#
+  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take
+  effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-d.txt
+++ b/doc/ale-d.txt
@@ -25,7 +25,16 @@ See |ale-integrations-local-executables|
 ===============================================================================
 uncrustify                                                   *ale-d-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_d_uncrustify_options                         *g:ale_d_uncrustify_options*
+                                                   *b:ale_d_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for D
+  files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-d.txt
+++ b/doc/ale-d.txt
@@ -25,13 +25,13 @@ See |ale-integrations-local-executables|
 ===============================================================================
 uncrustify                                                   *ale-d-uncrustify*
 
-g:ale_d_uncrustify_options                         *g:ale_d_uncrustify_options*
-                                                   *b:ale_d_uncrustify_options*
+g:ale_uncrustify_d_options                         *g:ale_uncrustify_d_options*
+                                                   *b:ale_uncrustify_d_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for D
-  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take effect.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-d.txt
+++ b/doc/ale-d.txt
@@ -30,11 +30,11 @@ g:ale_d_uncrustify_options                         *g:ale_d_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for D
-  files.
+  This variable can be changed to modify flags given to uncrustify for D
+  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -226,16 +226,16 @@ g:ale_java_eclipselsp_workspace_path     *g:ale_java_eclipselsp_workspace_path*
 ===============================================================================
 uncrustify                                                *ale-java-uncrustify*
 
-g:ale_java_uncrustify_options                   *g:ale_java_uncrustify_options*
+g:ale_java_uncrustify_options                    *g:ale_java_uncrustify_options*
                                                 *b:ale_java_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for Java
-  files.
+  This variable can be changed to modify flags given to uncrustify for Java
+  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -226,13 +226,13 @@ g:ale_java_eclipselsp_workspace_path     *g:ale_java_eclipselsp_workspace_path*
 ===============================================================================
 uncrustify                                                *ale-java-uncrustify*
 
-g:ale_java_uncrustify_options                    *g:ale_java_uncrustify_options*
-                                                *b:ale_java_uncrustify_options*
+g:ale_uncrustify_java_options                    *g:ale_uncrustify_java_options*
+                                                *b:ale_uncrustify_java_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for Java
-  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take effect.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-java.txt
+++ b/doc/ale-java.txt
@@ -226,7 +226,16 @@ g:ale_java_eclipselsp_workspace_path     *g:ale_java_eclipselsp_workspace_path*
 ===============================================================================
 uncrustify                                                *ale-java-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_java_uncrustify_options                   *g:ale_java_uncrustify_options*
+                                                *b:ale_java_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for Java
+  files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-objc.txt
+++ b/doc/ale-objc.txt
@@ -40,11 +40,12 @@ g:ale_objc_uncrustify_options                   *g:ale_objc_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for
-  Objective-C files.
+  This variable can be changed to modify flags given to uncrustify for
+  Objective-C files. Note: |g:ale_uncrustify_per_type| must be enabled for this
+  to take effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-objc.txt
+++ b/doc/ale-objc.txt
@@ -35,14 +35,13 @@ g:ale_objc_clangd_options                           *g:ale_objc_clangd_options*
 ===============================================================================
 uncrustify                                                *ale-objc-uncrustify*
 
-g:ale_objc_uncrustify_options                   *g:ale_objc_uncrustify_options*
-                                                *b:ale_objc_uncrustify_options*
+g:ale_uncrustify_objc_options                   *g:ale_uncrustify_objc_options*
+                                                *b:ale_uncrustify_objc_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for
-  Objective-C files. Note: |g:ale_uncrustify_per_type| must be enabled for this
-  to take effect.
+  Objective-C files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-objc.txt
+++ b/doc/ale-objc.txt
@@ -35,7 +35,16 @@ g:ale_objc_clangd_options                           *g:ale_objc_clangd_options*
 ===============================================================================
 uncrustify                                                *ale-objc-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_objc_uncrustify_options                   *g:ale_objc_uncrustify_options*
+                                                *b:ale_objc_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for
+  Objective-C files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-pawn.txt
+++ b/doc/ale-pawn.txt
@@ -10,11 +10,12 @@ g:ale_pawn_uncrustify_options                   *g:ale_pawn_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for Pawn
-  files.
+  This variable can be changed to modify flags given to uncrustify for Pawn
+  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to
+  take effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-pawn.txt
+++ b/doc/ale-pawn.txt
@@ -5,7 +5,16 @@ ALE Pawn Integration                                         *ale-pawn-options*
 ===============================================================================
 uncrustify                                                *ale-pawn-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_pawn_uncrustify_options                   *g:ale_pawn_uncrustify_options*
+                                                *b:ale_pawn_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for Pawn
+  files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-pawn.txt
+++ b/doc/ale-pawn.txt
@@ -5,14 +5,13 @@ ALE Pawn Integration                                         *ale-pawn-options*
 ===============================================================================
 uncrustify                                                *ale-pawn-uncrustify*
 
-g:ale_pawn_uncrustify_options                   *g:ale_pawn_uncrustify_options*
-                                                *b:ale_pawn_uncrustify_options*
+g:ale_uncrustify_pawn_options                   *g:ale_uncrustify_pawn_options*
+                                                *b:ale_uncrustify_pawn_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for Pawn
-  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to
-  take effect.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/doc/ale-uncrustify.txt
+++ b/doc/ale-uncrustify.txt
@@ -36,7 +36,7 @@ g:ale_uncrustify_vim_filetype                    *g:ale_uncrustify_vim_filetype*
 Language options                                        *ale-uncrustify-language*
 
 
-Options can be set for individual languages. When a file of from one of those
+Options can be set for individual languages. When a file from one of those
 languages is opened, the individual language options are passed to Uncrustify.
 Options for the current filetype will override any global options.
 Currently the supported language-specific options are

--- a/doc/ale-uncrustify.txt
+++ b/doc/ale-uncrustify.txt
@@ -18,7 +18,7 @@ g:ale_uncrustify_global_options                  *g:ale_uncrustify_global_option
   Default: `''`
 
   Options that are used for all languages. Language-specific options override
-  these (they are passed to Uncrustify before global options). Note: langauge
+  these (they are passed to Uncrustify before global options). Note: language
   options override any options in |g:ale_uncrustify_global_options|.
 
 

--- a/doc/ale-uncrustify.txt
+++ b/doc/ale-uncrustify.txt
@@ -1,18 +1,8 @@
 ===============================================================================
-ALE Uncrustify Integration                               *ale-uncrustify-options*
-
-
-===============================================================================
-When using Uncrustify, ALE can either use the same options for all filetypes
-or different options for each filetype.
-
-For per-filetype options, after setting |g:ale_uncrustify_per_type| to 1,
-use g:ale_lang_uncrustify_options where "lang" is one of "c", "cpp", "cs",
-"objc", "d", "java", "pawn", or "vala".
-
+ALE Uncrustify Integration                                       *ale-uncrustify*
 
 ===============================================================================
-uncrustify                                                       *ale-uncrustify*
+Global options                                            *ale-uncrustify-global*
 
 g:ale_uncrustify_executable                         *g:ale_uncrustify_executable*
                                                    *b:ale_uncrustify_executable*
@@ -22,41 +12,66 @@ g:ale_uncrustify_executable                         *g:ale_uncrustify_executable
   This variable can be changed to use a different executable for Uncrustify.
 
 
-g:ale_uncrustify_per_type                              *g:ale_uncrustify_per_type*
-                                                      *b:ale_uncrustify_per_type*
-  Type: |Number|
-  Default: `0`
-
-  If 1 then different options are passed to Uncrustify depending on the type
-  of file being edited. To set individual language options, use
-  "g:ale_lang_uncrustify_options" where "lang" is one of "c", "cpp", "cs",
-  "objc", "d", "java", "pawn", or "vala". For example
-  |g:ale_c_uncrustify_options|.
-
-  If 0 then |g:ale_uncrustify_global_options| are always passed to Uncrustify
-  and the "g:ale_lang_uncrustify_options" are ignored for all "lang'. Note: for
-  backward compatibility, if this is 0 and |g_ale_uncrustify_global_options| is
-  not set then |g:ale_c_uncrustify_options| are always passed instead.
-
-
 g:ale_uncrustify_global_options                  *g:ale_uncrustify_global_options*
                                                 *b:ale_uncrustify_global_options*
   Type: |String|
   Default: `''`
 
   Options that are used for all languages. Language-specific options override
-  these (they are passed to Uncrustify before global options).
+  these (they are passed to Uncrustify before global options). Note: langauge
+  options override any options in |g:ale_uncrustify_global_options|.
 
 
-g:ale_uncrustify_force_filetype                  *g:ale_uncrustify_force_filetype*
-                                                *b:ale_uncrustify_force_filetype*
+g:ale_uncrustify_vim_filetype                    *g:ale_uncrustify_vim_filetype*
+                                                *b:ale_uncrustify_vim_filetype*
   Type: |Number|
   Default: `0`
 
   If 1 then the language that vim detects for the filetype is passed to
   Uncrustify explicitly. This overrides any language setting in
-  |g:ale_uncrustify_global_options| or "g:ale_lang_uncrustify_options" for any
-  "lang".
+  |g:ale_uncrustify_global_options| or any language options
+
+
+===============================================================================
+Language options                                        *ale-uncrustify-language*
+
+
+Options can be set for individual languages. When a file of from one of those
+languages is opened, the individual language options are passed to Uncrustify.
+Options for the current filetype will override any global options.
+Currently the supported language-specific options are
+|g:ale_uncrustify_c_options|, |g:ale_uncrustify_cpp_options|,
+|g:ale_uncrustify_cs_options|, |g:ale_uncrustify_objc_options|,
+|g:ale_uncrustify_d_options|, |g:ale_uncrustify_java_options|,
+|g:ale_uncrustify_pawn_options|, and |g:ale_uncrustify_vala_options|.
+
+
+===============================================================================
+Deprecated options                                    *ale-uncrustify-deprecated*
+
+
+These options are supported for backward compatibility but are deprecated and
+should not be used.
+
+
+g:ale_c_uncrustify_options                           *g:ale_c_uncrustify_options*
+                                                    *b:ale_c_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  Deprecated settings for Uncrustify. Note: this option is deprecated and only
+  takes effect if |g:ale_uncrustify_global_options| is not set and there are no
+  language-specific options for the current filetype. Note: To set options for
+  C files, you should use |g:ale_uncrustify_c_options|.
+
+
+g:ale_c_uncrustify_executable                     *g:ale_c_uncrustify_executable*
+                                                 *b:ale_c_uncrustify_executable*
+  Type: |String|
+  Default: `'''`
+
+  Deprecated executable for Uncrustify. Note: this option is deprecated and only
+  used if |g:ale_uncrustify_executable| is not set.
 
 
 ===============================================================================

--- a/doc/ale-uncrustify.txt
+++ b/doc/ale-uncrustify.txt
@@ -1,0 +1,63 @@
+===============================================================================
+ALE Uncrustify Integration                               *ale-uncrustify-options*
+
+
+===============================================================================
+When using Uncrustify, ALE can either use the same options for all filetypes
+or different options for each filetype.
+
+For per-filetype options, after setting |g:ale_uncrustify_per_type| to 1,
+use g:ale_lang_uncrustify_options where "lang" is one of "c", "cpp", "cs",
+"objc", "d", "java", "pawn", or "vala".
+
+
+===============================================================================
+uncrustify                                                       *ale-uncrustify*
+
+g:ale_uncrustify_executable                         *g:ale_uncrustify_executable*
+                                                   *b:ale_uncrustify_executable*
+  Type: |String|
+  Default: `'uncrustify'`
+
+  This variable can be changed to use a different executable for Uncrustify.
+
+
+g:ale_uncrustify_per_type                              *g:ale_uncrustify_per_type*
+                                                      *b:ale_uncrustify_per_type*
+  Type: |Number|
+  Default: `0`
+
+  If 1 then different options are passed to Uncrustify depending on the type
+  of file being edited. To set individual language options, use
+  "g:ale_lang_uncrustify_options" where "lang" is one of "c", "cpp", "cs",
+  "objc", "d", "java", "pawn", or "vala". For example
+  |g:ale_c_uncrustify_options|.
+
+  If 0 then |g:ale_uncrustify_global_options| are always passed to Uncrustify
+  and the "g:ale_lang_uncrustify_options" are ignored for all "lang'. Note: for
+  backward compatibility, if this is 0 and |g_ale_uncrustify_global_options| is
+  not set then |g:ale_c_uncrustify_options| are always passed instead.
+
+
+g:ale_uncrustify_global_options                  *g:ale_uncrustify_global_options*
+                                                *b:ale_uncrustify_global_options*
+  Type: |String|
+  Default: `''`
+
+  Options that are used for all languages. Language-specific options override
+  these (they are passed to Uncrustify before global options).
+
+
+g:ale_uncrustify_force_filetype                  *g:ale_uncrustify_force_filetype*
+                                                *b:ale_uncrustify_force_filetype*
+  Type: |Number|
+  Default: `0`
+
+  If 1 then the language that vim detects for the filetype is passed to
+  Uncrustify explicitly. This overrides any language setting in
+  |g:ale_uncrustify_global_options| or "g:ale_lang_uncrustify_options" for any
+  "lang".
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-vala.txt
+++ b/doc/ale-vala.txt
@@ -5,7 +5,16 @@ ALE VALA Integration                                         *ale-vala-options*
 ===============================================================================
 uncrustify                                                *ale-vala-uncrustify*
 
-See |ale-c-uncrustify| for information about the available options.
+g:ale_vala_uncrustify_options                   *g:ale_vala_uncrustify_options*
+                                                *b:ale_vala_uncrustify_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be change to modify flags given to uncrustify for VALA
+  files.
+
+
+See |ale-c-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-vala.txt
+++ b/doc/ale-vala.txt
@@ -10,11 +10,12 @@ g:ale_vala_uncrustify_options                   *g:ale_vala_uncrustify_options*
   Type: |String|
   Default: `''`
 
-  This variable can be change to modify flags given to uncrustify for VALA
-  files.
+  This variable can be changed to modify flags given to uncrustify for VALA
+  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take
+  effect.
 
 
-See |ale-c-uncrustify| for information about the other available options.
+See |ale-uncrustify| for information about the other available options.
 
 
 ===============================================================================

--- a/doc/ale-vala.txt
+++ b/doc/ale-vala.txt
@@ -5,14 +5,13 @@ ALE VALA Integration                                         *ale-vala-options*
 ===============================================================================
 uncrustify                                                *ale-vala-uncrustify*
 
-g:ale_vala_uncrustify_options                   *g:ale_vala_uncrustify_options*
-                                                *b:ale_vala_uncrustify_options*
+g:ale_uncrustify_vala_options                   *g:ale_uncrustify_vala_options*
+                                                *b:ale_uncrustify_vala_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to modify flags given to uncrustify for VALA
-  files. Note: |g:ale_uncrustify_per_type| must be enabled for this to take
-  effect.
+  files.
 
 
 See |ale-uncrustify| for information about the other available options.

--- a/test/fixers/test_uncrustify_fixer_callback.vader
+++ b/test/fixers/test_uncrustify_fixer_callback.vader
@@ -15,7 +15,6 @@ After:
   call ale#test#RestoreDirectory()
 
 Execute(The callback should return the correct default values):
-  call ale#test#SetFilename('c_paths/dummy.c')
 
   AssertEqual
   \ {
@@ -25,124 +24,156 @@ Execute(The callback should return the correct default values):
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include global options):
-  call ale#test#SetFilename('c_paths/dummy.c')
   let b:ale_uncrustify_global_options = '--some-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --some-option',
+  \     . ' --no-backup ' . ale#Escape('--some-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include language-specific options before global options):
-  call ale#test#SetFilename('c_paths/dummy.c')
+  let &filetype = 'c'
+  let b:ale_uncrustify_per_type = 1
   let b:ale_uncrustify_global_options = '--some-option'
   let b:ale_c_uncrustify_options = '--c-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --c-option --some-option',
+  \     . ' --no-backup ' . ale#Escape('--c-option --some-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_global_options = ''
+
+Execute(The uncrustify callback should include only global options if available and not using per_type):
+  let &filetype = 'c'
+  let b:ale_uncrustify_per_type = 0
+  let b:ale_uncrustify_global_options = '--some-option'
+  let b:ale_c_uncrustify_options = '--c-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup ' . ale#Escape('--some-option'),
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_global_options = ''
+
+Execute(The uncrustify callback should include C options if not using per_type and global options aren't set (for backwards compatibility)):
+  let &filetype = 'cpp'
+  let b:ale_uncrustify_per_type = 0
+  let b:ale_uncrustify_global_options = ''
+  let b:ale_c_uncrustify_options = '--c-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup ' . ale#Escape('--c-option'),
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_global_options = ''
 
 
 "Language-specific tests
 
 
 Execute(The uncrustify callback should include C specific options):
-  call ale#test#SetFilename('c_paths/dummy.c')
+  let &filetype = 'c'
   let b:ale_uncrustify_per_type = 1
   let b:ale_c_uncrustify_options = '--c-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --c-option',
+  \     . ' --no-backup ' . ale#Escape('--c-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include C++ options):
-  call ale#test#SetFilename('c_paths/dummy.cpp')
+  let &filetype = 'cpp'
   let b:ale_uncrustify_per_type = 1
   let b:ale_cpp_uncrustify_options = '--cpp-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --cpp-option',
+  \     . ' --no-backup ' . ale#Escape('--cpp-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include C# options):
-  call ale#test#SetFilename('c_paths/dummy.cs')
+  let &filetype = 'cs'
   let b:ale_uncrustify_per_type = 1
   let b:ale_cs_uncrustify_options = '--cs-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --cs-option',
+  \     . ' --no-backup ' . ale#Escape('--cs-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include Objective C options):
-  call ale#test#SetFilename('c_paths/dummy.m')
+  let &filetype = 'objc'
   let b:ale_uncrustify_per_type = 1
   let b:ale_objc_uncrustify_options = '--objc-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --objc-option',
+  \     . ' --no-backup ' . ale#Escape('--objc-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include D options):
-  call ale#test#SetFilename('c_paths/dummy.d')
+  let &filetype = 'd'
   let b:ale_uncrustify_per_type = 1
   let b:ale_d_uncrustify_options = '--d-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --d-option',
+  \     . ' --no-backup ' . ale#Escape('--d-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include Java options):
-  call ale#test#SetFilename('c_paths/dummy.java')
+  let &filetype = 'java'
   let b:ale_uncrustify_per_type = 1
   let b:ale_java_uncrustify_options = '--java-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --java-option',
+  \     . ' --no-backup ' . ale#Escape('--java-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include Pawn options):
-  call ale#test#SetFilename('c_paths/dummy.pawn')
+  let &filetype = 'pawn'
   let b:ale_uncrustify_per_type = 1
   let b:ale_pawn_uncrustify_options = '--pawn-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --pawn-option',
+  \     . ' --no-backup ' . ale#Escape('--pawn-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
 Execute(The uncrustify callback should include Vala options):
-  call ale#test#SetFilename('c_paths/dummy.vala')
+  let &filetype = 'vala'
   let b:ale_uncrustify_per_type = 1
-  let b:ale_pawn_uncrustify_options = '--vala-option'
+  let b:ale_vala_uncrustify_options = '--vala-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup --vala-option',
+  \     . ' --no-backup ' . ale#Escape('--vala-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))

--- a/test/fixers/test_uncrustify_fixer_callback.vader
+++ b/test/fixers/test_uncrustify_fixer_callback.vader
@@ -1,8 +1,8 @@
 Before:
-  Save g:ale_c_uncrustify_executable
+  Save g:ale_uncrustify_executable
 
   " Use an invalid global executable, so we don't match it.
-  let g:ale_c_uncrustify_executable = 'xxxinvalid'
+  let g:ale_uncrustify_executable = 'xxxinvalid'
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
   silent cd ..
@@ -14,23 +14,135 @@ After:
 
   call ale#test#RestoreDirectory()
 
-Execute(The clang-format callback should return the correct default values):
+Execute(The callback should return the correct default values):
   call ale#test#SetFilename('c_paths/dummy.c')
 
   AssertEqual
   \ {
-  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
   \       . ' --no-backup'
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
-Execute(The uncrustify callback should include any additional options):
+Execute(The uncrustify callback should include global options):
   call ale#test#SetFilename('c_paths/dummy.c')
-  let b:ale_c_uncrustify_options = '--some-option'
+  let b:ale_uncrustify_global_options = '--some-option'
 
   AssertEqual
   \ {
-  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
   \     . ' --no-backup --some-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include language-specific options before global options):
+  call ale#test#SetFilename('c_paths/dummy.c')
+  let b:ale_uncrustify_global_options = '--some-option'
+  let b:ale_c_uncrustify_options = '--c-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --c-option --some-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+
+"Language-specific tests
+
+
+Execute(The uncrustify callback should include C specific options):
+  call ale#test#SetFilename('c_paths/dummy.c')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_c_uncrustify_options = '--c-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --c-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include C++ options):
+  call ale#test#SetFilename('c_paths/dummy.cpp')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_cpp_uncrustify_options = '--cpp-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --cpp-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include C# options):
+  call ale#test#SetFilename('c_paths/dummy.cs')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_cs_uncrustify_options = '--cs-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --cs-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include Objective C options):
+  call ale#test#SetFilename('c_paths/dummy.m')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_objc_uncrustify_options = '--objc-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --objc-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include D options):
+  call ale#test#SetFilename('c_paths/dummy.d')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_d_uncrustify_options = '--d-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --d-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include Java options):
+  call ale#test#SetFilename('c_paths/dummy.java')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_java_uncrustify_options = '--java-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --java-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include Pawn options):
+  call ale#test#SetFilename('c_paths/dummy.pawn')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_pawn_uncrustify_options = '--pawn-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --pawn-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include Vala options):
+  call ale#test#SetFilename('c_paths/dummy.vala')
+  let b:ale_uncrustify_per_type = 1
+  let b:ale_pawn_uncrustify_options = '--vala-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup --vala-option',
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))

--- a/test/fixers/test_uncrustify_fixer_callback.vader
+++ b/test/fixers/test_uncrustify_fixer_callback.vader
@@ -14,14 +14,42 @@ After:
 
   call ale#test#RestoreDirectory()
 
-Execute(The callback should return the correct default values):
+Execute(The uncrustify callback should return the correct default values):
+  let &filetype = 'c'
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \       . ' --no-backup ' . ale#Escape('-l C')
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should include vim filetype if enabled):
+  let &filetype = 'c'
+  let b:ale_uncrustify_vim_filetype = 1
+  let b:ale_uncrustify_global_options = '--some-option'
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \       . ' --no-backup'
+  \     . ' --no-backup ' . ale#Escape('-l C --some-option'),
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_global_options = ''
+
+Execute(The uncrustify callback shouldn't include vim filetype if disabled):
+  let &filetype = 'c'
+  let b:ale_uncrustify_vim_filetype = 0
+  let b:ale_uncrustify_global_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup ' . ale#Escape('--some-option'),
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_global_options = ''
 
 Execute(The uncrustify callback should include global options):
   let b:ale_uncrustify_global_options = '--some-option'
@@ -35,9 +63,8 @@ Execute(The uncrustify callback should include global options):
 
 Execute(The uncrustify callback should include language-specific options before global options):
   let &filetype = 'c'
-  let b:ale_uncrustify_per_type = 1
   let b:ale_uncrustify_global_options = '--some-option'
-  let b:ale_c_uncrustify_options = '--c-option'
+  let b:ale_uncrustify_c_options = '--c-option'
 
   AssertEqual
   \ {
@@ -48,25 +75,10 @@ Execute(The uncrustify callback should include language-specific options before 
 
   let b:ale_uncrustify_global_options = ''
 
-Execute(The uncrustify callback should include only global options if available and not using per_type):
-  let &filetype = 'c'
-  let b:ale_uncrustify_per_type = 0
-  let b:ale_uncrustify_global_options = '--some-option'
-  let b:ale_c_uncrustify_options = '--c-option'
-
-  AssertEqual
-  \ {
-  \   'command': ale#Escape(g:ale_uncrustify_executable)
-  \     . ' --no-backup ' . ale#Escape('--some-option'),
-  \ },
-  \ ale#fixers#uncrustify#Fix(bufnr(''))
-
-  let b:ale_uncrustify_global_options = ''
-
-Execute(The uncrustify callback should include C options if not using per_type and global options aren't set (for backwards compatibility)):
+Execute(The uncrustify callback should use deprecated options if global options aren't set):
   let &filetype = 'cpp'
-  let b:ale_uncrustify_per_type = 0
   let b:ale_uncrustify_global_options = ''
+  let b:ale_uncrustify_cpp_options = ''
   let b:ale_c_uncrustify_options = '--c-option'
 
   AssertEqual
@@ -76,16 +88,73 @@ Execute(The uncrustify callback should include C options if not using per_type a
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
+Execute(The uncrustify callback shouldn't use deprecated options if global options are set):
+  let &filetype = 'cpp'
+  let b:ale_uncrustify_global_options = '--option'
+  let b:ale_uncrustify_cpp_options = ''
+  let b:ale_c_uncrustify_options = '--c-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup ' . ale#Escape('--option'),
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
   let b:ale_uncrustify_global_options = ''
+
+Execute(The uncrustify callback shouldn't use deprecated options if filetype options are set):
+  let &filetype = 'cpp'
+  let b:ale_uncrustify_global_options = ''
+  let b:ale_uncrustify_cpp_options = '--cpp-option'
+  let b:ale_c_uncrustify_options = '--c-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_uncrustify_executable)
+  \     . ' --no-backup ' . ale#Escape('--cpp-option'),
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_global_options = ''
+  let b:ale_uncrustify_cpp_options = ''
+  let b:ale_c_uncrustify_options = ''
+
+Execute(The uncrustify callback should use deprecated executable if it is set and new-style executable is not):
+  let &filetype = 'cpp'
+  let b:ale_c_uncrustify_executable = 'olduncrustify'
+  let b:ale_uncrustify_executable = 'uncrustify'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(b:ale_c_uncrustify_executable)
+  \     . ' --no-backup',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_executable = 'xxxinvalid'
+
+Execute(The uncrustify callback shouldn't use deprecated executable if new-style executable is set):
+  let &filetype = 'cpp'
+  let b:ale_c_uncrustify_executable = 'olduncrustify'
+  let b:ale_uncrustify_executable = 'xxxinvalid'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(b:ale_uncrustify_executable)
+  \     . ' --no-backup',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  let b:ale_uncrustify_executable = 'xxxinvalid'
 
 
 "Language-specific tests
 
 
-Execute(The uncrustify callback should include C specific options):
+Execute(The uncrustify callback should include C options):
   let &filetype = 'c'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_c_uncrustify_options = '--c-option'
+  let b:ale_uncrustify_c_options = '--c-option'
 
   AssertEqual
   \ {
@@ -96,8 +165,7 @@ Execute(The uncrustify callback should include C specific options):
 
 Execute(The uncrustify callback should include C++ options):
   let &filetype = 'cpp'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_cpp_uncrustify_options = '--cpp-option'
+  let b:ale_uncrustify_cpp_options = '--cpp-option'
 
   AssertEqual
   \ {
@@ -108,8 +176,7 @@ Execute(The uncrustify callback should include C++ options):
 
 Execute(The uncrustify callback should include C# options):
   let &filetype = 'cs'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_cs_uncrustify_options = '--cs-option'
+  let b:ale_uncrustify_cs_options = '--cs-option'
 
   AssertEqual
   \ {
@@ -120,8 +187,7 @@ Execute(The uncrustify callback should include C# options):
 
 Execute(The uncrustify callback should include Objective C options):
   let &filetype = 'objc'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_objc_uncrustify_options = '--objc-option'
+  let b:ale_uncrustify_objc_options = '--objc-option'
 
   AssertEqual
   \ {
@@ -132,8 +198,7 @@ Execute(The uncrustify callback should include Objective C options):
 
 Execute(The uncrustify callback should include D options):
   let &filetype = 'd'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_d_uncrustify_options = '--d-option'
+  let b:ale_uncrustify_d_options = '--d-option'
 
   AssertEqual
   \ {
@@ -144,8 +209,7 @@ Execute(The uncrustify callback should include D options):
 
 Execute(The uncrustify callback should include Java options):
   let &filetype = 'java'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_java_uncrustify_options = '--java-option'
+  let b:ale_uncrustify_java_options = '--java-option'
 
   AssertEqual
   \ {
@@ -156,8 +220,7 @@ Execute(The uncrustify callback should include Java options):
 
 Execute(The uncrustify callback should include Pawn options):
   let &filetype = 'pawn'
-  let b:ale_uncrustify_per_type = 1
-  let b:ale_pawn_uncrustify_options = '--pawn-option'
+  let b:ale_uncrustify_pawn_options = '--pawn-option'
 
   AssertEqual
   \ {
@@ -169,7 +232,7 @@ Execute(The uncrustify callback should include Pawn options):
 Execute(The uncrustify callback should include Vala options):
   let &filetype = 'vala'
   let b:ale_uncrustify_per_type = 1
-  let b:ale_vala_uncrustify_options = '--vala-option'
+  let b:ale_uncrustify_vala_options = '--vala-option'
 
   AssertEqual
   \ {


### PR DESCRIPTION
This PR adds options for passing different arguments to the Uncrustify fixer depending on Vim's filetype. It also adds an option to have the language corresponding to Vim's filetype automatically passed to Uncrustify.