### PR TITLE
Add astyle for C/C++ formatting

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -160,6 +160,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['php'],
 \       'description': 'Fix PHP files with php-cs-fixer.',
 \   },
+\    'astyle': {
+\       'function': 'ale#fixers#astyle#Fix',
+\       'suggested_filetypes': ['c', 'cpp'],
+\       'description': 'Fix C/C++ with astyle.',
+\    },
 \   'clangtidy': {
 \       'function': 'ale#fixers#clangtidy#Fix',
 \       'suggested_filetypes': ['c', 'cpp', 'objc'],

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -163,7 +163,7 @@ let s:default_registry = {
 \    'astyle': {
 \       'function': 'ale#fixers#astyle#Fix',
 \       'suggested_filetypes': ['c', 'cpp'],
-\       'description': 'Fix C with astyle.',
+\       'description': 'Fix C/C++ with astyle.',
 \    },
 \   'clangtidy': {
 \       'function': 'ale#fixers#clangtidy#Fix',

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -162,8 +162,8 @@ let s:default_registry = {
 \   },
 \    'astyle': {
 \       'function': 'ale#fixers#astyle#Fix',
-\       'suggested_filetypes': ['c', 'cpp'],
-\       'description': 'Fix C/C++ with astyle.',
+\       'suggested_filetypes': ['c'],
+\       'description': 'Fix C with astyle.',
 \    },
 \   'clangtidy': {
 \       'function': 'ale#fixers#clangtidy#Fix',

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -162,7 +162,7 @@ let s:default_registry = {
 \   },
 \    'astyle': {
 \       'function': 'ale#fixers#astyle#Fix',
-\       'suggested_filetypes': ['c'],
+\       'suggested_filetypes': ['c', 'cpp'],
 \       'description': 'Fix C with astyle.',
 \    },
 \   'clangtidy': {

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -21,10 +21,11 @@ function! ale#fixers#astyle#Fix(buffer) abort
     let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
     let l:filename = ale#Escape(bufname(a:buffer))
     let l:options = ale#fixers#astyle#Var(a:buffer, 'options')
-    let l:command = ' --stdin=' . l:filename
+    let l:command = ' --stdin='
 
     return {
-    \   'command': ale#Escape(l:executable) . l:command
+    \   'command': ale#Escape(l:executable)
     \     . (empty(l:options) ? '' : ' --project=' . l:options)
+    \     . l:command
     \}
 endfunction

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -1,14 +1,27 @@
 " Author: James Kim <jhlink@users.noreply.github.com>
-" Description: Fix C files with astyle.
+" Description: Fix C/C++ files with astyle.
 
-call ale#Set('c_astyle_executable', 'astyle')
+function! s:set_variables() abort
+    for l:ft in ['c', 'cpp']
+        call ale#Set(l:ft . '_astyle_executable', 'astyle')
+    endfor
+endfunction
+
+call s:set_variables()
+
+function! ale#fixers#astyle#Var(buffer, name) abort
+    let l:ft = getbufvar(str2nr(a:buffer), '&filetype')
+    let l:ft = l:ft =~# 'cpp' ? 'cpp' : 'c'
+
+    return ale#Var(a:buffer, l:ft . '_astyle_' . a:name)
+endfunction
 
 function! ale#fixers#astyle#Fix(buffer) abort
-    let l:executable = ale#Var(a:buffer, 'c_astyle_executable')
+    let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
+    let l:command = ' %t'
 
     return {
-    \   'command': ale#Escape(l:executable)
-    \       . ' %t',
+    \   'command': ale#Escape(l:executable) . l:command,
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -18,15 +18,42 @@ function! ale#fixers#astyle#Var(buffer, name) abort
     return ale#Var(a:buffer, l:ft . '_astyle_' . a:name)
 endfunction
 
+" Try to find a project options file.
+function! ale#fixers#astyle#FindProjectOptions(buffer) abort
+    let l:proj_options = ale#fixers#astyle#Var(a:buffer, 'project_options')
+
+    " If user has set project options variable then use it and skip any searching.
+    " This would allow users to use project files named differently than .astylerc.
+    if !empty(l:proj_options)
+         return l:proj_options
+    endif
+
+    " Try to find nearest .astylerc file.
+    let l:proj_options = fnamemodify(ale#path#FindNearestFile(a:buffer, '.astylerc'), ':t')
+
+    if !empty(l:proj_options)
+        return l:proj_options
+    endif
+
+    " Try to find nearest _astylerc file.
+    let l:proj_options = fnamemodify(ale#path#FindNearestFile(a:buffer, '_astylerc'), ':t')
+
+    if !empty(l:proj_options)
+        return l:proj_options
+    endif
+
+    " If no project options file is found return an empty string.
+    return ''
+endfunction
+
 function! ale#fixers#astyle#Fix(buffer) abort
     let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
-    let l:filename = ale#Escape(bufname(a:buffer))
-    let l:options = ale#fixers#astyle#Var(a:buffer, 'project_options')
+    let l:proj_options = ale#fixers#astyle#FindProjectOptions(a:buffer)
     let l:command = ' --stdin='
 
     return {
     \   'command': ale#Escape(l:executable)
-    \     . (empty(l:options) ? '' : ' --project=' . l:options)
+    \     . (empty(l:proj_options) ? '' : ' --project=' . l:proj_options)
     \     . l:command
     \}
 endfunction

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -18,10 +18,10 @@ endfunction
 
 function! ale#fixers#astyle#Fix(buffer) abort
     let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
-    let l:command = ' %t'
+    let l:filename = ale#Escape(bufname(a:buffer))
+    let l:command = ' --stdin=' . l:filename
 
     return {
-    \   'command': ale#Escape(l:executable) . l:command,
-    \   'read_temporary_file': 1,
+    \   'command': ale#Escape(l:executable) . l:command
     \}
 endfunction

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -4,6 +4,7 @@
 function! s:set_variables() abort
     for l:ft in ['c', 'cpp']
         call ale#Set(l:ft . '_astyle_executable', 'astyle')
+        call ale#Set(l:ft . '_astyle_options', '')
     endfor
 endfunction
 
@@ -19,9 +20,11 @@ endfunction
 function! ale#fixers#astyle#Fix(buffer) abort
     let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
     let l:filename = ale#Escape(bufname(a:buffer))
+    let l:options = ale#fixers#astyle#Var(a:buffer, 'options')
     let l:command = ' --stdin=' . l:filename
 
     return {
     \   'command': ale#Escape(l:executable) . l:command
+    \     . (empty(l:options) ? '' : ' --project=' . l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -1,5 +1,5 @@
 " Author: James Kim <jhlink@users.noreply.github.com>
-" Description: Fix C/C++ files with astyle.
+" Description: Fix C files with astyle.
 
 call ale#Set('c_astyle_executable', 'astyle')
 

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -1,0 +1,14 @@
+" Author: James Kim <jhlink@users.noreply.github.com>
+" Description: Fix C/C++ files with astyle.
+
+call ale#Set('c_astyle_executable', 'astyle')
+
+function! ale#fixers#astyle#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'c_astyle_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -25,7 +25,7 @@ function! ale#fixers#astyle#FindProjectOptions(buffer) abort
     " If user has set project options variable then use it and skip any searching.
     " This would allow users to use project files named differently than .astylerc.
     if !empty(l:proj_options)
-         return l:proj_options
+        return l:proj_options
     endif
 
     " Try to find nearest .astylerc file.

--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -4,11 +4,12 @@
 function! s:set_variables() abort
     for l:ft in ['c', 'cpp']
         call ale#Set(l:ft . '_astyle_executable', 'astyle')
-        call ale#Set(l:ft . '_astyle_options', '')
+        call ale#Set(l:ft . '_astyle_project_options', '')
     endfor
 endfunction
 
 call s:set_variables()
+
 
 function! ale#fixers#astyle#Var(buffer, name) abort
     let l:ft = getbufvar(str2nr(a:buffer), '&filetype')
@@ -20,7 +21,7 @@ endfunction
 function! ale#fixers#astyle#Fix(buffer) abort
     let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
     let l:filename = ale#Escape(bufname(a:buffer))
-    let l:options = ale#fixers#astyle#Var(a:buffer, 'options')
+    let l:options = ale#fixers#astyle#Var(a:buffer, 'project_options')
     let l:command = ' --stdin='
 
     return {

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -70,6 +70,19 @@ g:ale_c_astyle_executable                           *g:ale_c_astyle_executable*
   This variable can be changed to use a different executable for astyle.
 
 
+g:ale_c_astyle_options                                 *g:ale_c_astyle_options*
+                                                       *b:ale_c_astyle_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to use an option file for project level
+  configurations. Provide only the filename of the option file that should be
+  present at the project's root directory. 
+
+  For example, if .astylrc is specified, the file is searched in the parent
+  directories of the source file's directory. 
+
+
 ===============================================================================
 clang                                                             *ale-c-clang*
 

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -59,7 +59,6 @@ g:ale_c_parse_makefile                                 *g:ale_c_parse_makefile*
   build flags to use for different files.
 
 
-
 ===============================================================================
 astyle                                                           *ale-c-astyle*
 

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -70,17 +70,17 @@ g:ale_c_astyle_executable                           *g:ale_c_astyle_executable*
   This variable can be changed to use a different executable for astyle.
 
 
-g:ale_c_astyle_options                                 *g:ale_c_astyle_options*
-                                                       *b:ale_c_astyle_options*
+g:ale_c_astyle_project_options                 *g:ale_c_astyle_project_options*
+                                               *b:ale_c_astyle_project_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to use an option file for project level
   configurations. Provide only the filename of the option file that should be
-  present at the project's root directory. 
+  present at the project's root directory.
 
   For example, if .astylrc is specified, the file is searched in the parent
-  directories of the source file's directory. 
+  directories of the source file's directory.
 
 
 ===============================================================================

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -59,6 +59,18 @@ g:ale_c_parse_makefile                                 *g:ale_c_parse_makefile*
   build flags to use for different files.
 
 
+
+===============================================================================
+astyle                                                           *ale-c-astyle*
+
+g:ale_c_astyle_executable                           *g:ale_c_astyle_executable*
+                                                    *b:ale_c_astyle_executable*
+  Type: |String|
+  Default: `'astyle'`
+
+  This variable can be changed to use a different executable for astyle.
+
+
 ===============================================================================
 clang                                                             *ale-c-clang*
 

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -14,6 +14,17 @@ The following C options also apply to some C++ linters too.
 
 
 ===============================================================================
+astyle                                                         *ale-cpp-astyle*
+
+g:ale_cpp_astyle_executable                       *g:ale_cpp_astyle_executable*
+                                                  *b:ale_cpp_astyle_executable*
+  Type: |String|
+  Default: `'astyle'`
+
+  This variable can be changed to use a different executable for astyle.
+
+
+===============================================================================
 clang                                                           *ale-cpp-clang*
 
 g:ale_cpp_clang_executable                         *g:ale_cpp_clang_executable*

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -24,6 +24,19 @@ g:ale_cpp_astyle_executable                       *g:ale_cpp_astyle_executable*
   This variable can be changed to use a different executable for astyle.
 
 
+g:ale_cpp_astyle_options                             *g:ale_cpp_astyle_options*
+                                                     *b:ale_cpp_astyle_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to use an option file for project level
+  configurations. Provide only the filename of the option file that should be
+  present at the project's root directory. 
+
+  For example, if .astylrc is specified, the file is searched in the parent
+  directories of the source file's directory. 
+
+
 ===============================================================================
 clang                                                           *ale-cpp-clang*
 

--- a/doc/ale-cpp.txt
+++ b/doc/ale-cpp.txt
@@ -24,17 +24,17 @@ g:ale_cpp_astyle_executable                       *g:ale_cpp_astyle_executable*
   This variable can be changed to use a different executable for astyle.
 
 
-g:ale_cpp_astyle_options                             *g:ale_cpp_astyle_options*
-                                                     *b:ale_cpp_astyle_options*
+g:ale_cpp_astyle_project_options             *g:ale_cpp_astyle_project_options*
+                                             *b:ale_cpp_astyle_project_options*
   Type: |String|
   Default: `''`
 
   This variable can be changed to use an option file for project level
   configurations. Provide only the filename of the option file that should be
-  present at the project's root directory. 
+  present at the project's root directory.
 
   For example, if .astylrc is specified, the file is searched in the parent
-  directories of the source file's directory. 
+  directories of the source file's directory.
 
 
 ===============================================================================

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -62,6 +62,7 @@ Notes:
   * `mcsc`!!
   * `uncrustify`
 * C++ (filetype cpp)
+  * `astyle`
   * `ccls`
   * `clang`
   * `clangcheck`!!

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -44,6 +44,7 @@ Notes:
   * `shellcheck`
   * `shfmt`
 * C
+  * `astyle`
   * `ccls`
   * `clang`
   * `clangd`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2284,6 +2284,7 @@ documented in additional help files.
   bib.....................................|ale-bib-options|
     bibclean..............................|ale-bib-bibclean|
   c.......................................|ale-c-options|
+    astyle................................|ale-c-astyle|
     clang.................................|ale-c-clang|
     clangd................................|ale-c-clangd|
     clang-format..........................|ale-c-clangformat|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2307,6 +2307,7 @@ documented in additional help files.
     cmakelint.............................|ale-cmake-cmakelint|
     cmake-format..........................|ale-cmake-cmakeformat|
   cpp.....................................|ale-cpp-options|
+    astyle................................|ale-cpp-astyle|
     clang.................................|ale-cpp-clang|
     clangd................................|ale-cpp-clangd|
     clangcheck............................|ale-cpp-clangcheck|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -53,6 +53,7 @@ formatting.
   * [shellcheck](https://www.shellcheck.net/)
   * [shfmt](https://github.com/mvdan/sh)
 * C
+  * [astyle](http://astyle.sourceforge.net/)
   * [ccls](https://github.com/MaskRay/ccls)
   * [clang](http://clang.llvm.org/)
   * [clangd](https://clang.llvm.org/extra/clangd.html)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -71,6 +71,7 @@ formatting.
   * [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) :floppy_disk: see:`help ale-cs-mcsc` for details and configuration
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * C++ (filetype cpp)
+  * [astyle](http://astyle.sourceforge.net/)
   * [ccls](https://github.com/MaskRay/ccls)
   * [clang](http://clang.llvm.org/)
   * [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) :floppy_disk:

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -49,7 +49,7 @@ Execute(The astyle callback should support cpp files with option file set):
 
 Execute(The astyle callback should return the correct default values with an option file set):
   call ale#test#SetFilename('../c_files/testfile.c')
-  let g:ale_c_astyle_project_options = '.astylerc'
+  let g:ale_c_astyle_project_options = '.astylerc_c'
 
   AssertEqual
   \ {

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -65,3 +65,14 @@ Execute(The astyle callback should return the correct default values with an opt
   \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
+
+Execute(The astyle callback should find nearest default option file _astylrc):
+  call ale#test#SetFilename('../test_c_projects/makefile_project/subdir/file.c')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' --project=_astylerc'
+  \     . ' --stdin='
+  \ },
+  \ ale#fixers#astyle#Fix(bufnr(''))

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -20,7 +20,7 @@ Execute(The astyle callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_c_astyle_executable)
-  \     . ' --stdin=' . ale#Escape(targetfile)
+  \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -32,7 +32,7 @@ Execute(The astyle callback should support cpp files):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_cpp_astyle_executable)
-  \     . ' --stdin=' . ale#Escape(targetfile)
+  \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -45,8 +45,8 @@ Execute(The astyle callback should support cpp files with option file set):
   AssertEqual
   \ {
   \   'command': ale#Escape('invalidpp')
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \     . ' --project=' . g:ale_cpp_astyle_options
+  \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -59,7 +59,7 @@ Execute(The astyle callback should return the correct default values with an opt
   AssertEqual
   \ {
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \     . ' --project=' . g:ale_c_astyle_options
+  \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -3,6 +3,7 @@ Before:
 
   " Use an invalid global executable, so we don't match it.
   let g:ale_c_astyle_executable = 'xxxinvalid'
+  let g:ale_cpp_astyle_executable = 'invalidpp'
   
   call ale#test#SetDirectory('/testplugin/test/fixers')
 
@@ -13,24 +14,24 @@ After:
 
 Execute(The astyle callback should return the correct default values):
   call ale#test#SetFilename('../c_files/testfile.c')
+  let targetfile = '/testplugin/test/c_files/testfile.c'
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
-  \     . ' %t',
+  \   'command': ale#Escape(g:ale_c_astyle_executable)
+  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
 Execute(The astyle callback should support cpp files):
   call ale#test#SetFilename('../cpp_files/dummy.cpp')
-  let g:ale_cpp_astyle_executable = 'xxxinvalid'
+  let targetfile = '/testplugin/test/cpp_files/dummy.cpp'
   set filetype=cpp " The test fails without this
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
-  \     . ' %t',
+  \   'command': ale#Escape(g:ale_cpp_astyle_executable)
+  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
+

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_c_astyle_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_c_astyle_executable = 'xxxinvalid'
+  
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The astyle callback should return the correct default values):
+  call ale#test#SetFilename('../c_files/testfile.c')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' %t',
+  \ },
+  \ ale#fixers#astyle#Fix(bufnr(''))

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -1,5 +1,6 @@
 Before:
   Save g:ale_c_astyle_executable
+  Save g:ale_c_astyle_options
 
   " Use an invalid global executable, so we don't match it.
   let g:ale_c_astyle_executable = 'xxxinvalid'
@@ -35,3 +36,30 @@ Execute(The astyle callback should support cpp files):
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
+Execute(The astyle callback should support cpp files with option file set):
+  call ale#test#SetFilename('../cpp_files/dummy.cpp')
+  let g:ale_cpp_astyle_options = '.astylerc_cpp'
+  let targetfile = '/testplugin/test/cpp_files/dummy.cpp'
+  set filetype=cpp " The test fails without this
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('invalidpp')
+  \     . ' --stdin=' . ale#Escape(targetfile)
+  \     . ' --project=' . g:ale_cpp_astyle_options
+  \ },
+  \ ale#fixers#astyle#Fix(bufnr(''))
+
+
+Execute(The astyle callback should return the correct default values with an option file set):
+  call ale#test#SetFilename('../c_files/testfile.c')
+  let targetfile = '/testplugin/test/c_files/testfile.c'
+  let g:ale_c_astyle_options = '.astylerc'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' --stdin=' . ale#Escape(targetfile)
+  \     . ' --project=' . g:ale_c_astyle_options
+  \ },
+  \ ale#fixers#astyle#Fix(bufnr(''))

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -1,11 +1,11 @@
 Before:
   Save g:ale_c_astyle_executable
-  Save g:ale_c_astyle_options
+  Save g:ale_c_astyle_project_options
 
   " Use an invalid global executable, so we don't match it.
   let g:ale_c_astyle_executable = 'xxxinvalid'
   let g:ale_cpp_astyle_executable = 'invalidpp'
-  
+
   call ale#test#SetDirectory('/testplugin/test/fixers')
 
 After:
@@ -38,14 +38,14 @@ Execute(The astyle callback should support cpp files):
 
 Execute(The astyle callback should support cpp files with option file set):
   call ale#test#SetFilename('../cpp_files/dummy.cpp')
-  let g:ale_cpp_astyle_options = '.astylerc_cpp'
+  let g:ale_cpp_astyle_project_options = '.astylerc_cpp'
   let targetfile = '/testplugin/test/cpp_files/dummy.cpp'
   set filetype=cpp " The test fails without this
 
   AssertEqual
   \ {
   \   'command': ale#Escape('invalidpp')
-  \     . ' --project=' . g:ale_cpp_astyle_options
+  \     . ' --project=' . g:ale_cpp_astyle_project_options
   \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
@@ -54,12 +54,12 @@ Execute(The astyle callback should support cpp files with option file set):
 Execute(The astyle callback should return the correct default values with an option file set):
   call ale#test#SetFilename('../c_files/testfile.c')
   let targetfile = '/testplugin/test/c_files/testfile.c'
-  let g:ale_c_astyle_options = '.astylerc'
+  let g:ale_c_astyle_project_options = '.astylerc'
 
   AssertEqual
   \ {
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' --project=' . g:ale_c_astyle_options
+  \     . ' --project=' . g:ale_c_astyle_project_options
   \     . ' --stdin='
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -21,3 +21,16 @@ Execute(The astyle callback should return the correct default values):
   \     . ' %t',
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
+
+Execute(The astyle callback should support cpp files):
+  call ale#test#SetFilename('../cpp_files/dummy.cpp')
+  let g:ale_cpp_astyle_executable = 'xxxinvalid'
+  set filetype=cpp " The test fails without this
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' %t',
+  \ },
+  \ ale#fixers#astyle#Fix(bufnr(''))

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -1,10 +1,13 @@
 Before:
   Save g:ale_c_astyle_executable
   Save g:ale_c_astyle_project_options
+  Save g:ale_cpp_astyle_project_options
 
   " Use an invalid global executable, so we don't match it.
   let g:ale_c_astyle_executable = 'xxxinvalid'
   let g:ale_cpp_astyle_executable = 'invalidpp'
+  let g:ale_c_astyle_project_options = ''
+  let g:ale_cpp_astyle_project_options = ''
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
 
@@ -14,6 +17,8 @@ After:
   call ale#test#RestoreDirectory()
 
 Execute(The astyle callback should return the correct default values):
+  " Because this file doesn't exist, no astylrc config
+  " exists near it. Therefore, project_options is empty.
   call ale#test#SetFilename('../c_files/testfile.c')
 
   AssertEqual
@@ -24,6 +29,8 @@ Execute(The astyle callback should return the correct default values):
   \ ale#fixers#astyle#Fix(bufnr(''))
 
 Execute(The astyle callback should support cpp files):
+  " Because this file doesn't exist, no astylrc config
+  " exists near it. Therefore, project_options is empty.
   call ale#test#SetFilename('../cpp_files/dummy.cpp')
   set filetype=cpp " The test fails without this
 

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -15,7 +15,6 @@ After:
 
 Execute(The astyle callback should return the correct default values):
   call ale#test#SetFilename('../c_files/testfile.c')
-  let targetfile = '/testplugin/test/c_files/testfile.c'
 
   AssertEqual
   \ {
@@ -26,7 +25,6 @@ Execute(The astyle callback should return the correct default values):
 
 Execute(The astyle callback should support cpp files):
   call ale#test#SetFilename('../cpp_files/dummy.cpp')
-  let targetfile = '/testplugin/test/cpp_files/dummy.cpp'
   set filetype=cpp " The test fails without this
 
   AssertEqual
@@ -39,7 +37,6 @@ Execute(The astyle callback should support cpp files):
 Execute(The astyle callback should support cpp files with option file set):
   call ale#test#SetFilename('../cpp_files/dummy.cpp')
   let g:ale_cpp_astyle_project_options = '.astylerc_cpp'
-  let targetfile = '/testplugin/test/cpp_files/dummy.cpp'
   set filetype=cpp " The test fails without this
 
   AssertEqual
@@ -50,10 +47,8 @@ Execute(The astyle callback should support cpp files with option file set):
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
-
 Execute(The astyle callback should return the correct default values with an option file set):
   call ale#test#SetFilename('../c_files/testfile.c')
-  let targetfile = '/testplugin/test/c_files/testfile.c'
   let g:ale_c_astyle_project_options = '.astylerc'
 
   AssertEqual


### PR DESCRIPTION
Hi all~~ First time commit!! Phew~~ 💦 

I'd like to add the astyle as a C formatter to ale. 

Technically, astyle supports [other formats](http://astyle.sourceforge.net/astyle.html) (Java, C#, ObjC, C++), but for simplicity, I'm adding astyle specifically for C. 

Please let me know if there are any changes I can make for a successful PR merge. 😄 

**--Edit--**
Closes issue #3228 

This PR also adds support for the following:
- C++
- project level options by providing the filename containing astyle options to `ale_c_astyle_options` or `ale_cpp_astyle_options`
  - e.g. If .astylerc is used in a project, add `let g:ale_c_astyle_options = .astylerc` to your vimrc, which passes the file name via [--project cmd line argument](http://astyle.sourceforge.net/astyle.html#_Option_Files). 
- redirection via stdin😅
