### PR TITLE
Fix asciidoc languagetool integration

### DIFF
--- a/ale_linters/asciidoc/languagetool.vim
+++ b/ale_linters/asciidoc/languagetool.vim
@@ -2,4 +2,4 @@
 " Description: languagetool for asciidoc files, copied from markdown.
 
 
-call ale#handlers#languagetool#DefineLinter('asciidoctor')
+call ale#handlers#languagetool#DefineLinter('asciidoc')


### PR DESCRIPTION
This fixes a typo in `asciidoc/languagetool.vim` that prevented languagetool from being loaded in asciidoc files at all.

Also, big thanks to all the contributors for bringing this awesome project :)