### PR TITLE
Update ale_ruby_rubocop_auto_correct_all tag

### DIFF
--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -114,8 +114,8 @@ g:ale_ruby_rubocop_options                         *g:ale_ruby_rubocop_options*
   This variable can be changed to modify flags given to rubocop.
 
 
-g:ale_ruby_rubocop_auto_correct_all                *g:ale_ruby_rubocop_options*
-                                                   *b:ale_ruby_rubocop_options*
+g:ale_ruby_rubocop_auto_correct_all       *g:ale_ruby_rubocop_auto_correct_all*
+                                          *b:ale_ruby_rubocop_auto_correct_all*
   Type: Number
   Default: `0`
 


### PR DESCRIPTION
Looks like updating the tags for `ale_ruby_rubocop_auto_correct_all` was missed; they're the same tags as `ale_ruby_rubocop_options`.