### PR TITLE
Add documentation for clang-format's support for proto files

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -167,8 +167,8 @@ let s:default_registry = {
 \   },
 \   'clang-format': {
 \       'function': 'ale#fixers#clangformat#Fix',
-\       'suggested_filetypes': ['c', 'cpp', 'cuda'],
-\       'description': 'Fix C/C++ and cuda files with clang-format.',
+\       'suggested_filetypes': ['c', 'cpp', 'cuda', 'proto'],
+\       'description': 'Fix C/C++, cuda and proto files with clang-format.',
 \   },
 \   'cmakeformat': {
 \       'function': 'ale#fixers#cmakeformat#Fix',

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -31,7 +31,7 @@ g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
 
 
 ===============================================================================
-clang-format                                              *ale-proto-clangformat*
+clang-format                                            *ale-proto-clangformat*
 
 See |ale-c-clangformat| for information about the available options.
 Note that the C options are also used for C++.

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -1,5 +1,5 @@
 ===============================================================================
-ALE Proto Integration                                         *ale-proto-options*
+ALE Proto Integration                                       *ale-proto-options*
 
 
 ===============================================================================
@@ -15,7 +15,7 @@ To enable `.proto` file linting, update |g:ale_linters| as appropriate:
   let g:ale_linters = {'proto': ['protoc-gen-lint']}
 <
 ===============================================================================
-protoc-gen-lint                                      *ale-proto-protoc-gen-lint*
+protoc-gen-lint                                     *ale-proto-protoc-gen-lint*
 
   The linter is a plugin for the `protoc` binary. As long as the binary resides
   in the system path, `protoc` will find it.

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -29,5 +29,13 @@ g:ale_proto_protoc_gen_lint_options       *g:ale_proto_protoc_gen_lint_options*
   directory of the linted file is always passed as an include path with '-I'
   before any user-supplied options.
 
+
+===============================================================================
+clang-format                                              *ale-proto-clangformat*
+
+See |ale-c-clangformat| for information about the available options.
+Note that the C options are also used for C++.
+
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -341,6 +341,7 @@ Notes:
 * Prolog
   * `swipl`
 * proto
+  * `clang-format`
   * `protoc-gen-lint`
 * Pug
   * `pug-lint`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2524,6 +2524,7 @@ documented in additional help files.
   prolog..................................|ale-prolog-options|
     swipl.................................|ale-prolog-swipl|
   proto...................................|ale-proto-options|
+    clang-format..........................|ale-proto-clangformat|
     protoc-gen-lint.......................|ale-proto-protoc-gen-lint|
   pug.....................................|ale-pug-options|
     puglint...............................|ale-pug-puglint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -350,6 +350,7 @@ formatting.
 * Prolog
   * [swipl](https://github.com/SWI-Prolog/swipl-devel)
 * proto
+  * [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
   * [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint)
 * Pug
   * [pug-lint](https://github.com/pugjs/pug-lint)


### PR DESCRIPTION
`clang-format` has support for formatting `proto` files (https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html) and it works out of box with current `ale` configurations. This PR adds some documentation so that `clang-format` appears as a suggested fixer for `proto` files.