### PR TITLE
eslint: Use cwd from executable location to fix nested projects

### DIFF
--- a/autoload/ale/node.vim
+++ b/autoload/ale/node.vim
@@ -12,6 +12,18 @@ function! ale#node#FindExecutable(buffer, base_var_name, path_list) abort
         return ale#Var(a:buffer, a:base_var_name . '_executable')
     endif
 
+    let l:nearest = ale#node#FindNearestExecutable(a:buffer, a:path_list)
+
+    if !empty(l:nearest)
+        return l:nearest
+    endif
+
+    return ale#Var(a:buffer, a:base_var_name . '_executable')
+endfunction
+
+" Given a buffer number, a base variable name, and a list of paths to search
+" for in ancestor directories, detect the executable path for a Node program.
+function! ale#node#FindNearestExecutable(buffer, path_list) abort
     for l:path in a:path_list
         let l:executable = ale#path#FindNearestFile(a:buffer, l:path)
 
@@ -20,7 +32,7 @@ function! ale#node#FindExecutable(buffer, base_var_name, path_list) abort
         endif
     endfor
 
-    return ale#Var(a:buffer, a:base_var_name . '_executable')
+    return ''
 endfunction
 
 " Create a executable string which executes a Node.js script command with a

--- a/test/test_eslint_executable_detection.vader
+++ b/test/test_eslint_executable_detection.vader
@@ -70,6 +70,25 @@ Execute(eslint.js executables should be run with node on Windows):
     \ ale#handlers#eslint#GetCommand(bufnr(''))
   endif
 
+Execute(eslint.js should be run from containing project with eslint):
+  call ale#test#SetFilename('eslint-test-files/react-app/subdir-with-package-json/testfile.js')
+
+  " We have to execute the file with node.
+  if has('win32')
+    AssertEqual
+    \ ale#path#CdString(ale#path#Simplify(g:dir . '/eslint-test-files/react-app'))
+    \   . ale#Escape('node.exe') . ' '
+    \   . ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
+    \   . ' -f json --stdin --stdin-filename %s',
+    \ ale#handlers#eslint#GetCommand(bufnr(''))
+  else
+    AssertEqual
+    \ ale#path#CdString(ale#path#Simplify(g:dir . '/eslint-test-files/react-app'))
+    \   . ale#Escape(ale#path#Simplify(g:dir . '/eslint-test-files/react-app/node_modules/eslint/bin/eslint.js'))
+    \   . ' -f json --stdin --stdin-filename %s',
+    \ ale#handlers#eslint#GetCommand(bufnr(''))
+  endif
+
 Execute(eslint.js executables can be run outside project dir):
   " Set filename above eslint-test-files (which contains node_modules)
   call ale#test#SetFilename('testfile.js')


### PR DESCRIPTION
Since  #2937, ESLint is run from the nearest directory with `node_modules`.  This does not work correctly for nested projects where the eslint and any required config/plugin packages are installed in the outer project.  For example: https://github.com/dense-analysis/ale/issues/3143#issuecomment-652452362

Adopt the behavior of SublimeLinter, which runs from `project_root` determined by the presence of the `eslint` executable in `node_modules/.bin` (or `eslint` in `dependencies`/`devDependencies` of `package.json`, which we can add later as necessary).  See SublimeLinter/SublimeLinter#1649 and [`NodeLinter#find_local_executable`](https://github.com/SublimeLinter/SublimeLinter/blob/056e6f6/lint/base_linter/node_linter.py#L109).

Thanks for considering,
Kevin

cc: @w0rp, @joeldodge79