### PR TITLE
Do not match the 'code' keyword when part of of longer word

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -260,7 +260,7 @@ function! ale#GetLocItemMessage(item, format_string) abort
     " \=l:variable is used to avoid escaping issues.
     let l:msg = substitute(l:msg, '\V%severity%', '\=l:severity', 'g')
     let l:msg = substitute(l:msg, '\V%linter%', '\=l:linter_name', 'g')
-    let l:msg = substitute(l:msg, '\v\%([^\%]*)code([^\%]*)\%', l:code_repl, 'g')
+    let l:msg = substitute(l:msg, '\v\%([^\%]*)<code>([^\%]*)\%', l:code_repl, 'g')
     " Replace %s with the text.
     let l:msg = substitute(l:msg, '\V%s', '\=a:item.text', 'g')
 

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -237,6 +237,16 @@ Execute(The %code% and %ifcode% should be removed when there's no code):
 
   AssertEqual 'Some information', GetLastMessage()
 
+Execute(The %code% and %ifcode% should not replace the linter name):
+  let g:ale_echo_msg_format = '%s (pycodestyle% code%)'
+
+  call cursor(2, 9)
+  call ale#cursor#EchoCursorWarning()
+
+  AssertEqual
+  \ 'Infix operators must be spaced. (pycodestyle space-infix-ops)',
+  \ GetLastMessage()
+
 Execute(The buffer message format option should take precedence):
   let g:ale_echo_msg_format = '%(code) %%s'
   let b:ale_echo_msg_format = 'FOO %s'


### PR DESCRIPTION
Fixes #3114
