### PR TITLE
clangtidy supports build_dir and cpp_clangtidy_options at the same time

### DIFF
--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -19,11 +19,9 @@ function! ale_linters#cpp#clangtidy#GetCommand(buffer, output) abort
     let l:options = ''
 
     " Get the extra options if we couldn't find a build directory.
-    if empty(l:build_dir)
-        let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
-        let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
-        let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
-    endif
+    let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
+    let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
+    let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
 
     " Get the options to pass directly to clang-tidy
     let l:extra_options = ale#Var(a:buffer, 'cpp_clangtidy_extra_options')

--- a/test/command_callback/test_c_import_paths.vader
+++ b/test/command_callback/test_c_import_paths.vader
@@ -235,6 +235,7 @@ Execute(The C++ ClangTidy handler should include json folders for projects with 
   \ ale#Escape('clang-tidy')
   \   . ' %s '
   \   . '-p ' . ale#Escape(ale#path#Simplify(g:dir . '/../test_c_projects/json_project/build'))
+  \   . ' -- -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test_c_projects/json_project/include'))
 
 Execute(The C++ ClangTidy handler should include 'include' directories for projects with a Makefile):
   call ale#assert#SetUpLinterTest('cpp', 'clangtidy')

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -47,7 +47,7 @@ Execute(The build directory should be configurable):
   \   . ' -checks=' . ale#Escape('*') . ' %s'
   \   . ' -p ' . ale#Escape('/foo/bar')
 
-Execute(The build directory setting should override the options):
+Execute(The build directory setting should coexist with the options):
   let b:ale_cpp_clangtidy_checks = ['*']
   let b:ale_c_build_dir = '/foo/bar'
   let b:ale_cpp_clangtidy_options = '-Wall'
@@ -55,7 +55,7 @@ Execute(The build directory setting should override the options):
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy')
   \   . ' -checks=' . ale#Escape('*') . ' %s'
-  \   . ' -p ' . ale#Escape('/foo/bar')
+  \   . ' -p ' . ale#Escape('/foo/bar') . ' -- -Wall'
 
 Execute(The build directory should be ignored for header files):
   call ale#test#SetFilename('test.h')


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Fixed https://github.com/dense-analysis/ale/issues/3118

## Manual test steps:
1. In the C++ project folder, create the `compile_commands.json`
2. In the C++ project folder, create the file `.vimrc` with content
```
let g:ale_cpp_clangtidy_options = ...
```
3. In `~/.vimrc` file, enable exrc feature
```
set exrc
set secure
```
4. In `~/.vim/ftplugin/cpp.vim`, enable linter and add buffer option
```
let b:ale_linters = ['clangtidy']
let b:ale_cpp_clangtidy_options = get(g:, 'ale_cpp_clangtidy_options', '') . ' -x c++'
```
5. Open any c++ header file or implementation file in the project, verify the configurations in `compile_commands.json`, `g:ale_cpp_clangtidy_options` and `b:ale_cpp_clangtidy_options` all take effect in `:ALEInfo`