### PR TITLE
Add dprint fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -380,6 +380,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['dhall'],
 \       'description': 'Fix Dhall files with dhall-format.',
 \   },
+\   'dprint': {
+\       'function': 'ale#fixers#dprint#Fix',
+\       'suggested_filetypes': ['javascript', 'typescript'],
+\       'description': 'Pluggable and configurable code formatting platform',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/dprint.vim
+++ b/autoload/ale/fixers/dprint.vim
@@ -1,0 +1,22 @@
+call ale#Set('typescript_dprint_executable', 'dprint')
+call ale#Set('typescript_dprint_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('typescript_dprint_options', '')
+
+function! ale#fixers#dprint#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'typescript_dprint', [
+    \   'node_modules/dprint/dist/cli-bin.js',
+    \   'node_modules/.bin/dprint',
+    \   'dprint',
+    \])
+endfunction
+
+function! ale#fixers#dprint#Fix(buffer) abort
+    let l:options = ale#Var(a:buffer, 'typescript_dprint_options')
+
+    return {
+    \   'command': ale#Escape(ale#fixers#dprint#GetExecutable(a:buffer))
+    \       . ' ' . ale#Escape(l:options)
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -224,6 +224,7 @@ Notes:
   * `PMD`
   * `uncrustify`
 * JavaScript
+  * `dprint`
   * `eslint`
   * `fecs`
   * `flow`
@@ -479,6 +480,7 @@ Notes:
 * Thrift
   * `thrift`
 * TypeScript
+  * `dprint`
   * `eslint`
   * `fecs`
   * `prettier`

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -233,6 +233,7 @@ formatting.
   * [PMD](https://pmd.github.io/)
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * JavaScript
+  * [dprint](https://dprint.dev/)
   * [eslint](http://eslint.org/)
   * [fecs](http://fecs.baidu.com/)
   * [flow](https://flowtype.org/)
@@ -488,6 +489,7 @@ formatting.
 * Thrift
   * [thrift](http://thrift.apache.org/)
 * TypeScript
+  * [dprint](https://dprint.dev/)
   * [eslint](http://eslint.org/)
   * [fecs](http://fecs.baidu.com/)
   * [prettier](https://github.com/prettier/prettier)

--- a/test/fixers/test_dprint_fixer_callback.vader
+++ b/test/fixers/test_dprint_fixer_callback.vader
@@ -1,0 +1,28 @@
+Before:
+  call ale#assert#SetUpFixerTest('typescript', 'dprint')
+
+After:
+  Restore
+  call ale#assert#TearDownFixerTest()
+
+Execute(The dprint callback should return the correct default values):
+  AssertFixer
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command':
+  \     ale#Escape('dprint')
+  \     . ' ' . ale#Escape('')
+  \     . ' %t',
+  \ }
+
+Execute(The dprint callback should include custom options):
+  let g:ale_typescript_dprint_options = '-c .dprintrc'
+
+  AssertFixer
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command':
+  \     ale#Escape('dprint')
+  \     . ' ' . ale#Escape('-c .dprintrc')
+  \     . ' %t',
+  \ }


### PR DESCRIPTION
Adds a fixer for [dprint](https://dprint.dev/) for `typescript` and `javascript` buffers. dprint is the formatter for [deno](https://deno.land) and is useful both for deno projects and for any `typescript`/`javascript` projects since it is pretty similar to [prettier](https://prettier.io).