### PR TITLE
Fixes govet linter for go 1.13+, with tests

### DIFF
--- a/autoload/ale/handlers/go.vim
+++ b/autoload/ale/handlers/go.vim
@@ -6,9 +6,12 @@
 "
 " Author: Ben Paxton <ben@gn32.uk>
 " Description: moved to generic Golang file from govet
+"
+" Author: mostfunkyduck <mostfunkyduck@protonmail.com>
+" Description: updated to work with go 1.14
 
 function! ale#handlers#go#Handler(buffer, lines) abort
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
+    let l:pattern = '\v^%(vet: )?([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:? ?(.+)$'
     let l:output = []
     let l:dir = expand('#' . a:buffer . ':p:h')
 

--- a/test/handler/test_go_generic_handler.vader
+++ b/test/handler/test_go_generic_handler.vader
@@ -15,8 +15,24 @@ Execute(The golang handler should return the correct filenames):
   \     'type': 'E',
   \     'filename': ale#path#Simplify(expand('%:p:h') . '/other.go'),
   \   },
+  \   {
+  \     'lnum': 18,
+  \     'col': 0,
+  \     'text': 'random error',
+  \     'type': 'E',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/go1.14.go'),
+  \   },
+  \   {
+  \     'lnum': 36,
+  \     'col': 2,
+  \     'text': 'another random error',
+  \     'type': 'E',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/anothergo1.14.go'),
+  \   },
   \ ],
   \ ale#handlers#go#Handler(bufnr(''), [
   \   'test.go:27: some error',
   \   'other.go:27:5: some error with a column',
+  \   'vet: go1.14.go:18:0: random error',
+  \   'vet: anothergo1.14.go:36:2: another random error',
   \ ])


### PR DESCRIPTION
This should fix #2761. #2776 also does practically the same thing, but I've added a couple of test cases. 