### PR TITLE
psscriptanalyzer: Add support for configurable options

### DIFF
--- a/ale_linters/powershell/psscriptanalyzer.vim
+++ b/ale_linters/powershell/psscriptanalyzer.vim
@@ -8,6 +8,7 @@ call ale#Set('powershell_psscriptanalyzer_exclusions', '')
 call ale#Set('powershell_psscriptanalyzer_executable', 'pwsh')
 call ale#Set('powershell_psscriptanalyzer_module',
 \ 'psscriptanalyzer')
+call ale#Set('powershell_psscriptanalyzer_options', '')
 
 function! ale_linters#powershell#psscriptanalyzer#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'powershell_psscriptanalyzer_executable')
@@ -20,8 +21,11 @@ function! ale_linters#powershell#psscriptanalyzer#GetCommand(buffer) abort
     \   a:buffer, 'powershell_psscriptanalyzer_exclusions')
     let l:module = ale#Var(
     \   a:buffer, 'powershell_psscriptanalyzer_module')
+    let l:options = ale#Var(
+    \   a:buffer, 'powershell_psscriptanalyzer_options')
     let l:script = ['Param($Script);
     \   Invoke-ScriptAnalyzer "$Script" '
+    \   . l:options . ' '
     \   . (!empty(l:exclude_option) ? '-Exclude ' . l:exclude_option : '')
     \   . '| ForEach-Object {
     \   $_.Line;

--- a/doc/ale-powershell.txt
+++ b/doc/ale-powershell.txt
@@ -72,6 +72,15 @@ g:ale_powershell_psscriptanalyzer_exclusions
   \  'PSAvoidUsingWriteHost,PSAvoidGlobalVars'
 <
 
+g:ale_powershell_psscriptanalyzer_options
+                                    *g:ale_powershell_psscriptanalyzer_options*
+                                    *b:ale_powershell_psscriptanalyzer_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to add command-line arguments to the
+  psscriptanalyzer invocation.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
For parity with many other linters, and to support my current desire for specifying `-Settings`, add support for configurable command options via the `ale_powershell_psscriptanalyzer_options` variable.

Note: This change is not covered by tests because I could not find any existing tests for `ale_linters#powershell#psscriptanalyzer#GetCommand`.  If tests are a hard requirement, can we discuss removing the temporary script generation and passing arguments directly to make it easier to test?

Thanks,
Kevin