### PR TITLE
Restore old behavior of ALEFix command for Rubocop

### DIFF
--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -1,15 +1,18 @@
 call ale#Set('ruby_rubocop_options', '')
+call ale#Set('ruby_rubocop_auto_correct_all', '')
 call ale#Set('ruby_rubocop_executable', 'rubocop')
 
 function! ale#fixers#rubocop#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_rubocop_executable')
     let l:config = ale#path#FindNearestFile(a:buffer, '.rubocop.yml')
     let l:options = ale#Var(a:buffer, 'ruby_rubocop_options')
+    let l:auto_correct_all = ale#Var(a:buffer, 'ruby_rubocop_auto_correct_all')
 
     return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' --auto-correct-all --force-exclusion %t'
+    \   . (!empty(l:auto_correct_all) ? ' --auto-correct-all' : ' --auto-correct')
+    \   . ' --force-exclusion %t'
 endfunction
 
 function! ale#fixers#rubocop#Fix(buffer) abort

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -1,5 +1,5 @@
 call ale#Set('ruby_rubocop_options', '')
-call ale#Set('ruby_rubocop_auto_correct_all', '')
+call ale#Set('ruby_rubocop_auto_correct_all', 0)
 call ale#Set('ruby_rubocop_executable', 'rubocop')
 
 function! ale#fixers#rubocop#GetCommand(buffer) abort
@@ -11,7 +11,7 @@ function! ale#fixers#rubocop#GetCommand(buffer) abort
     return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . (!empty(l:auto_correct_all) ? ' --auto-correct-all' : ' --auto-correct')
+    \   . (l:auto_correct_all ? ' --auto-correct-all' : ' --auto-correct')
     \   . ' --force-exclusion %t'
 endfunction
 

--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -9,7 +9,7 @@ function! ale#fixers#rubocop#GetCommand(buffer) abort
     return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' --auto-correct --force-exclusion %t'
+    \   . ' --auto-correct-all --force-exclusion %t'
 endfunction
 
 function! ale#fixers#rubocop#Fix(buffer) abort

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -114,6 +114,14 @@ g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
   This variable can be changed to modify flags given to rubocop.
 
 
+g:ale_ruby_rubocop_auto_correct_all                *g:ale_ruby_rubocop_options*
+                                                   *b:ale_ruby_rubocop_options*
+  Type: Number
+  Default: `0`
+
+  This variable can be changed to make rubocop to correct all offenses (unsafe).
+
+
 ===============================================================================
 ruby                                                            *ale-ruby-ruby*
 

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -23,7 +23,7 @@ Execute(The rubocop callback should return the correct default values):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --auto-correct --force-exclusion %t',
+  \     . ' --auto-correct-all --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -35,7 +35,7 @@ Execute(The rubocop callback should include configuration files):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
-  \     . ' --auto-correct --force-exclusion %t',
+  \     . ' --auto-correct-all --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -49,6 +49,6 @@ Execute(The rubocop callback should include custom rubocop options):
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
   \     . ' --except Lint/Debugger'
-  \     . ' --auto-correct --force-exclusion %t',
+  \     . ' --auto-correct-all --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -23,7 +23,7 @@ Execute(The rubocop callback should return the correct default values):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --auto-correct-all --force-exclusion %t',
+  \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -35,7 +35,7 @@ Execute(The rubocop callback should include configuration files):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
-  \     . ' --auto-correct-all --force-exclusion %t',
+  \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
@@ -49,6 +49,6 @@ Execute(The rubocop callback should include custom rubocop options):
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
   \     . ' --except Lint/Debugger'
-  \     . ' --auto-correct-all --force-exclusion %t',
+  \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -52,3 +52,16 @@ Execute(The rubocop callback should include custom rubocop options):
   \     . ' --auto-correct --force-exclusion %t',
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
+
+Execute(The rubocop callback should use auto-correct-all option when set):
+  let g:ale_ruby_rubocop_auto_correct_all = 1
+  call ale#test#SetFilename('ruby_paths/with_config/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
+  \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.rubocop.yml'))
+  \     . ' --auto-correct-all --force-exclusion %t',
+  \ },
+  \ ale#fixers#rubocop#Fix(bufnr(''))


### PR DESCRIPTION
Since RuboCop 0.60 ALEFix command stopped to fix all found offenses. This change restores the 
previous behavior by allowing rubocop to fix all detected offenses.

Also see: https://docs.rubocop.org/rubocop/usage/auto_correct.html