### PR TITLE
linter/scala/metals: Fix return value of GetProjectRoot()

### DIFF
--- a/ale_linters/scala/metals.vim
+++ b/ale_linters/scala/metals.vim
@@ -32,6 +32,8 @@ function! ale_linters#scala#metals#GetProjectRoot(buffer) abort
             \)
         endif
     endfor
+
+    return ''
 endfunction
 
 function! ale_linters#scala#metals#GetCommand(buffer) abort


### PR DESCRIPTION
It was returning 0 when it should be returning an empty string.

The `AssertEqual` in the ale docker image is from an old version so it does not
check the types of the arguments.

This is already fixed in https://github.com/junegunn/vader.vim/commit/427fe19104c15066e4c1d5d385076e8e07a0dee8

Closes #3120
