### PR TITLE
Fix ghdl and vcom linter regex patterns to support Windows paths (i.e. drive letter and colon C:)

### DIFF
--- a/ale_linters/vhdl/ghdl.vim
+++ b/ale_linters/vhdl/ghdl.vim
@@ -13,7 +13,21 @@ function! ale_linters#vhdl#ghdl#Handle(buffer, lines) abort
     " Look for 'error' lines like the following:
     " dff_en.vhd:41:5:error: 'begin' is expected instead of 'if'
     " /path/to/file.vhdl:12:8: no declaration for "i0"
-    let l:pattern = '^[a-zA-Z0-9\-\.\_\/ ]\+:\(\d\+\):\(\d\+\):\(.*\)'
+    " tb_me_top.vhd:37:10 warning: Instantiating module me_top with dangling input port 1 (rst_n) floating.
+    " tb_me_top.vhd:17:9 syntax error
+    " memory_single_port.vhd:2:10 syntax error
+    " C:\users\tb_me_top.vhd:17:6:20 error: Invalid module instantiation
+    "
+    " Regex descriptions:
+    " ^ start of line
+    " \s*      0 or more whitespaces
+    " \u\=     0 or 1 Uppercase letter (for Drive letter)
+    " :\=      0 or 1 colon (for Drive letter)
+    " [^:]\+   1 or more greedy any character EXCEPT colon
+    " :\(\d\+\) Capture number(line num) after first colon
+    " :\(\d\+\) Capture number(column/row num) after second colon
+    " : \(.\+\) Capture rest of message string
+    let l:pattern = '^\s*\u\=:\=[^:]\+:\(\d\+\):\(\d\+\): \(.\+\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
@@ -27,6 +41,7 @@ function! ale_linters#vhdl#ghdl#Handle(buffer, lines) abort
 
     return l:output
 endfunction
+
 
 call ale#linter#Define('vhdl', {
 \   'name': 'ghdl',

--- a/ale_linters/vhdl/ghdl.vim
+++ b/ale_linters/vhdl/ghdl.vim
@@ -27,7 +27,7 @@ function! ale_linters#vhdl#ghdl#Handle(buffer, lines) abort
     " :\(\d\+\) Capture number(line num) after first colon
     " :\(\d\+\) Capture number(column/row num) after second colon
     " : \(.\+\) Capture rest of message string
-    let l:pattern = '^\s*\u\=:\=[^:]\+:\(\d\+\):\(\d\+\):\s*\(.\+\)'
+    let l:pattern = '^\s*\u\=:\=[^:]\+:\(\d\+\):\(\d\+\):\(.*\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/ale_linters/vhdl/ghdl.vim
+++ b/ale_linters/vhdl/ghdl.vim
@@ -27,7 +27,7 @@ function! ale_linters#vhdl#ghdl#Handle(buffer, lines) abort
     " :\(\d\+\) Capture number(line num) after first colon
     " :\(\d\+\) Capture number(column/row num) after second colon
     " : \(.\+\) Capture rest of message string
-    let l:pattern = '^\s*\u\=:\=[^:]\+:\(\d\+\):\(\d\+\): \(.\+\)'
+    let l:pattern = '^\s*\u\=:\=[^:]\+:\(\d\+\):\(\d\+\):\s*\(.\+\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/ale_linters/vhdl/vcom.vim
+++ b/ale_linters/vhdl/vcom.vim
@@ -15,13 +15,27 @@ function! ale_linters#vhdl#vcom#Handle(buffer, lines) abort
     "** Error: tb_file.vhd(73): (vcom-1136) Unknown identifier "aresetn".
     "** Error: tb_file.vhd(73): Bad resolution function (STD_LOGIC) for type (error).
     "** Error: tb_file.vhd(73): near ":": (vcom-1576) expecting ';' or ')'.
-    let l:pattern = '^**\s\(\w*\):[a-zA-Z0-9\-\.\_\/ ]\+(\(\d\+\)):\s\+\(.*\)'
+    "** Error: C:\Users\avander\AppData\Local\Temp\VICE0F.tmp\file.vhd(25): Unknown expanded name
+    "** Error (suppressible): C:\Users\avander\AppData\Local\Temp\VICE0F.tmp\file.vhd(25):
+    "                         (vcom-1195) Cannot find expanded name "work.Pkgpackage".
+    "
+    "Regex description:
+    "^          Start of line
+    "**         vcom message leader literal
+    "\s         single whitespace
+    "\([^:]\+\) Capture 1 or more greedy any character EXCEPT colon
+    ":\s        Colon and single whitespace
+    "[^(]\+     1 or more greedy any character EXCEPT open parentheses
+    "(\(\d\+\)) Capture line number in parentheses
+    ":\s\+      Colon and whitespace
+    "\(.*\)     Capture rest of message string
+    let l:pattern = '^**\s\([^:]\+\):\s[^(]\+(\(\d\+\)):\s\+\(.*\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'lnum': l:match[2] + 0,
-        \   'type': l:match[1] is? 'Error' ? 'E' : 'W',
+        \   'type': l:match[1] is? 'Warning' ? 'W' : 'E',
         \   'text': l:match[3],
         \})
     endfor


### PR DESCRIPTION
Resolves #3340 
Resolves #3239 

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

