### PR TITLE
Add option to sync buffer cursor with loc|qf list.

### DIFF
--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -147,6 +147,8 @@ function! ale#events#Init() abort
                 autocmd InsertLeave * if exists('*ale#engine#Cleanup') | call ale#virtualtext#ShowCursorWarning() | endif
             endif
 
+            autocmd CursorMoved <buffer> call ale#list#Follow()
+
             if g:ale_close_preview_on_insert
                 autocmd InsertEnter * if exists('*ale#preview#CloseIfTypeMatches') | call ale#preview#CloseIfTypeMatches('ale-preview') | endif
             endif

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1499,6 +1499,16 @@ g:ale_open_list                                               *g:ale_open_list*
   augroup END
 <
 
+g:ale_follow_list                                             *g:ale_follow_list*
+                                                              *b:ale_follow_list*
+  Type: |Number|
+  Default: `1`
+
+  When this is set to 1, ALE will move the line in the loclist or quickfix
+  so it highlights the error/warning that corresponds to the current cursor
+  line in the buffer being linted.
+
+
 g:ale_pattern_options                                   *g:ale_pattern_options*
 
   Type: |Dictionary|

--- a/test/test_autocmd_commands.vader
+++ b/test/test_autocmd_commands.vader
@@ -85,6 +85,7 @@ Execute (All events should be set up when everything is on):
   \   'BufWritePost * call ale#events#SaveEvent(str2nr(expand(''<abuf>'')))',
   \   'CursorHold * if exists(''*ale#engine#Cleanup'') | call ale#cursor#EchoCursorWarningWithDelay() | endif',
   \   'CursorMoved * if exists(''*ale#engine#Cleanup'') | call ale#cursor#EchoCursorWarningWithDelay() | endif',
+  \   'CursorMoved <buffer> call ale#list#Follow()',
   \   'FileChangedShellPost * call ale#events#FileChangedEvent(str2nr(expand(''<abuf>'')))',
   \   'FileType * call ale#events#FileTypeEvent( str2nr(expand(''<abuf>'')), expand(''<amatch>''))',
   \   'InsertLeave * if ale#Var(str2nr(expand(''<abuf>'')), ''lint_on_insert_leave'') | call ale#Queue(0) | endif',


### PR DESCRIPTION
Pressing enter in the loclist or quickfix list jumps to the
corresponding line in the buffer.

This MR introduces a new option `g:ale_follow_list` that allows
ALE to do the opposite. Moving the cursor inside the buffer, if the
current line has a linter error, then it will move the cursor inside
the loc|qf list to the line where that error is.