### PR TITLE
Add dhall-format as a Fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -375,6 +375,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['html', 'htmldjango'],
 \       'description': 'Fix HTML files with html-beautify.',
 \   },
+\   'dhall': {
+\       'function': 'ale#fixers#dhall#Fix',
+\       'suggested_filetypes': ['dhall'],
+\       'description': 'Fix Dhall files with dhall-format.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/dhall.vim
+++ b/autoload/ale/fixers/dhall.vim
@@ -1,0 +1,23 @@
+" Author: Pat Brisbin <pbrisbin@gmail.com>
+" Description: Integration of dhall-format with ALE.
+
+call ale#Set('dhall_format_executable', 'dhall')
+
+function! ale#fixers#dhall#GetExecutable(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'dhall_format_executable')
+
+    " Dhall is written in Haskell and commonly installed with Stack
+    return ale#handlers#haskell_stack#EscapeExecutable(l:executable, 'dhall')
+endfunction
+
+function! ale#fixers#dhall#Fix(buffer) abort
+    let l:executable = ale#fixers#dhall#GetExecutable(a:buffer)
+
+    return {
+    \   'command': l:executable
+    \       . ' format'
+    \       . ' --inplace'
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -119,6 +119,8 @@ Notes:
   * `dartanalyzer`!!
   * `dartfmt`!!
   * `language_server`
+* Dhall
+  * `dhall-format`
 * Dockerfile
   * `dockerfile_lint`
   * `hadolint`

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -128,6 +128,8 @@ formatting.
   * [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli) :floppy_disk:
   * [dartfmt](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)
   * [language_server](https://github.com/natebosch/dart_language_server)
+* Dhall
+  * [dhall-format](https://github.com/dhall-lang/dhall-lang)
 * Dockerfile
   * [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint)
   * [hadolint](https://github.com/hadolint/hadolint)

--- a/test/fixers/test_dhall_fixer_callback.vader
+++ b/test/fixers/test_dhall_fixer_callback.vader
@@ -1,0 +1,11 @@
+Before:
+  call ale#assert#SetUpFixerTest('dhall', 'dhall')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The default command should be correct):
+  AssertFixer
+  \ { 'read_temporary_file': 1,
+  \   'command': ale#Escape('dhall') . ' format --inplace %t'
+  \ }


### PR DESCRIPTION
https://github.com/dhall-lang/dhall-lang

I modeled this after a combination of Brittany (in that it's commonly installed via `stack`) and Terraform
(in that it has a formatting sub-command).

The tests pass locally except for Swift failing the sorting test, which seems unrelated to me. Let me know
if it's not and I need to change anything.

Thanks!
