### PR TITLE
Broken message in pycodestyle (or any other Linters whose name include 'code')

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -258,9 +258,9 @@ function! ale#GetLocItemMessage(item, format_string) abort
 
     " Replace special markers with certain information.
     " \=l:variable is used to avoid escaping issues.
+    let l:msg = substitute(l:msg, '\v\%([^\%]*)code([^\%]*)\%', l:code_repl, 'g')
     let l:msg = substitute(l:msg, '\V%severity%', '\=l:severity', 'g')
     let l:msg = substitute(l:msg, '\V%linter%', '\=l:linter_name', 'g')
-    let l:msg = substitute(l:msg, '\v\%([^\%]*)code([^\%]*)\%', l:code_repl, 'g')
     " Replace %s with the text.
     let l:msg = substitute(l:msg, '\V%s', '\=a:item.text', 'g')
 

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -75,6 +75,17 @@ Before:
   \       'type': 'E',
   \       'text': 'lowercase error',
   \     },
+  \     {
+  \       'lnum': 3,
+  \       'col': 5,
+  \       'bufnr': bufnr('%'),
+  \       'vcol': 0,
+  \       'linter_name': 'fakecodelinter',
+  \       'nr': -1,
+  \       'type': 'E',
+  \       'code': 'E001',
+  \       'text': 'This error does not exist',
+  \     },
   \   ],
   \ },
   \}
@@ -236,6 +247,14 @@ Execute(The %code% and %ifcode% should be removed when there's no code):
   call ale#cursor#EchoCursorWarning()
 
   AssertEqual 'Some information', GetLastMessage()
+
+Execute(The %code% should be formatted correctly when other variables contain 'code'):
+  let g:ale_echo_msg_format = '%s (%linter%% code%)'
+
+  call cursor(3, 5)
+  call ale#cursor#EchoCursorWarning()
+
+  AssertEqual 'This error does not exist (fakecodelinter E001)', GetLastMessage()
 
 Execute(The buffer message format option should take precedence):
   let g:ale_echo_msg_format = '%(code) %%s'


### PR DESCRIPTION
When you `let g:ale_echo_msg_format = '[%severity%] %s (%linter%% code%)'` and open python script with pycodestyle available in ale, the echoed message is substituted in wrong way like `[Error] s (pyE501style code%)`.

This is because the pycodestyle includes 'code' in its name and it is substituted like this way:
1. ` [%severity%] %s (%linter%% code%)`
2. ` [Error] %s (%linter%% code%)` <- %severity% substitution
3. ` [Error] %s (pycodestyle% code%)` <- %linter% substitution
4. ` [Error] s (pyE501style code%)` <- %...code...% substitution

This PR resolves the problem by swapping the substitution order like this way:
1. ` [%severity%] %s (%linter%% code%)`
2. ` [%severity%] %s (%linter% E501)` <- %...code...% substitution
3. ` [Error] %s (%linter% E501)` <- %severity% substitution
4. ` [Error] %s (pycodestyle E501)` <- %linter% substitution
5. ` [Error] line too long (82 > 79 characters) (pycodestyle E501)` <- %s% substitution