### PR TITLE
Added support for local solhint executable

### DIFF
--- a/ale_linters/solidity/solhint.vim
+++ b/ale_linters/solidity/solhint.vim
@@ -5,16 +5,30 @@
 function! ale_linters#solidity#solhint#Handle(buffer, lines) abort
     " Matches patterns like the following:
     " /path/to/file/file.sol: line 1, col 10, Error - 'addOne' is defined but never used. (no-unused-vars)
-    let l:pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (.*) \((.*)\)$'
     let l:output = []
 
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+    let l:lint_pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (.*) \((.*)\)$'
+
+    for l:match in ale#util#GetMatches(a:lines, l:lint_pattern)
         let l:isError = l:match[3] is? 'error'
         call add(l:output, {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 0,
         \   'text': l:match[4],
         \   'code': l:match[5],
+        \   'type': l:isError ? 'E' : 'W',
+        \})
+    endfor
+
+    let l:syntax_pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (Parse error): (.*)$'
+
+    for l:match in ale#util#GetMatches(a:lines, l:syntax_pattern)
+        let l:isError = l:match[3] is? 'error'
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[5],
+        \   'code': l:match[4],
         \   'type': l:isError ? 'E' : 'W',
         \})
     endfor

--- a/ale_linters/solidity/solhint.vim
+++ b/ale_linters/solidity/solhint.vim
@@ -1,4 +1,5 @@
-" Author: Franco Victorio - https://github.com/fvictorio
+" Authors: Franco Victorio - https://github.com/fvictorio, Henrique Barcelos
+" https://github.com/hbarcelos
 " Description: Report errors in Solidity code with solhint
 
 function! ale_linters#solidity#solhint#Handle(buffer, lines) abort
@@ -23,7 +24,7 @@ endfunction
 
 call ale#linter#Define('solidity', {
 \   'name': 'solhint',
-\   'executable': 'solhint',
-\   'command': 'solhint --formatter compact %t',
+\   'executable': function('ale#handlers#solhint#GetExecutable'),
+\   'command': function('ale#handlers#solhint#GetCommand'),
 \   'callback': 'ale_linters#solidity#solhint#Handle',
 \})

--- a/autoload/ale/handlers/solhint.vim
+++ b/autoload/ale/handlers/solhint.vim
@@ -1,0 +1,65 @@
+" Author: Henrique Barcelos <@hbarcelos>
+" Description: Functions for working with local solhint for checking *.sol files.
+
+let s:executables = [
+\   'node_modules/.bin/solhint',
+\   'node_modules/solhint/solhint.js',
+\]
+
+let s:sep = has('win32') ? '\' : '/'
+
+call ale#Set('solidity_solhint_options', '')
+call ale#Set('solidity_solhint_executable', 'solhint')
+call ale#Set('solidity_solhint_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! ale#handlers#solhint#FindConfig(buffer) abort
+    for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))
+        for l:basename in [
+        \   '.solhintrc.js',
+        \   '.solhintrc.json',
+        \   '.solhintrc',
+        \]
+            let l:config = ale#path#Simplify(join([l:path, l:basename], s:sep))
+
+            if filereadable(l:config)
+                return l:config
+            endif
+        endfor
+    endfor
+
+    return ale#path#FindNearestFile(a:buffer, 'package.json')
+endfunction
+
+function! ale#handlers#solhint#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'solidity_solhint', s:executables)
+endfunction
+
+" Given a buffer, return a command prefix string which changes directory
+" as necessary for running solhint.
+function! ale#handlers#solhint#GetCdString(buffer) abort
+    " If solhint is installed in a directory which contains the buffer, assume
+    " it is the solhint project root. Otherwise, use nearest node_modules.
+    " Note: If node_modules not present yet, can't load local deps anyway.
+    let l:executable = ale#node#FindNearestExecutable(a:buffer, s:executables)
+
+    if !empty(l:executable)
+        let l:nmi = strridx(l:executable, 'node_modules')
+        let l:project_dir = l:executable[0:l:nmi - 2]
+    else
+        let l:modules_dir = ale#path#FindNearestDirectory(a:buffer, 'node_modules')
+        let l:project_dir = !empty(l:modules_dir) ? fnamemodify(l:modules_dir, ':h:h') : ''
+    endif
+
+    return !empty(l:project_dir) ? ale#path#CdString(l:project_dir) : ''
+endfunction
+
+function! ale#handlers#solhint#GetCommand(buffer) abort
+    let l:executable = ale#handlers#solhint#GetExecutable(a:buffer)
+
+    let l:options = ale#Var(a:buffer, 'solidity_solhint_options')
+
+    return ale#handlers#solhint#GetCdString(a:buffer)
+    \   . ale#node#Executable(a:buffer, l:executable)
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' --formatter compact %s'
+endfunction

