### PR TITLE
Support markdownlint 0.19.0 and 0.22.0

### DIFF
--- a/autoload/ale/handlers/markdownlint.vim
+++ b/autoload/ale/handlers/markdownlint.vim
@@ -2,15 +2,22 @@
 " Description: Adds support for markdownlint
 
 function! ale#handlers#markdownlint#Handle(buffer, lines) abort
-    let l:pattern=': \(\d*\): \(MD\d\{3}\)\(\/\)\([A-Za-z0-9-]\+\)\(.*\)$'
+    let l:pattern=': \?\(\d\+\)\(:\(\d\+\)\?\)\? \(MD\d\{3}/[A-Za-z0-9-]\+\) \(.*\)$'
     let l:output=[]
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        call add(l:output, {
+        let l:result = ({
         \ 'lnum': l:match[1] + 0,
-        \ 'text': '(' . l:match[2] . l:match[3] . l:match[4] . ')' . l:match[5],
+        \ 'code': l:match[4],
+        \ 'text': l:match[5],
         \ 'type': 'W',
         \})
+
+        if len(l:match[3]) > 0
+            let l:result.col = (l:match[3] + 0)
+        endif
+
+        call add(l:output, l:result)
     endfor
 
     return l:output

--- a/test/handler/test_markdownlint_handler.vader
+++ b/test/handler/test_markdownlint_handler.vader
@@ -4,21 +4,74 @@ Before:
 After:
   call ale#linter#Reset()
 
-Execute(The Markdownlint handler should parse output correctly):
+Execute(The Markdownlint handler should parse pre v0.19.0 output with single digit line correctly):
   AssertEqual
   \ [
   \   {
   \     'lnum': 1,
-  \     'text': '(MD002/first-header-h1) First header should be a top level header [Expected: h1; Actual: h2]',
-  \     'type': 'W'
-  \   },
-  \   {
-  \     'lnum': 298,
-  \     'text': '(MD033/no-inline-html) Inline HTML [Element: p]',
+  \     'code': 'MD013/line-length',
+  \     'text': 'Line length [Expected: 80; Actual: 114]',
   \     'type': 'W'
   \   }
   \ ],
   \ ale#handlers#markdownlint#Handle(0, [
-  \ 'README.md: 1: MD002/first-header-h1 First header should be a top level header [Expected: h1; Actual: h2]',
-  \ 'README.md: 298: MD033/no-inline-html Inline HTML [Element: p]'
+  \ 'README.md: 1: MD013/line-length Line length [Expected: 80; Actual: 114]'
+  \ ])
+
+Execute(The Markdownlint handler should parse pre v0.19.0 output with multi digit line correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 100,
+  \     'code': 'MD013/line-length',
+  \     'text': 'Line length [Expected: 80; Actual: 114]',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale#handlers#markdownlint#Handle(0, [
+  \ 'README.md: 100: MD013/line-length Line length [Expected: 80; Actual: 114]'
+  \ ])
+
+Execute(The Markdownlint handler should parse post v0.19.0 output with single digit line correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'code': 'MD013/line-length',
+  \     'text': 'Line length [Expected: 80; Actual: 114]',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale#handlers#markdownlint#Handle(0, [
+  \ 'README.md:1 MD013/line-length Line length [Expected: 80; Actual: 114]'
+  \ ])
+
+Execute(The Markdownlint handler should parse post v0.19.0 output with multi digit line correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 100,
+  \     'code': 'MD013/line-length',
+  \     'text': 'Line length [Expected: 80; Actual: 114]',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale#handlers#markdownlint#Handle(0, [
+  \ 'README.md:100 MD013/line-length Line length [Expected: 80; Actual: 114]'
+  \ ])
+
+
+Execute(The Markdownlint handler should parse post v0.22.0 output with column correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 10,
+  \     'col':  20,
+  \     'code': 'MD013/line-length',
+  \     'text': 'Line length [Expected: 80; Actual: 114]',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale#handlers#markdownlint#Handle(0, [
+  \ 'README.md:10:20 MD013/line-length Line length [Expected: 80; Actual: 114]'
   \ ])


### PR DESCRIPTION
Fixes #2965

Markdownlint 0.19.0 removed spaces and colons in its output and 0.22.0 added columns. This pull request adds support for these changes while keeping compatibility with the old format. It also parses the `code` and adds it to the right place instead of the message.

Supersedes https://github.com/dense-analysis/ale/pull/2895 and https://github.com/dense-analysis/ale/pull/2926 which do not have support for 0.22.0 output 