### PR TITLE
pandoc: add a new fixer for markdown

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -48,6 +48,11 @@ let s:default_registry = {
 \       'description': 'Apply prettier-standard to a file.',
 \       'aliases': ['prettier-standard'],
 \   },
+\   'pandoc': {
+\       'function': 'ale#fixers#pandoc#Fix',
+\       'suggested_filetypes': ['markdown', 'dokuwiki', 'org', 'rst', 'vimwiki'],
+\       'description': 'Fix common plaintext files',
+\   },
 \   'elm-format': {
 \       'function': 'ale#fixers#elm_format#Fix',
 \       'suggested_filetypes': ['elm'],

--- a/autoload/ale/fixers/pandoc.vim
+++ b/autoload/ale/fixers/pandoc.vim
@@ -1,0 +1,30 @@
+scriptencoding utf-8
+" Author: Dongsheng Cai <d@tux.im>
+" Description: Fix plaintext formats with pandoc.
+
+call ale#Set('pandoc_executable', 'pandoc')
+call ale#Set('pandoc_options', '')
+call ale#Set('pandoc_use_gfm', 1)
+
+function! s:TransformOptions(buffer) abort
+    let l:use_gfm = ale#Var(a:buffer, 'pandoc_use_gfm')
+    let l:filetype = getbufvar(a:buffer, '&filetype')
+    let l:ft = l:filetype =~? '^markdown' && l:use_gfm
+    \   ? 'gfm'
+    \   : l:filetype
+
+    let l:args = ' -f ' . l:ft . ' -t ' . l:ft
+
+    return l:args
+endfunction
+
+function! ale#fixers#pandoc#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'pandoc_executable')
+    let l:options = ale#Var(a:buffer, 'pandoc_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . s:TransformOptions(a:buffer)
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \}
+endfunction

--- a/test/fixers/test_pandoc_fixer_callback.vader
+++ b/test/fixers/test_pandoc_fixer_callback.vader
@@ -1,0 +1,34 @@
+Before:
+  Save g:ale_pandoc_executable
+  Save g:ale_pandoc_options
+  Save g:ale_pandoc_use_gfm
+
+  call ale#assert#SetUpFixerTest('filetype', 'pandoc')
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The pandoc callback should return 'pandoc' as default command):
+  setlocal noexpandtab
+  Assert
+  \ ale#fixers#pandoc#Fix(bufnr('')).command =~# '^' . ale#Escape('pandoc'),
+  \ "Default command name is expected to be 'pandoc'"
+
+Execute(The pandoc callback should format markdown as gfm):
+  let g:ale_pandoc_executable = 'pandoc'
+  let g:ale_pandoc_options = ''
+  set filetype=markdown
+  AssertFixer {'command': ale#Escape('pandoc') . ' -f gfm -t gfm'}
+
+Execute(The pandoc callback should format markdown as is):
+  let g:ale_pandoc_executable = 'pandoc'
+  let g:ale_pandoc_options = ''
+  let g:ale_pandoc_use_gfm = 0
+  set filetype=markdown
+  AssertFixer {'command': ale#Escape('pandoc') . ' -f markdown -t markdown'}
+
+Execute(The pandoc executable and options should be configurable):
+  let g:ale_pandoc_executable = 'pppp'
+  let g:ale_pandoc_options = '--columns=88'
+  set filetype=dokuwiki
+
+  AssertFixer {'command': ale#Escape('pppp') . ' -f dokuwiki -t dokuwiki --columns=88'}


### PR DESCRIPTION
Long time fan, first time contributor, thanks for creating this plugin.

I added this fixer to format common markdown and other plaintext formats with pandoc.