### PR TITLE
Fix cabal_ghc linter

### DIFF
--- a/ale_linters/haskell/cabal_ghc.vim
+++ b/ale_linters/haskell/cabal_ghc.vim
@@ -1,11 +1,32 @@
 " Author: Eric Wolf <ericwolf42@gmail.com>
 " Description: ghc for Haskell files called with cabal exec
+"
+" Modified to search for the cabal file so that it is not necessary to work from
+" the project root
+"
+" Correct exec command
 
 call ale#Set('haskell_cabal_ghc_options', '-fno-code -v0')
 
+function! ale_linters#haskell#cabal_ghc#GetProjectRoot(buffer) abort
+    " Search all of the paths except for the root filesystem path.
+    let l:paths = join(
+    \   ale#path#Upwards(expand('#' . a:buffer . ':p:h'))[:-2],
+    \   ','
+    \)
+
+    let l:project_file = globpath(l:paths, '*.cabal')
+
+    " If we can't find one, use the current file.
+    if empty(l:project_file)
+        let l:project_file = expand('#' . a:buffer . ':p')
+    endif
+
+    return fnamemodify(l:project_file, ':h')
+endfunction
+
 function! ale_linters#haskell#cabal_ghc#GetCommand(buffer) abort
-    return ale#path#BufferCdString(a:buffer)
-    \   . 'cabal exec -- ghc '
+    return 'cabal v2-exec ghc -- '
     \   . ale#Var(a:buffer, 'haskell_cabal_ghc_options')
     \   . ' %t'
 endfunction
@@ -17,4 +38,5 @@ call ale#linter#Define('haskell', {
 \   'executable': 'cabal',
 \   'command': function('ale_linters#haskell#cabal_ghc#GetCommand'),
 \   'callback': 'ale#handlers#haskell#HandleGHCFormat',
+\   'project_root': function('ale_linters#haskell#cabal_ghc#GetProjectRoot'),
 \})

--- a/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
+++ b/test/command_callback/test_haskell_cabal_ghc_command_callbacks.vader
@@ -13,11 +13,11 @@ After:
 
 Execute(The options should be used in the command):
   AssertEqual
-  \ ale#path#BufferCdString(bufnr('')) . 'cabal exec -- ghc -fno-code -v0 %t',
+  \ 'cabal v2-exec ghc -- -fno-code -v0 %t',
   \ ale_linters#haskell#cabal_ghc#GetCommand(bufnr(''))
 
   let b:ale_haskell_cabal_ghc_options = 'foobar'
 
   AssertEqual
-  \ ale#path#BufferCdString(bufnr('')) . 'cabal exec -- ghc foobar %t',
+  \ 'cabal v2-exec ghc -- foobar %t',
   \ ale_linters#haskell#cabal_ghc#GetCommand(bufnr(''))


### PR DESCRIPTION
... so that vim doesn't need to be run from the project root and that ghc is
called with the right environment

Not sure how the previous version could have worked with recent versions of `cabal`