### PR TITLE
Handling for puppet parser error at end of input.

### DIFF
--- a/ale_linters/puppet/puppet.vim
+++ b/ale_linters/puppet/puppet.vim
@@ -9,13 +9,14 @@ function! ale_linters#puppet#puppet#Handle(buffer, lines) abort
     " Error: Could not parse for environment production: Syntax error at '='; expected '}' at /root/puppetcode/modules/pancakes/manifests/init.pp:5"
     " Error: Could not parse for environment production: Syntax error at 'parameter1' (file: /tmp/modules/mariadb/manifests/slave.pp, line: 4, column: 5)
     " Error: Illegal attempt to assign to 'a Name'. Not an assignable reference (file: /tmp/modules/waffles/manifests/syrup.pp, line: 5, column: 11)
-    let l:pattern = '^Error:\%(.*:\)\? \(.\+\) \((file:\|at\) .\+\.pp\(, line: \|:\)\(\d\+\)\(, column: \|:\)\=\(\d*\)'
+    " Error: Could not parse for environment production: Syntax error at end of input (file: /tmp/modules/bob/manifests/init.pp)
+    let l:pattern = '^Error:\%(.*:\)\? \(.\+\) \((file:\|at\) .\+\.pp\(\(, line: \|:\)\(\d\+\)\(, column: \|:\)\=\(\d*\)\|)$\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
-        \   'lnum': l:match[4] + 0,
-        \   'col': l:match[6] + 0,
+        \   'lnum': l:match[5] + 0,
+        \   'col': l:match[7] + 0,
         \   'text': l:match[1],
         \})
     endfor

--- a/test/handler/test_puppet_handler.vader
+++ b/test/handler/test_puppet_handler.vader
@@ -63,3 +63,15 @@ Execute(The puppet handler should correctly parse errors that are reported befor
   \ ale_linters#puppet#puppet#Handle(255, [
   \   "Error: Illegal attempt to assign to 'a Name'. Not an assignable reference (file: /tmp/modules/waffles/manifests/syrup.pp, line: 5, column: 11)",
   \ ])
+Execute(The puppet handler should parse lines when end of input is the location):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 0,
+  \     'col': 0,
+  \     'text': "Syntax error at end of input"
+  \   },
+  \ ],
+  \ ale_linters#puppet#puppet#Handle(255, [
+  \   "Error: Could not parse for environment production: Syntax error at end of input (file: /tmp//modules/test/manifests/init.pp)",
+  \ ])


### PR DESCRIPTION
Add handling for `Syntax error at end of input` which doesn't give a line or column.

Fixes #2656