### PR TITLE
feat: Adds variable to use custom config file with Elixir Credo

### DIFF
--- a/ale_linters/elixir/credo.vim
+++ b/ale_linters/elixir/credo.vim
@@ -45,6 +45,16 @@ function! ale_linters#elixir#credo#GetMode() abort
     endif
 endfunction
 
+function! ale_linters#elixir#credo#GetConfigFile() abort
+    let l:config_file = get(g:, 'ale_elixir_credo_config_file', '')
+
+    if len(l:config_file) == 0
+        return ''
+    else
+        return ' --config-file ' . l:config_file
+    endif
+endfunction
+
 function! ale_linters#elixir#credo#GetCommand(buffer) abort
     let l:project_root = ale#handlers#elixir#FindMixUmbrellaRoot(a:buffer)
     let l:mode = ale_linters#elixir#credo#GetMode()
@@ -52,6 +62,7 @@ function! ale_linters#elixir#credo#GetCommand(buffer) abort
     return ale#path#CdString(l:project_root)
     \ . 'mix help credo && '
     \ . 'mix credo ' . ale_linters#elixir#credo#GetMode()
+    \ . ale_linters#elixir#credo#GetConfigFile()
     \ . ' --format=flycheck --read-from-stdin %s'
 endfunction
 

--- a/doc/ale-elixir.txt
+++ b/doc/ale-elixir.txt
@@ -85,5 +85,12 @@ g:ale_elixir_credo_strict                           *g:ale_elixir_credo_strict*
   Tells credo to run in strict mode or suggest mode.  Set variable to 1 to
   enable --strict mode.
 
+g:ale_elixir_credo_config_file                 g:ale_elixir_credo_config_file
+
+  Type: String
+  Default: ''
+
+  Tells credo to use a custom configuration file.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/test_elixir_credo.vader
+++ b/test/test_elixir_credo.vader
@@ -2,19 +2,21 @@ Before:
   call ale#test#SetDirectory('/testplugin/test')
 
   runtime ale_linters/elixir/credo.vim
+  let g:test_command_start = ale#path#CdString('.') . 'mix help credo && '
 
 After:
   call ale#test#RestoreDirectory()
   call ale#linter#Reset()
   let g:ale_elixir_credo_strict = 0
   let g:ale_elixir_credo_config_file = ''
+  let g:test_command_start = ''
 
 Execute(credo runs the right command):
   call ale#test#SetFilename('elixir-test-files/testfile.ex')
 
   AssertEqual
   \ ale_linters#elixir#credo#GetCommand(bufnr('')),
-  \ 'cd ''.'' && mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
+  \ g:test_command_start . 'mix credo suggest --format=flycheck --read-from-stdin %s'
 
 Execute(credo runs the right command with the strict flag):
   let g:ale_elixir_credo_strict = 1
@@ -22,7 +24,7 @@ Execute(credo runs the right command with the strict flag):
 
   AssertEqual
   \ ale_linters#elixir#credo#GetCommand(bufnr('')),
-  \ 'cd ''.'' && mix help credo && mix credo --strict --format=flycheck --read-from-stdin %s'
+  \ g:test_command_start . 'mix credo --strict --format=flycheck --read-from-stdin %s'
 
 Execute(credo runs the right command with a custom config file):
   let g:ale_elixir_credo_config_file = '/home/user/custom_credo.exs'
@@ -30,4 +32,4 @@ Execute(credo runs the right command with a custom config file):
 
   AssertEqual
   \ ale_linters#elixir#credo#GetCommand(bufnr('')),
-  \ 'cd ''.'' && mix help credo && mix credo suggest --config-file /home/user/custom_credo.exs --format=flycheck --read-from-stdin %s'
+  \ g:test_command_start . 'mix credo suggest --config-file /home/user/custom_credo.exs --format=flycheck --read-from-stdin %s'

--- a/test/test_elixir_credo.vader
+++ b/test/test_elixir_credo.vader
@@ -1,0 +1,33 @@
+Before:
+  call ale#test#SetDirectory('/testplugin/test')
+
+  runtime ale_linters/elixir/credo.vim
+
+After:
+  call ale#test#RestoreDirectory()
+  call ale#linter#Reset()
+  let g:ale_elixir_credo_strict = 0
+  let g:ale_elixir_credo_config_file = ''
+
+Execute(credo runs the right command):
+  call ale#test#SetFilename('elixir-test-files/testfile.ex')
+
+  AssertEqual
+  \ ale_linters#elixir#credo#GetCommand(bufnr('')),
+  \ 'cd ''.'' && mix help credo && mix credo suggest --format=flycheck --read-from-stdin %s'
+
+Execute(credo runs the right command with the strict flag):
+  let g:ale_elixir_credo_strict = 1
+  call ale#test#SetFilename('elixir-test-files/testfile.ex')
+
+  AssertEqual
+  \ ale_linters#elixir#credo#GetCommand(bufnr('')),
+  \ 'cd ''.'' && mix help credo && mix credo --strict --format=flycheck --read-from-stdin %s'
+
+Execute(credo runs the right command with a custom config file):
+  let g:ale_elixir_credo_config_file = '/home/user/custom_credo.exs'
+  call ale#test#SetFilename('elixir-test-files/testfile.ex')
+
+  AssertEqual
+  \ ale_linters#elixir#credo#GetCommand(bufnr('')),
+  \ 'cd ''.'' && mix help credo && mix credo suggest --config-file /home/user/custom_credo.exs --format=flycheck --read-from-stdin %s'


### PR DESCRIPTION
Adds `g:ale_elixir_credo_config_file` to allow users to use a custom configuration file for the checks. Motivation is my company using a centralised configuration file for all of our Elixir projects, so it's our belief that more people could benefit from this option.

Apart from that, this PR also adds tests in general for Credo calls, because there were none before.

Thank you!