### PR TITLE
OmniSharp C# linter over LSP

### DIFF
--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -1,0 +1,29 @@
+" Author: Luiz Ribeiro <luizribeiro@gmail.com>
+" Description: C# support via omnisharp
+
+call ale#Set('cs_omnisharp_mono_executable', 'mono')
+call ale#Set('cs_omnisharp_executable', 'OmniSharp.exe')
+call ale#Set('cs_omnisharp_options', '-lsp')
+
+function! ale_linters#cs#omnisharp#GetProjectRoot(buffer) abort
+    let l:omnisharp_json = ale#path#FindNearestFile(a:buffer, 'omnisharp.json')
+    return !empty(l:omnisharp_json) ? fnamemodify(l:omnisharp_json, ':h') : ''
+endfunction
+
+function! ale_linters#cs#omnisharp#GetMonoExecutable(buffer) abort
+    return ale#Var(a:buffer, 'cs_omnisharp_mono_executable')
+endfunction
+
+function! ale_linters#cs#omnisharp#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'cs_omnisharp_executable')
+    let l:options = ale#Var(a:buffer, 'cs_omnisharp_options')
+    return '%e ' . l:executable . ' ' . l:options
+endfunction
+
+call ale#linter#Define('cs', {
+\   'name': 'omnisharp',
+\   'lsp': 'stdio',
+\   'executable': function('ale_linters#cs#omnisharp#GetMonoExecutable'),
+\   'command': function('ale_linters#cs#omnisharp#GetCommand'),
+\   'project_root': function('ale_linters#cs#omnisharp#GetProjectRoot'),
+\})

--- a/ale_linters/cs/omnisharp.vim
+++ b/ale_linters/cs/omnisharp.vim
@@ -7,6 +7,7 @@ call ale#Set('cs_omnisharp_options', '-lsp')
 
 function! ale_linters#cs#omnisharp#GetProjectRoot(buffer) abort
     let l:omnisharp_json = ale#path#FindNearestFile(a:buffer, 'omnisharp.json')
+
     return !empty(l:omnisharp_json) ? fnamemodify(l:omnisharp_json, ':h') : ''
 endfunction
 
@@ -17,6 +18,7 @@ endfunction
 function! ale_linters#cs#omnisharp#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'cs_omnisharp_executable')
     let l:options = ale#Var(a:buffer, 'cs_omnisharp_options')
+
     return '%e ' . l:executable . ' ' . l:options
 endfunction
 

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -187,6 +187,52 @@ g:ale_cs_mcsc_assemblies                             *g:ale_cs_mcsc_assemblies*
     \]
 <
 
+
+===============================================================================
+omnisharp                                                    *ale-cs-omnisharp*
+
+  The `omnisharp` linter uses the OmniSharp .NET development platform based on
+  Roslyn workspaces. See https://github.com/OmniSharp/omnisharp-roslyn for its
+  installation instructions.
+
+
+g:ale_cs_omnisharp_mono_executable         *g:ale_cs_omnisharp_mono_executable*
+                                           *b:ale_cs_omnisharp_mono_executable*
+
+  Type: String
+  Default: `'mono'`
+
+  This variable controls the path to the mono executable, used to run
+  `OmniSharp.exe`. You should only have to set this if your `mono` binary is
+  not in your `PATH` or if you want to use another `mono` version other than
+  one in your path.
+
+
+g:ale_cs_omnisharp_executable                   *g:ale_cs_omnisharp_executable*
+                                                *b:ale_cs_omnisharp_executable*
+
+  Type: String
+  Default: `'OmniSharp.exe'`
+
+  This variable controls the path to `OmniSharp.exe` binary. You most likely
+  want to set this variable.
+
+  For example: >
+
+    let g:ale_cs_omnisharp_executable = '/usr/local/opt/omnisharp-mono/libexec/OmniSharp.exe'
+<
+
+
+g:ale_cs_omnisharp_options                         *g:ale_cs_omnisharp_options*
+                                                   *b:ale_cs_omnisharp_options*
+
+  Type: String
+  Default: `'-lsp'`
+
+  Use this variable to control the additional options that are passed to
+  `OmniSharp.exe`.
+
+
 ===============================================================================
 uncrustify                                                  *ale-cs-uncrustify*
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2323,6 +2323,7 @@ documented in additional help files.
     csc...................................|ale-cs-csc|
     mcs...................................|ale-cs-mcs|
     mcsc..................................|ale-cs-mcsc|
+    omnisharp.............................|ale-cs-omnisharp|
     uncrustify............................|ale-cs-uncrustify|
   css.....................................|ale-css-options|
     fecs..................................|ale-css-fecs|

--- a/test/command_callback/test_omnisharp_command_callbacks.vader
+++ b/test/command_callback/test_omnisharp_command_callbacks.vader
@@ -1,0 +1,23 @@
+Before:
+  call ale#assert#SetUpLinterTest('cs', 'omnisharp')
+
+After:
+  unlet! b:command_tail
+
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'mono', ale#Escape('mono') . ' OmniSharp.exe -lsp'
+
+Execute(The mono executable should be configurable):
+  let b:ale_cs_omnisharp_mono_executable = '/usr/bin/mono'
+  AssertLinter '/usr/bin/mono',
+  \ ale#Escape('/usr/bin/mono') . ' OmniSharp.exe -lsp'
+
+Execute(The omnisharp executable should be configurable):
+  let b:ale_cs_omnisharp_executable = '/opt/omnisharp/OmniSharp.exe'
+  AssertLinter 'mono', ale#Escape('mono') . ' /opt/omnisharp/OmniSharp.exe -lsp'
+
+Execute(The options should be configurable):
+  let b:ale_cs_omnisharp_options = '--something'
+  AssertLinter 'mono', ale#Escape('mono') . ' OmniSharp.exe --something'


### PR DESCRIPTION
This sets up a linter for C# with [OmniSharp](https://github.com/OmniSharp/omnisharp-roslyn) over LSP.

I wrote documentation explaining how to use it and added some tests too.

Been using this successfully with C# projects with OmniSharp 1.32.5 on macOS. See [luizribeiro/mgsb](https://github.com/luizribeiro/mgsb) for an example of a project.