### PR TITLE
bashate typo

### DIFF
--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -22,7 +22,7 @@ g:ale_sh_bashate_options                             *g:ale_sh_bashate_options*
   example to ignore the indentation rule:
 
 >
-  let g:ale_sh_shellcheck_options = '-i E003'
+  let g:ale_sh_bashate_options = '-i E003'
 <
 
 ===============================================================================


### PR DESCRIPTION
Looks like there was a leftover reference to shellcheck here when the documentation was created for bashate.
