### PR TITLE
Improved macro handling in gcc

### DIFF
--- a/test/handler/test_gcc_handler.vader
+++ b/test/handler/test_gcc_handler.vader
@@ -279,3 +279,38 @@ Execute(The GCC handler should handle errors for inlined header functions):
   \ '     __open_too_many_args ();',
   \ '     ^~~~~~~~~~~~~~~~~~~~~~~',
   \ ])
+
+Execute(The GCC handler should handle macro expansion errors in current file):
+  AssertEqual
+  \ [
+  \   {
+  \    'lnum': 1,
+  \    'col': 19,
+  \    'type': 'E',
+  \    'text': 'error message',
+  \    'detail': "error message\n<stdin>:1:19: note: in expansion of macro 'TEST'",
+  \   },
+  \ ],
+  \ ale#handlers#gcc#HandleGCCFormatWithIncludes(347, [
+  \ '<command-line>: error: error message',
+  \ '<stdin>:1:19: note: in expansion of macro ‘TEST’',
+  \ '  1 | std::string str = TEST;',
+  \ '    |                   ^~~~',
+  \ ])
+
+Execute(The GCC handler should handle macro expansion errors in other files):
+  AssertEqual
+  \ [
+  \  {
+  \    'lnum': 0,
+  \    'type': 'E',
+  \    'text': 'Error found in macro expansion. See :ALEDetail',
+  \    'detail': "error message\ninc.h:1:19: note: in expansion of macro 'TEST'",
+  \  },
+  \ ],
+  \ ale#handlers#gcc#HandleGCCFormatWithIncludes(347, [
+  \ '<command-line>: error: error message',
+  \ 'inc.h:1:19: note: in expansion of macro ‘TEST’',
+  \ '  1 | std::string str = TEST;',
+  \ '    |                   ^~~~',
+  \ ])


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->
Here is the fix for #3320. I went with a solution where if the macro expansion error happens in the current file, set ```lnum``` and ```col``` accordingly. If the error happens in some other file, there's really no easy way to know on which line the error should be placed on in the current file, so just let ```lnum``` be 0.

For example, consider this situation:
```
/* c.cpp */
#include <string>
#include "header1.h"

int main(){
   return 0;
}
```
```
/* header1.h */
#include "header2.h"
```
```
/* header2.h */
std::string str = TEST;
```
```
# compile with
g++ c.cpp -DTEST='w'
```

The error reported by GCC would be
```
<command-line>: error: ‘w’ was not declared in this scope
header2.h:1:19: note: in expansion of macro ‘TEST’
    1 | std::string str = TEST;
      |                   ^~~~
```
To figure out on which line in ```c.cpp``` we should place the error we would need to go through the different headers in ```c.cpp``` until we find ```header2.h```. I think that's a bit overkill, and just letting the ```lnum``` be zero with the ```text``` ```Error found in macro expansion. See :ALEDetail``` is (hopefully) good enough.