### PR TITLE
rust/cargo: add support for a custom target directory

### DIFF
--- a/ale_linters/rust/cargo.vim
+++ b/ale_linters/rust/cargo.vim
@@ -11,6 +11,7 @@ call ale#Set('rust_cargo_default_feature_behavior', 'default')
 call ale#Set('rust_cargo_include_features', '')
 call ale#Set('rust_cargo_use_clippy', 0)
 call ale#Set('rust_cargo_clippy_options', '')
+call ale#Set('rust_cargo_target_dir', '')
 
 function! ale_linters#rust#cargo#GetCargoExecutable(bufnr) abort
     if ale#path#FindNearestFile(a:bufnr, 'Cargo.toml') isnot# ''
@@ -31,6 +32,9 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version) abort
     \   && ale#semver#GTE(a:version, [0, 22, 0])
     let l:use_tests = ale#Var(a:buffer, 'rust_cargo_check_tests')
     \   && ale#semver#GTE(a:version, [0, 22, 0])
+    let l:target_dir = ale#Var(a:buffer, 'rust_cargo_target_dir')
+    let l:use_target_dir = !empty(l:target_dir)
+    \   && ale#semver#GTE(a:version, [0, 17, 0])
 
     let l:include_features = ale#Var(a:buffer, 'rust_cargo_include_features')
 
@@ -82,6 +86,7 @@ function! ale_linters#rust#cargo#GetCommand(buffer, version) abort
     \   . (l:use_all_targets ? ' --all-targets' : '')
     \   . (l:use_examples ? ' --examples' : '')
     \   . (l:use_tests ? ' --tests' : '')
+    \   . (l:use_target_dir ? (' --target-dir ' . ale#Escape(l:target_dir)) : '')
     \   . ' --frozen --message-format=json -q'
     \   . l:default_feature
     \   . l:include_features

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -174,6 +174,18 @@ g:ale_rust_cargo_clippy_options
   only `cargo clippy` supports (e.g. `--deny`).
 
 
+g:ale_rust_cargo_target_dir
+                                                  *g:ale_rust_cargo_target_dir*
+                                                  *b:ale_rust_cargo_target_dir*
+
+  Type: |String|
+  Default: `''`
+
+  Use a custom target directory when running the commands for ALE. This can
+  help to avoid "waiting for file lock on build directory" messages when
+  running `cargo` commands manually while ALE is performing its checks.
+
+
 ===============================================================================
 rls                                                              *ale-rust-rls*
 

--- a/test/command_callback/test_cargo_command_callbacks.vader
+++ b/test/command_callback/test_cargo_command_callbacks.vader
@@ -169,10 +169,11 @@ Execute(Build supports all cargo flags):
   let g:ale_rust_cargo_check_tests = 1
   let g:ale_rust_cargo_check_examples = 1
   let b:ale_rust_cargo_default_feature_behavior = 'all'
+  let b:ale_rust_cargo_target_dir = 'target/ale'
 
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
-  \ 'cargo build --all-targets --examples --tests --frozen --message-format=json -q --all-features',
+  \ 'cargo build --all-targets --examples --tests --target-dir ' . ale#Escape('target/ale') . ' --frozen --message-format=json -q --all-features',
   \]
 
 Execute(Clippy supports all cargo flags):
@@ -182,10 +183,11 @@ Execute(Clippy supports all cargo flags):
   let g:ale_rust_cargo_check_examples = 1
   let b:ale_rust_cargo_default_feature_behavior = 'all'
   let b:ale_rust_cargo_clippy_options = '-D warnings'
+  let b:ale_rust_cargo_target_dir = 'target/ale'
 
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
-  \ 'cargo clippy --all-targets --examples --tests --frozen --message-format=json -q --all-features -- -D warnings',
+  \ 'cargo clippy --all-targets --examples --tests --target-dir ' . ale#Escape('target/ale') . ' --frozen --message-format=json -q --all-features -- -D warnings',
   \]
 
 Execute(cargo-check does not refer ale_rust_cargo_clippy_options):
@@ -196,4 +198,22 @@ Execute(cargo-check does not refer ale_rust_cargo_clippy_options):
   AssertLinter 'cargo', [
   \ ale#Escape('cargo') . ' --version',
   \ 'cargo check --frozen --message-format=json -q',
+  \]
+
+Execute(`cargo --target-dir` should be used when the version is new enough and it is set):
+  let b:ale_rust_cargo_target_dir = 'target/ale'
+
+  GivenCommandOutput ['cargo 0.17.0 (3423351a5 2017-10-06)']
+  AssertLinter 'cargo', [
+  \ ale#Escape('cargo') . ' --version',
+  \ 'cargo check --target-dir ' . ale#Escape('target/ale') . g:suffix,
+  \]
+
+Execute(`cargo --target-dir` should not be used when the version is not new enough and it is set):
+  let b:ale_rust_cargo_target_dir = 'target/ale'
+
+  GivenCommandOutput ['cargo 0.16.0 (3423351a5 2017-10-06)']
+  AssertLinter 'cargo', [
+  \ ale#Escape('cargo') . ' --version',
+  \ 'cargo build' . g:suffix,
   \]


### PR DESCRIPTION
This can avoid having to wait for ALE or ALE being blocked on other
cargo actions within the same crate.

---
> Where are the tests?

Where should I add them? I don't see any existing ones testing this kind of feature already.

Seriously, read `:help ale-dev` and write tests.