### PR TITLE
Make C/C++ project files configurable

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -5,8 +5,12 @@ call ale#Set('c_parse_makefile', 0)
 call ale#Set('c_parse_compile_commands', 0)
 let s:sep = has('win32') ? '\' : '/'
 
-" Set just so tests can override it.
-let g:__ale_c_project_filenames = ['.git/HEAD', 'configure', 'Makefile', 'CMakeLists.txt']
+let g:ale_c_project_filenames = get(g:, 'ale_c_project_filenames', [
+\   '.git/HEAD',
+\   'configure',
+\   'Makefile',
+\   'CMakeLists.txt',
+\])
 
 function! ale#c#GetBuildDirectory(buffer) abort
     " Don't include build directory for header files, as compile_commands.json
@@ -192,7 +196,7 @@ function! ale#c#FindProjectRoot(buffer) abort
 
     " Fall back on detecting the project root based on other filenames.
     if empty(l:root)
-        for l:project_filename in g:__ale_c_project_filenames
+        for l:project_filename in g:ale_c_project_filenames
             let l:full_path = ale#path#FindNearestFile(a:buffer, l:project_filename)
 
             if !empty(l:full_path)

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -59,6 +59,16 @@ g:ale_c_parse_makefile                                 *g:ale_c_parse_makefile*
   build flags to use for different files.
 
 
+g:ale_c_project_filenames                           *g:ale_c_project_filenames*
+                                                    *b:ale_c_project_filenames*
+  Type: |List|
+  Default: `['.git/HEAD', 'configure', 'Makefile', 'CMakeLists.txt']`
+
+  A list of file names to be used to find a C/C++ project root. If any file
+  from this list is found in the project root, ALE will treat the project as
+  a C/C++ project.
+
+
 ===============================================================================
 clang                                                             *ale-c-clang*
 

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -11,6 +11,7 @@ The following C options also apply to some C++ linters too.
 * |g:ale_c_build_dir|
 * |g:ale_c_parse_makefile|
 * |g:ale_c_parse_compile_commands|
+* |g:ale_c_project_filenames|
 
 
 ===============================================================================

--- a/test/command_callback/test_c_clangd_command_callbacks.vader
+++ b/test/command_callback/test_c_clangd_command_callbacks.vader
@@ -8,6 +8,7 @@ Before:
   Save b:ale_c_build_dir
   Save b:ale_c_build_dir_names
   Save b:ale_c_parse_compile_commands
+  Save b:ale_c_project_filenames
 
 After:
   call ale#assert#TearDownLinterTest()
@@ -44,6 +45,7 @@ Execute(The compile command database should be detected correctly):
   let b:ale_c_build_dir = ''
   let b:ale_c_build_dir_names = ['unusual_build_dir_name']
   let b:ale_c_parse_compile_commands = 1
+  let b:ale_c_project_filenames = ['.git/HEAD', 'configure', 'Makefile', 'CMakeLists.txt']
 
   AssertLinter 'clangd', ale#Escape('clangd')
   \  . ' -compile-commands-dir='

--- a/test/command_callback/test_c_import_paths.vader
+++ b/test/command_callback/test_c_import_paths.vader
@@ -4,14 +4,14 @@ Before:
 
   Save g:ale_c_parse_compile_commands
   Save g:ale_c_parse_makefile
-  Save g:__ale_c_project_filenames
+  Save g:ale_c_project_filenames
 
-  let g:original_project_filenames = g:__ale_c_project_filenames
+  let g:original_project_filenames = g:ale_c_project_filenames
 
   " Remove the .git/HEAD dir for C import paths for these tests.
   " The tests run inside of a git repo.
-  let g:__ale_c_project_filenames = filter(
-  \ copy(g:__ale_c_project_filenames),
+  let g:ale_c_project_filenames = filter(
+  \ copy(g:ale_c_project_filenames),
   \ 'v:val isnot# ''.git/HEAD'''
   \)
 


### PR DESCRIPTION
New global variable `g:ale_c_project_filenames` allows users to configure which files trigger a directory as a C/C++ project root.

Should address https://github.com/dense-analysis/ale/issues/2831