### PR TITLE
Improve :ALEDetail for dockerfile_lint [READY TO REVIEW]

### DIFF
--- a/ale_linters/dockerfile/dockerfile_lint.vim
+++ b/ale_linters/dockerfile/dockerfile_lint.vim
@@ -32,14 +32,26 @@ function! ale_linters#dockerfile#dockerfile_lint#Handle(buffer, lines) abort
             let l:line = get(l:object, 'line', -1)
             let l:message = l:object['message']
 
-            if get(l:object, 'description', 'None') isnot# 'None'
-                let l:message = l:message . '. ' . l:object['description']
+            let l:link = get(l:object, 'reference_url', '')
+            if type(l:link) == type([])
+                " Somehow, reference_url is returned as two-part list.
+                " Anchor markers in that list are sometimes duplicated.
+                " See https://github.com/projectatomic/dockerfile_lint/issues/134
+                let l:link = join(l:link, '')
+                let l:link = substitute(l:link, '##', '#', '')
             endif
+
+            let l:detail = l:message
+            if get(l:object, 'description', 'None') isnot# 'None'
+                let l:detail .= "\n\n" . l:object['description']
+            endif
+            let l:detail .= "\n\n" . l:link
 
             call add(l:messages, {
             \   'lnum': l:line,
             \   'text': l:message,
             \   'type': ale_linters#dockerfile#dockerfile_lint#GetType(l:type),
+            \   'detail': l:detail,
             \})
         endfor
     endfor

--- a/ale_linters/dockerfile/dockerfile_lint.vim
+++ b/ale_linters/dockerfile/dockerfile_lint.vim
@@ -33,7 +33,8 @@ function! ale_linters#dockerfile#dockerfile_lint#Handle(buffer, lines) abort
             let l:message = l:object['message']
 
             let l:link = get(l:object, 'reference_url', '')
-            if type(l:link) == type([])
+
+            if type(l:link) == v:t_list
                 " Somehow, reference_url is returned as two-part list.
                 " Anchor markers in that list are sometimes duplicated.
                 " See https://github.com/projectatomic/dockerfile_lint/issues/134
@@ -42,9 +43,11 @@ function! ale_linters#dockerfile#dockerfile_lint#Handle(buffer, lines) abort
             endif
 
             let l:detail = l:message
+
             if get(l:object, 'description', 'None') isnot# 'None'
                 let l:detail .= "\n\n" . l:object['description']
             endif
+
             let l:detail .= "\n\n" . l:link
 
             call add(l:messages, {

--- a/test/handler/test_dockerfile_lint_handler.vader
+++ b/test/handler/test_dockerfile_lint_handler.vader
@@ -26,21 +26,25 @@ Execute(The dockerfile_lint handler should handle a normal example):
   \     'lnum': -1,
   \     'type': 'E',
   \     'text': "Required LABEL name/key 'Name' is not defined",
+  \     'detail': "Required LABEL name/key 'Name' is not defined\n\nhttp://docs.projectatomic.io/container-best-practices/#_recommended_labels_for_your_project",
   \   },
   \   {
   \     'lnum': -1,
   \     'type': 'E',
   \     'text': "Required LABEL name/key 'Version' is not defined",
+  \     'detail': "Required LABEL name/key 'Version' is not defined\n\nhttp://docs.projectatomic.io/container-best-practices/#_recommended_labels_for_your_project",
   \   },
   \   {
   \     'lnum': 3,
   \     'type': 'I',
-  \     'text': "the MAINTAINER command is deprecated. MAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0",
+  \     'text': "the MAINTAINER command is deprecated",
+  \     'detail': "the MAINTAINER command is deprecated\n\nMAINTAINER is deprecated in favor of using LABEL since Docker v1.13.0\n\nhttps://github.com/docker/cli/blob/master/docs/deprecated.md#maintainer-in-dockerfile",
   \   },
   \   {
   \     'lnum': -1,
   \     'type': 'I',
   \     'text': "There is no 'CMD' instruction",
+  \     'detail': "There is no 'CMD' instruction\n\nhttps://docs.docker.com/engine/reference/builder/#cmd",
   \   },
   \ ],
   \ ale_linters#dockerfile#dockerfile_lint#Handle(bufnr(''), [


### PR DESCRIPTION
Hi!

This just makes the existing integration with [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint/) a bit nicer.

Tested manually and via `./run-tests`. Existing unit-test updated to include `detail`.

BTW: thoroughly enjoyed making the patch; thanks for nice docs & test infra. Cheers!