--- a/autoload/ale/handlers/solhint.vim
+++ b/autoload/ale/handlers/solhint.vim
@@ -4,6 +4,7 @@
 let s:executables = [
 \   'node_modules/.bin/solhint',
 \   'node_modules/solhint/solhint.js',
+\   'solhint',
 \]
 
 let s:sep = has('win32') ? '\' : '/'

--- a/test/command_callback/test_solhint_command_callback.vader
+++ b/test/command_callback/test_solhint_command_callback.vader
@@ -1,0 +1,18 @@
+Before:
+  call ale#assert#SetUpLinterTest('solidity', 'solhint')
+  call ale#test#SetFilename('Example.sol')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default solhint command should be correct):
+  AssertLinter 'solhint',
+  \ ale#path#CdString(expand('%:p:h'))
+  \   . ale#Escape('solhint') . ' --formatter compact %s'
+
+Execute(The executable should be configurable and escaped):
+  let b:ale_solidity_solhint_executable = 'foo bar'
+
+  AssertLinter 'foo bar',
+  \ ale#path#CdString(expand('%:p:h'))
+  \   . ale#Escape('foo bar') . ' --formatter compact %s'

--- a/test/handler/test_solhint_handler.vader
+++ b/test/handler/test_solhint_handler.vader
@@ -4,7 +4,7 @@ Before:
 After:
   call ale#linter#Reset()
 
-Execute(The vint handler should parse error messages correctly):
+Execute(The solhint handler should parse linter error messages correctly):
   AssertEqual
   \ [
   \   {
@@ -57,4 +57,28 @@ Execute(The vint handler should parse error messages correctly):
   \   'contracts/Bounty.sol: line 13, col 3, Error - Expected indentation of 4 spaces but found 2 (indent)',
   \   'contracts/Bounty.sol: line 14, col 3, Error - Expected indentation of 4 spaces but found 2 (indent)',
   \   'contracts/Bounty.sol: line 47, col 3, Error - Function order is incorrect, public function can not go after internal function. (func-order)',
+  \ ])
+
+
+Execute(The solhint handler should parse syntax error messages correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 30,
+  \     'col': 4,
+  \     'text': "missing ';' at 'uint248'",
+  \     'code': 'Parse error',
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 203,
+  \     'col': 4,
+  \     'text': "no viable alternative at input '_loserStakeMultiplier}'",
+  \     'code': 'Parse error',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#solidity#solhint#Handle(bufnr(''), [
+  \   "contracts/Bounty.sol: line 30, col 4, Error - Parse error: missing ';' at 'uint248'",
+  \   "contracts/Bounty.sol: line 203, col 4, Error - Parse error: no viable alternative at input '_loserStakeMultiplier}'",
   \ ])


### PR DESCRIPTION
Fixes #3304 .

This is a shameless copy of `eslint` handler. `solhint` is also managed with the node.js ecosystem, so it should follow basically the same rules.

I haven't added any specific test for this because the only test present so far at `test/handler/test_solhint_handler.vader` regards only parsing the error messages correctly.

If that's still a requirement, I'd need some guidance because I'm not used to writing tests with vader.
I did manually test it locally and it's working as expected.