### PR TITLE
Use old solc error reporter

### DIFF
--- a/ale_linters/solidity/solc.vim
+++ b/ale_linters/solidity/solc.vim
@@ -23,7 +23,7 @@ function! ale_linters#solidity#solc#Handle(buffer, lines) abort
 endfunction
 
 function! ale_linters#solidity#solc#GetCommand(buffer) abort
-    return 'solc' . ale#Pad(ale#Var(a:buffer, 'solidity_solc_options')) . ' %s'
+    return 'solc --old-reporter' . ale#Pad(ale#Var(a:buffer, 'solidity_solc_options')) . ' %s'
 endfunction
 
 call ale#linter#Define('solidity', {

--- a/test/command_callback/test_solc_command_callback.vader
+++ b/test/command_callback/test_solc_command_callback.vader
@@ -5,9 +5,9 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'solc', 'solc %s'
+  AssertLinter 'solc', 'solc --old-reporter %s'
 
 Execute(The options should be configurable):
   let g:ale_solidity_solc_options = '--foobar'
 
-  AssertLinter 'solc', 'solc --foobar %s'
+  AssertLinter 'solc', 'solc --old-reporter --foobar %s'


### PR DESCRIPTION
Solc switched to a new error reporter with
https://github.com/ethereum/solidity/releases/tag/v0.6.0

Use a flag to bring back the old reporting.