### PR TITLE
latexindent: Run fixer from stdin instead of a temporary file

### DIFF
--- a/autoload/ale/fixers/latexindent.vim
+++ b/autoload/ale/fixers/latexindent.vim
@@ -10,9 +10,7 @@ function! ale#fixers#latexindent#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' -l -w'
+    \       . ' -l'
     \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' %t',
-    \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_latexindent_fixer_callback.vader
+++ b/test/fixers/test_latexindent_fixer_callback.vader
@@ -18,10 +18,8 @@ Execute(The latexindent callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' -l -w'
-  \     . ' %t',
+  \     . ' -l'
   \ },
   \ ale#fixers#latexindent#Fix(bufnr(''))
 
@@ -31,10 +29,8 @@ Execute(The latexindent callback should include custom gofmt options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' -l -w'
+  \     . ' -l'
   \     . ' ' . g:ale_tex_latexindent_options
-  \     . ' %t',
   \ },
   \ ale#fixers#latexindent#Fix(bufnr(''))


### PR DESCRIPTION
Latexindent supports reading from STDIN since 2018 as specified [here](https://latexindentpl.readthedocs.io/en/latest/sec-how-to-use.html?highlight=stdin#from-the-command-line). So, I have modified the fixer to read from the file directly through STDIN redirection instead of creating temporary files.

I have also fixed the tests which were reading from temporary files to work on STDIN. All tests are passing in my fork and code formatting should be good to go. Thanks!