### PR TITLE
don't append a newline to temp file when buffer is noeol and nofixeol is set

### DIFF
--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -418,7 +418,10 @@ function! ale#util#Writefile(buffer, lines, filename) abort
     \   ? map(copy(a:lines), 'substitute(v:val, ''\r*$'', ''\r'', '''')')
     \   : a:lines
 
-    call writefile(l:corrected_lines, a:filename, 'S') " no-custom-checks
+    " Set binary flag if buffer doesn't have eol and nofixeol to avoid appending newline
+    let l:flags = !getbufvar(a:buffer, '&eol') && exists('+fixeol') && !&fixeol ? 'bS' : 'S'
+
+    call writefile(l:corrected_lines, a:filename, l:flags) " no-custom-checks
 endfunction
 
 if !exists('s:patial_timers')

--- a/test/test_writefile_function.vader
+++ b/test/test_writefile_function.vader
@@ -69,3 +69,49 @@ Execute(Unix file lines should be written as normal):
   AssertEqual
   \ ['first', 'second', 'third', ''],
   \ readfile(g:new_line_test_file, 'b')
+
+Execute(Newline at end of file should be preserved even when nofixeol):
+  call ale#test#SetFilename(g:new_line_test_file)
+
+  setlocal buftype=
+  noautocmd :w
+  noautocmd :e! ++ff=unix
+  set eol
+  set nofixeol
+
+  call ale#util#Writefile(bufnr(''), getline(1, '$'), g:new_line_test_file)
+
+  AssertEqual
+  \ ['first', 'second', 'third', ''],
+  \ readfile(g:new_line_test_file, 'b')
+
+Execute(Newline should not be appended on write when noeol and nofixeol):
+  call ale#test#SetFilename(g:new_line_test_file)
+
+  setlocal buftype=
+  noautocmd :w
+  noautocmd :e! ++ff=unix
+  set noeol
+  set nofixeol
+
+  call ale#util#Writefile(bufnr(''), getline(1, '$'), g:new_line_test_file)
+
+  AssertEqual
+  \ ['first', 'second', 'third'],
+  \ readfile(g:new_line_test_file, 'b')
+
+Execute(Newline should be appended on write when noeol and fixeol):
+  call ale#test#SetFilename(g:new_line_test_file)
+
+  setlocal buftype=
+  noautocmd :w
+  noautocmd :e! ++ff=unix
+  set noeol
+  set fixeol
+
+  call ale#util#Writefile(bufnr(''), getline(1, '$'), g:new_line_test_file)
+
+  AssertEqual
+  \ ['first', 'second', 'third', ''],
+  \ readfile(g:new_line_test_file, 'b')
+


### PR DESCRIPTION
The `Writefile` util will append a newline to the end of the last line in the buffer, even if it is `noeol` and `nofixeol` is set. This breaks linting for `noeol` (temp file will always have `eol`). This PR fixes the issue by calling `writefile` with the binary flag when the buffer is `noeol` and `nofixeol` is set, thus preserving the `noeol`.