### PR TITLE
add option to lint diff buffers

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -51,7 +51,7 @@ function! ale#ShouldDoNothing(buffer) abort
     endif
 
     " Do nothing for diff buffers.
-    if getbufvar(a:buffer, '&diff')
+    if getbufvar(a:buffer, '&diff') && !get(g:, 'ale_lint_diff', 0)
         return 1
     endif
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1094,12 +1094,13 @@ g:ale_lint_delay                                             *g:ale_lint_delay*
   |g:ale_lint_on_text_changed| variable set to `always`, `insert`, or `normal`.
 
 
-g:ale_lint_diff                                             *g:ale_lint_diff*
+g:ale_lint_diff                                               *g:ale_lint_diff*
 
   Type: |Number|
   Default: `0`
 
   When this option is set to `1`, ALE will lint buffers where `&diff` is set.
+
 
 g:ale_lint_on_enter                                       *g:ale_lint_on_enter*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1094,6 +1094,13 @@ g:ale_lint_delay                                             *g:ale_lint_delay*
   |g:ale_lint_on_text_changed| variable set to `always`, `insert`, or `normal`.
 
 
+g:ale_lint_diff                                             *g:ale_lint_diff*
+
+  Type: |Number|
+  Default: `0`
+
+  When this option is set to `1`, ALE will lint buffers where `&diff` is set.
+
 g:ale_lint_on_enter                                       *g:ale_lint_on_enter*
 
   Type: |Number|

--- a/test/test_should_do_nothing_conditions.vader
+++ b/test/test_should_do_nothing_conditions.vader
@@ -32,6 +32,7 @@ After:
     let b:funky_command_created = 0
   endif
 
+  unlet! g:ale_lint_diff
   unlet! b:funky_command_created
   unlet! b:fake_mode
 
@@ -78,6 +79,12 @@ Execute(DoNothing should return 1 for diff buffers):
   let &diff = 1
 
   AssertEqual 1, ale#ShouldDoNothing(bufnr(''))
+
+Execute(DoNothing should return 0 for diff buffers when ale_lint_diff is set):
+  let &diff = 1
+  let g:ale_lint_diff = 1
+
+  AssertEqual 0, ale#ShouldDoNothing(bufnr(''))
 
 Execute(The DoNothing check should work if the ALE globals aren't defined):
   unlet! g:ale_filetype_blacklist


### PR DESCRIPTION
Adds an option to lint diff buffers as suggested below:
https://github.com/dense-analysis/ale/issues/2583

Tests added, documentation updated.
