### PR TITLE
vim/vint: show policy name

### DIFF
--- a/ale_linters/vim/vint.vim
+++ b/ale_linters/vim/vint.vim
@@ -5,7 +5,7 @@
 call ale#Set('vim_vint_show_style_issues', 1)
 call ale#Set('vim_vint_executable', 'vint')
 let s:enable_neovim = has('nvim') ? ' --enable-neovim' : ''
-let s:format = '-f "{file_path}:{line_number}:{column_number}: {severity}: {description} (see {reference})"'
+let s:format = '-f "{file_path}:{line_number}:{column_number}: {severity}: {policy_name} - {description} (see {reference})"'
 
 function! ale_linters#vim#vint#GetCommand(buffer, version) abort
     let l:can_use_no_color_flag = empty(a:version)

--- a/test/command_callback/test_vint_command_callback.vader
+++ b/test/command_callback/test_vint_command_callback.vader
@@ -1,7 +1,7 @@
 Before:
   call ale#assert#SetUpLinterTest('vim', 'vint')
   let b:command_tail = (has('nvim') ? ' --enable-neovim' : '')
-  \ . ' -f "{file_path}:{line_number}:{column_number}: {severity}: {description} (see {reference})" %t'
+  \ . ' -f "{file_path}:{line_number}:{column_number}: {severity}: {policy_name} - {description} (see {reference})" %t'
 
 After:
   unlet! b:bin_dir


### PR DESCRIPTION
So that I can find the relevant information in the vint linting policy summary and policies can be easily configured https://github.com/Vimjas/vint/wiki/Vint-linting-policy-summary

Before this change an example warning message appears as:

    autocmd should execute in an augroup or execute with a group (see :help :autocmd)

After this change the same example appears as:

    ProhibitAutocmdWithNoGroup - autocmd should execute in an augroup or execute with a group (see :help :autocmd)

I have updated a test.