### PR TITLE
Add dmypy(mypy daemon) as a linter

### DIFF
--- a/ale_linters/python/dmypy.vim
+++ b/ale_linters/python/dmypy.vim
@@ -1,0 +1,61 @@
+" Author: Keith Smiley <k@keith.so>, w0rp <devw0rp@gmail.com>, davidatbu <davidat@bu.edu>
+" Description: dmypy (mypy daemon) support for optional python typechecking
+
+call ale#Set('python_dmypy_executable', 'dmypy')
+call ale#Set('python_dmypy_options', '')
+call ale#Set('python_dmypy_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_dmypy_auto_pipenv', 0)
+
+function! ale_linters#python#dmypy#GetExecutable(buffer) abort
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_dmypy_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
+    return ale#python#FindExecutable(a:buffer, 'python_dmypy', ['dmypy'])
+endfunction
+
+" The directory to change to before running dmypy
+function! s:GetDir(buffer) abort
+    " If we find a directory with ".dmypy.json" in it use that,
+    " else try and find the "python project" root, or failing
+    " that, run from the same folder as the current file
+    for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))
+        if filereadable(l:path . '/.dmypy.json')
+            return l:path
+        endif
+    endfor
+
+    let l:project_root = ale#python#FindProjectRoot(a:buffer)
+
+    return !empty(l:project_root)
+    \   ? l:project_root
+    \   : expand('#' . a:buffer . ':p:h')
+endfunction
+
+function! ale_linters#python#dmypy#GetCommand(buffer) abort
+    let l:dir = s:GetDir(a:buffer)
+    let l:executable = ale_linters#python#dmypy#GetExecutable(a:buffer)
+
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run dmypy'
+    \   : ''
+
+    " We have to always switch to an explicit directory for a command so
+    " we can know with certainty the base path for the 'filename' keys below.
+    return ale#path#CdString(l:dir)
+    \   . ale#Escape(l:executable) . l:exec_args
+    \   . ' run '
+    \   . ale#Var(a:buffer, 'python_dmypy_options')
+    \   . ' -- --show-column-numbers '
+    \   . ale#Var(a:buffer, 'python_mypy_options')
+    \   . ' --shadow-file %s %t %s'
+endfunction
+
+call ale#linter#Define('python', {
+\   'name': 'dmypy',
+\   'executable': function('ale_linters#python#dmypy#GetExecutable'),
+\   'command': function('ale_linters#python#dmypy#GetCommand'),
+\   'callback': 'ale_linters#python#mypy#Handle',
+\   'output_stream': 'both',
+\})

--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -7,6 +7,29 @@ call ale#Set('python_mypy_show_notes', 1)
 call ale#Set('python_mypy_options', '')
 call ale#Set('python_mypy_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_mypy_auto_pipenv', 0)
+call ale#Set('python_mypy_run_even_with_dmypy', 0)
+
+function! ale_linters#python#mypy#upgadeToDmypyIfPossible(buffer) abort
+    if !ale#Var(a:buffer, 'python_mypy_run_even_with_dmypy')
+        return
+    endif
+
+    let l:enabled_linters = ale#linter#GetLintersLoaded()
+
+    " Check if dmypy is enabled
+    if exists('enabled_linters["python"]')
+        for l:linter in l:enabled_linters['python']
+            if l:linter['name'] is? 'dmypy'
+                " Check if there's a .dmypy.json file
+                for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))
+                    if filereadable(l:path . '/.dmypy.json')
+                        " TODO: Ok, how do we abort running mypy now?
+                    endif
+                endfor
+            endif
+        endfor
+    endif
+endfunction
 
 function! ale_linters#python#mypy#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_mypy_auto_pipenv'))

--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -24,6 +24,7 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/pytest.ini')
         \|| filereadable(l:path . '/tox.ini')
         \|| filereadable(l:path . '/mypy.ini')
+        \|| filereadable(l:path . '/.dmypy.json')
         \|| filereadable(l:path . '/pycodestyle.cfg')
         \|| filereadable(l:path . '/.flake8')
         \|| filereadable(l:path . '/.flake8rc')

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -28,6 +28,7 @@ ALE will look for configuration files with the following filenames. >
   pytest.ini
   tox.ini
   mypy.ini
+  .dmypy.json
   pycodestyle.cfg
   .flake8
   .flake8rc

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -361,6 +361,7 @@ Notes:
   * `autopep8`
   * `bandit`
   * `black`
+  * `dmypy`
   * `flake8`
   * `isort`
   * `mypy`

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -373,6 +373,7 @@ formatting.
   * [flake8](http://flake8.pycqa.org/en/latest/)
   * [isort](https://github.com/timothycrosley/isort)
   * [mypy](http://mypy-lang.org/)
+  * [dmypy](https://mypy.readthedocs.io/en/stable/mypy_daemon.html)
   * [prospector](https://github.com/PyCQA/prospector) :warning:
   * [pycodestyle](https://github.com/PyCQA/pycodestyle) :warning:
   * [pydocstyle](https://www.pydocstyle.org/) :warning:


### PR DESCRIPTION
Two years ago, in #1557 , `dmypy` support was discussed. @ascandella implemented a proof-of-concept on his own fork, but that never made it through to an actual PR. This is another attempt. This time, I tried to follow @w0rp 's suggestions on keeping `dmypy` and `mypy` as separate linters.

## Question
This PR is a draft PR because I am not sure how to go about disabling `mypy` if `dmypy` is installed (and there's a `.dmypy.json` file somewhere). This idea was also @w0rp 's suggestion in #1557 . If someone can point me to what the best way to do that would be, that's be great. 

## Other important points
 - There's a new `python_mypy_run_even_with_dmypy` flag, according to @w0rp  's suggestion(it's not being used right now, look at "Question" above).
This linter uses the same `Handle` function as the `mypy` linter(Which means it uses the flags `python_mypy_ignore_invalid_syntax` and `python_mypy_show_notes`). 
- Additionally, this linter also uses the `python_mypy_options`, _in addition_ to `python_dmypy_options`. The latter is meant for `dmypy`-only options.
 
Once the question above is answered, I'd be happy to write tests, and once we finalize the implementation, the documentation.
