### PR TITLE
ccls: Detect build dir and set compilationDatabaseDirectory

### DIFF
--- a/ale_linters/c/ccls.vim
+++ b/ale_linters/c/ccls.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('c_ccls_executable', 'ccls')
 call ale#Set('c_ccls_init_options', {})
+call ale#Set('c_build_dir', '')
 
 call ale#linter#Define('c', {
 \   'name': 'ccls',
@@ -10,5 +11,5 @@ call ale#linter#Define('c', {
 \   'executable': {b -> ale#Var(b, 'c_ccls_executable')},
 \   'command': '%e',
 \   'project_root': function('ale#handlers#ccls#GetProjectRoot'),
-\   'initialization_options': {b -> ale#Var(b, 'c_ccls_init_options')},
+\   'initialization_options': {b -> ale#handlers#ccls#GetInitOpts(b, 'c_ccls_init_options')},
 \})

--- a/ale_linters/cpp/ccls.vim
+++ b/ale_linters/cpp/ccls.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('cpp_ccls_executable', 'ccls')
 call ale#Set('cpp_ccls_init_options', {})
+call ale#Set('c_build_dir', '')
 
 call ale#linter#Define('cpp', {
 \   'name': 'ccls',
@@ -10,5 +11,5 @@ call ale#linter#Define('cpp', {
 \   'executable': {b -> ale#Var(b, 'cpp_ccls_executable')},
 \   'command': '%e',
 \   'project_root': function('ale#handlers#ccls#GetProjectRoot'),
-\   'initialization_options': {b -> ale#Var(b, 'cpp_ccls_init_options')},
+\   'initialization_options': {b -> ale#handlers#ccls#GetInitOpts(b, 'cpp_ccls_init_options')},
 \})

--- a/ale_linters/objc/ccls.vim
+++ b/ale_linters/objc/ccls.vim
@@ -3,6 +3,7 @@
 
 call ale#Set('objc_ccls_executable', 'ccls')
 call ale#Set('objc_ccls_init_options', {})
+call ale#Set('c_build_dir', '')
 
 call ale#linter#Define('objc', {
 \   'name': 'ccls',
@@ -10,5 +11,5 @@ call ale#linter#Define('objc', {
 \   'executable': {b -> ale#Var(b, 'objc_ccls_executable')},
 \   'command': '%e',
 \   'project_root': function('ale#handlers#ccls#GetProjectRoot'),
-\   'initialization_options': {b -> ale#Var(b, 'objc_ccls_init_options')},
+\   'initialization_options': {b -> ale#handlers#ccls#GetInitOpts(b, 'objc_ccls_init_options')},
 \})

--- a/autoload/ale/handlers/ccls.vim
+++ b/autoload/ale/handlers/ccls.vim
@@ -17,3 +17,10 @@ function! ale#handlers#ccls#GetProjectRoot(buffer) abort
     " Fall back on default project root detection.
     return ale#c#FindProjectRoot(a:buffer)
 endfunction
+
+function! ale#handlers#ccls#GetInitOpts(buffer, init_options_var) abort
+    let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
+    let l:init_options = empty(l:build_dir) ? {} : {'compilationDatabaseDirectory': l:build_dir}
+
+    return extend(l:init_options, ale#Var(a:buffer, a:init_options_var))
+endfunction

--- a/test/command_callback/test_c_ccls_command_callbacks.vader
+++ b/test/command_callback/test_c_ccls_command_callbacks.vader
@@ -4,6 +4,10 @@
 Before:
   call ale#assert#SetUpLinterTest('c', 'ccls')
 
+  Save b:ale_c_build_dir_names
+  Save b:ale_c_ccls_executable
+  Save b:ale_c_ccls_init_options
+
 After:
   call ale#assert#TearDownLinterTest()
 
@@ -47,3 +51,19 @@ Execute(The initialization options should be configurable):
   let b:ale_c_ccls_init_options = { 'cacheDirectory': '/tmp/ccls' }
 
   AssertLSPOptions { 'cacheDirectory': '/tmp/ccls' }
+
+Execute(The compile command database should be detected correctly):
+  call ale#test#SetFilename('ccls_paths/with_ccls/dummy.c')
+
+  AssertLSPOptions {}
+
+  call ale#test#SetFilename('ccls_paths/with_compile_commands_json/dummy.c')
+
+  AssertLSPOptions { 'compilationDatabaseDirectory':
+  \  ale#path#Simplify(g:dir . '/ccls_paths/with_compile_commands_json') }
+
+  call ale#test#SetFilename('ccls_paths/with_build_dir/dummy.c')
+  let b:ale_c_build_dir_names = ['unusual_build_dir_name']
+
+  AssertLSPOptions { 'compilationDatabaseDirectory':
+  \  ale#path#Simplify(g:dir . '/ccls_paths/with_build_dir/unusual_build_dir_name') }

--- a/test/command_callback/test_cpp_ccls_command_callbacks.vader
+++ b/test/command_callback/test_cpp_ccls_command_callbacks.vader
@@ -4,6 +4,10 @@
 Before:
   call ale#assert#SetUpLinterTest('cpp', 'ccls')
 
+  Save b:ale_c_build_dir_names
+  Save b:ale_cpp_ccls_executable
+  Save b:ale_cpp_ccls_init_options
+
 After:
   call ale#assert#TearDownLinterTest()
 
@@ -47,3 +51,19 @@ Execute(The initialization options should be configurable):
   let b:ale_cpp_ccls_init_options = { 'cacheDirectory': '/tmp/ccls' }
 
   AssertLSPOptions { 'cacheDirectory': '/tmp/ccls' }
+
+Execute(The compile command database should be detected correctly):
+  call ale#test#SetFilename('ccls_paths/with_ccls/dummy.c')
+
+  AssertLSPOptions {}
+
+  call ale#test#SetFilename('ccls_paths/with_compile_commands_json/dummy.c')
+
+  AssertLSPOptions { 'compilationDatabaseDirectory':
+  \  ale#path#Simplify(g:dir . '/ccls_paths/with_compile_commands_json') }
+
+  call ale#test#SetFilename('ccls_paths/with_build_dir/dummy.c')
+  let b:ale_c_build_dir_names = ['unusual_build_dir_name']
+
+  AssertLSPOptions { 'compilationDatabaseDirectory':
+  \  ale#path#Simplify(g:dir . '/ccls_paths/with_build_dir/unusual_build_dir_name') }

--- a/test/command_callback/test_objc_ccls_command_callbacks.vader
+++ b/test/command_callback/test_objc_ccls_command_callbacks.vader
@@ -1,6 +1,10 @@
 Before:
   call ale#assert#SetUpLinterTest('objc', 'ccls')
 
+  Save b:ale_c_build_dir_names
+  Save b:ale_objc_ccls_executable
+  Save b:ale_objc_ccls_init_options
+
 After:
   call ale#assert#TearDownLinterTest()
 
@@ -44,3 +48,19 @@ Execute(The initialization options should be configurable):
   let b:ale_objc_ccls_init_options = { 'cacheDirectory': '/tmp/ccls' }
 
   AssertLSPOptions { 'cacheDirectory': '/tmp/ccls' }
+
+Execute(The compile command database should be detected correctly):
+  call ale#test#SetFilename('ccls_paths/with_ccls/dummy.c')
+
+  AssertLSPOptions {}
+
+  call ale#test#SetFilename('ccls_paths/with_compile_commands_json/dummy.c')
+
+  AssertLSPOptions { 'compilationDatabaseDirectory':
+  \  ale#path#Simplify(g:dir . '/ccls_paths/with_compile_commands_json') }
+
+  call ale#test#SetFilename('ccls_paths/with_build_dir/dummy.c')
+  let b:ale_c_build_dir_names = ['unusual_build_dir_name']
+
+  AssertLSPOptions { 'compilationDatabaseDirectory':
+  \  ale#path#Simplify(g:dir . '/ccls_paths/with_build_dir/unusual_build_dir_name') }


### PR DESCRIPTION
Fixes #2621

This supersedes #2713 (which no longer merges cleanly as clangd gained this functionality in https://github.com/dense-analysis/ale/commit/dfe9b7cc2650c03127c5f897767bcb85bc0bad1f) and adds tests and removes repetition. (Actually I implemented it before even noticing #2713 but it's not too different)

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
-->