### PR TITLE
Update error-parser for `nix-instantiate` on Nix 2.4+

### DIFF
--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -1,18 +1,51 @@
 " Author: Alistair Bill <@alibabzo>
+" Author: Maximilian Bosch <maximilian@mbosch.me>
 " Description: nix-instantiate linter for nix files
 
+function! ale_linters#nix#nix#Command(buffer, output, meta) abort
+    let l:version = a:output[0][22:]
+
+    if l:version =~# '^\(2.4\|3\).*'
+        return 'nix-instantiate --log-format internal-json --parse -'
+    else
+        return 'nix-instantiate --parse -'
+    endif
+endfunction
+
 function! ale_linters#nix#nix#Handle(buffer, lines) abort
-    let l:pattern = '^\(.\+\): \(.\+\), at .*:\(\d\+\):\(\d\+\)$'
     let l:output = []
 
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        call add(l:output, {
-        \   'lnum': l:match[3] + 0,
-        \   'col': l:match[4] + 0,
-        \   'text': l:match[1] . ': ' . l:match[2],
-        \   'type': l:match[1] =~# '^error' ? 'E' : 'W',
-        \})
-    endfor
+    if empty(a:lines)
+        return l:output
+    endif
+
+    if a:lines[0] =~# '^@nix .*'
+        for l:line in a:lines
+            if l:line =~# '^@nix .*'
+                let l:result = json_decode(strpart(l:line, 4))
+
+                if has_key(l:result, 'column')
+                    call add(l:output, {
+                    \     'type': 'E',
+                    \     'lnum': l:result.line,
+                    \     'col': l:result.column,
+                    \     'text': l:result.raw_msg
+                    \})
+                endif
+            endif
+        endfor
+    else
+        let l:pattern = '^\(.\+\): \(.\+\) at .*:\(\d\+\):\(\d\+\)$'
+
+        for l:match in ale#util#GetMatches(a:lines, l:pattern)
+            call add(l:output, {
+            \   'lnum': l:match[3] + 0,
+            \   'col': l:match[4] + 0,
+            \   'text': l:match[1] . ': ' . substitute(l:match[2], ',$', '', ''),
+            \   'type': l:match[1] =~# '^error' ? 'E' : 'W',
+            \})
+        endfor
+    endif
 
     return l:output
 endfunction
@@ -21,6 +54,10 @@ call ale#linter#Define('nix', {
 \   'name': 'nix',
 \   'output_stream': 'stderr',
 \   'executable': 'nix-instantiate',
-\   'command': 'nix-instantiate --parse -',
+\   'command': {buffer -> ale#command#Run(
+\       buffer,
+\       'nix-instantiate --version',
+\       function('ale_linters#nix#nix#Command')
+\   )},
 \   'callback': 'ale_linters#nix#nix#Handle',
 \})

--- a/test/handler/test_nix_handler.vader
+++ b/test/handler/test_nix_handler.vader
@@ -8,6 +8,29 @@ Execute(The nix handler should parse nix-instantiate error messages correctly):
   AssertEqual
   \ [
   \   {
+  \     'lnum': 6,
+  \     'col': 3,
+  \     'type': 'E',
+  \     'text': "syntax error, unexpected ']', expecting ';'",
+  \   },
+  \   {
+  \     'lnum': 3,
+  \     'col': 5,
+  \     'type': 'E',
+  \     'text': "undefined variable 'foo'",
+  \   },
+  \
+  \ ],
+  \ ale_linters#nix#nix#Handle(bufnr(''), [
+  \   "@nix {\"line\":6,\"column\":3,\"raw_msg\":\"syntax error, unexpected ']', expecting ';'\"}",
+  \   "@nix {\"line\":3,\"column\":5,\"raw_msg\":\"undefined variable 'foo'\"}",
+  \   "@nix {\"unrelated\":\"message\"}"
+  \ ])
+
+Execute(The nix handler should parse message from old nix-instantiate correctly):
+  AssertEqual
+  \ [
+  \   {
   \     'lnum': 23,
   \     'col': 14,
   \     'text': 'error: syntax error, unexpected IN',


### PR DESCRIPTION



In the (unreleased) Nix 2.4 the error-messages have been reformatted[1].
This patch aims to retain proper `.nix`-support in `ale`, for both
stable Nix (2.3 and older) and unstable Nix (2.4 and newer).

[1] NixOS/nix#3590

