### PR TITLE
fix(ale_linters/phpcs): add support for multiline error messages

### DIFF
--- a/ale_linters/php/phpcs.vim
+++ b/ale_linters/php/phpcs.vim
@@ -23,7 +23,7 @@ function! ale_linters#php#phpcs#Handle(buffer, lines) abort
     " Matches against lines like the following:
     "
     " /path/to/some-filename.php:18:3: error - Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
-    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) - \(.\+\) (\(.\+\))$'
+    let l:pattern = '^.*:\(\d\+\):\(\d\+\): \(.\+\) - \(.\+\) (\(.\+\)).*$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_phpcs_handler.vader
+++ b/test/handler/test_phpcs_handler.vader
@@ -13,7 +13,16 @@ Execute(phpcs errors should be handled):
   \     'type': 'E',
   \     'sub_type': 'style',
   \     'text': 'Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)',
-  \   }],
+  \   },
+  \   {
+  \     'lnum': 22,
+  \     'col': 3,
+  \     'type': 'E',
+  \     'sub_type': 'style',
+  \     'text': 'All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks)',
+  \   },
+  \ ],
   \ ale_linters#php#phpcs#Handle(bufnr(''), [
   \ '/path/to/some-filename.php:18:3: error - Line indented incorrectly; expected 4 spaces, found 2 (Generic.WhiteSpace.ScopeIndent.IncorrectExact)',
+  \ "/path/to/some-filename.php:22:3: error - All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '\"\n'.",
   \ ])


### PR DESCRIPTION
This PR adds support for `phpcs` when there are errors resulting on messages containing more than one line.

An example would be :

```php
<?php
$foo = 'bar';
echo "
<div>
    <h1>hello world</h1>
    <p>$foo</p>
</div>
";
```

Before this fix, the command below would return an error, but Ale wouldn't catch it.
```
$ phpcs --report=emacs theme/single-member.php
/home/user/file-name.php:14:10: error - All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '"
'.
```