### PR TITLE
Support markdownlint rules with multiple slashes

### DIFF
--- a/autoload/ale/handlers/markdownlint.vim
+++ b/autoload/ale/handlers/markdownlint.vim
@@ -2,7 +2,7 @@
 " Description: Adds support for markdownlint
 
 function! ale#handlers#markdownlint#Handle(buffer, lines) abort
-    let l:pattern=': \?\(\d\+\)\(:\(\d\+\)\?\)\? \(MD\d\{3}/[A-Za-z0-9-]\+\) \(.*\)$'
+    let l:pattern=': \?\(\d\+\)\(:\(\d\+\)\?\)\? \(MD\d\{3}/[A-Za-z0-9-/]\+\) \(.*\)$'
     let l:output=[]
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_markdownlint_handler.vader
+++ b/test/handler/test_markdownlint_handler.vader
@@ -75,3 +75,17 @@ Execute(The Markdownlint handler should parse post v0.22.0 output with column co
   \ ale#handlers#markdownlint#Handle(0, [
   \ 'README.md:10:20 MD013/line-length Line length [Expected: 80; Actual: 114]'
   \ ])
+
+Execute(The Markdownlint handler should parse output with multiple slashes in rule name correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 10,
+  \     'code': 'MD022/blanks-around-headings/blanks-around-headers',
+  \     'text': 'Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "### something"]',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale#handlers#markdownlint#Handle(0, [
+  \ 'README.md:10 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "### something"]'
+  \ ])


### PR DESCRIPTION
The markdownlint parser assumes that rules have the format MD000/something in the output, but in fact there are some rules that have the following format: MD000/something/something-else. This pull request adds support for that.