### PR TITLE
Fix 2269 - use ktlint stdin.

### DIFF
--- a/ale_linters/kotlin/ktlint.vim
+++ b/ale_linters/kotlin/ktlint.vim
@@ -6,5 +6,5 @@ call ale#linter#Define('kotlin', {
 \   'executable': 'ktlint',
 \   'command': function('ale#handlers#ktlint#GetCommand'),
 \   'callback': 'ale#handlers#ktlint#Handle',
-\   'lint_file': 1
+\   'output_stream': 'stderr'
 \})

--- a/autoload/ale/fixers/ktlint.vim
+++ b/autoload/ale/fixers/ktlint.vim
@@ -3,7 +3,6 @@
 
 function! ale#fixers#ktlint#Fix(buffer) abort
     return {
-    \   'command': ale#handlers#ktlint#GetCommand(a:buffer) . ' --format',
-    \   'read_temporary_file': 1,
+    \   'command': ale#handlers#ktlint#GetCommand(a:buffer) . ' --format'
     \}
 endfunction

--- a/autoload/ale/handlers/ktlint.vim
+++ b/autoload/ale/handlers/ktlint.vim
@@ -13,7 +13,7 @@ function! ale#handlers#ktlint#GetCommand(buffer) abort
     return ale#Escape(l:executable)
     \   . (empty(l:options) ? '' : ' ' . l:options)
     \   . (empty(l:rulesets) ? '' : ' ' . l:rulesets)
-    \   . ' %t'
+    \   . ' --stdin'
 endfunction
 
 function! ale#handlers#ktlint#GetRulesets(buffer) abort

--- a/test/fixers/test_ktlint_fixer_callback.vader
+++ b/test/fixers/test_ktlint_fixer_callback.vader
@@ -21,9 +21,8 @@ Execute(The ktlint callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' %t'
+  \     . ' --stdin'
   \     . ' --format',
-  \   'read_temporary_file': 1,
   \ },
   \ ale#fixers#ktlint#Fix(bufnr(''))
 
@@ -37,8 +36,7 @@ Execute(The ktlint callback should include custom ktlint options):
   \   'command': ale#Escape('xxxinvalid')
   \     . ' ' . g:ale_kotlin_ktlint_options
   \     . ' --ruleset /path/to/custom/ruleset.jar'
-  \     . ' %t'
+  \     . ' --stdin'
   \     . ' --format',
-  \   'read_temporary_file': 1,
   \ },
   \ ale#fixers#ktlint#Fix(bufnr(''))


### PR DESCRIPTION
Use stdin flag instead of temporary files. This allows ktlint to work
with .editorconfig files.
