### PR TITLE
Add Pandoc for markdown formatting

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -76,7 +76,7 @@ let s:default_registry = {
 \   },
 \   'pandoc': {
 \       'function': 'ale#fixers#pandoc#Fix',
-\       'suggested_filetypes': ['pandoc'],
+\       'suggested_filetypes': ['markdown'],
 \       'description': 'Format pandoc markdown with pandoc.'
 \   },
 \   'prettier': {

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -74,6 +74,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['python'],
 \       'description': 'Sort Python imports with isort.',
 \   },
+\   'pandoc': {
+\       'function': 'ale#fixers#pandoc#Fix',
+\       'suggested_filetypes': ['pandoc'],
+\       'description': 'Format pandoc markdown with pandoc.'
+\   },
 \   'prettier': {
 \       'function': 'ale#fixers#prettier#Fix',
 \       'suggested_filetypes': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue', 'html', 'yaml'],

--- a/autoload/ale/fixers/pandoc.vim
+++ b/autoload/ale/fixers/pandoc.vim
@@ -1,0 +1,32 @@
+" Author: Eric Zhao <21zhaoe@protonmail.com>
+" Description: Format Pandoc markdown with pandoc.
+
+call ale#Set('pandoc_pandoc_executable', 'pandoc')
+call ale#Set('pandoc_pandoc_input_flags', [])
+call ale#Set('pandoc_pandoc_target_flags', [])
+call ale#Set('pandoc_pandoc_options', [])
+
+function! ale#fixers#pandoc#Var(buffer, name) abort
+    return ale#Var(a:buffer, 'pandoc_pandoc_' . a:name)
+endfunction
+
+function! ale#fixers#pandoc#Fix(buffer) abort
+    let l:executable = ale#fixers#pandoc#Var(a:buffer, 'executable')
+    let l:filename = ale#Escape(bufname(a:buffer))
+
+    let l:input_flags = ale#fixers#pandoc#Var(a:buffer, 'input_flags')
+    let l:target_flags = ale#fixers#pandoc#Var(a:buffer, 'target_flags')
+    let l:options = ale#fixers#pandoc#Var(a:buffer, 'options')
+
+    let l:command = ale#Escape(l:executable)
+    \   . ' -f markdown' . join(l:input_flags, '')
+    \   . ' -t markdown' . join(l:target_flags, '')
+    \   . ' -s '
+    \   . join(l:options, ' ')
+    \   . ' '
+    \   . l:filename
+
+    return {
+    \   'command': l:command
+    \}
+endfunction

--- a/autoload/ale/fixers/pandoc.vim
+++ b/autoload/ale/fixers/pandoc.vim
@@ -1,13 +1,13 @@
 " Author: Eric Zhao <21zhaoe@protonmail.com>
 " Description: Format Pandoc markdown with pandoc.
 
-call ale#Set('pandoc_pandoc_executable', 'pandoc')
-call ale#Set('pandoc_pandoc_input_flags', [])
-call ale#Set('pandoc_pandoc_target_flags', [])
-call ale#Set('pandoc_pandoc_options', [])
+call ale#Set('markdown_pandoc_executable', 'pandoc')
+call ale#Set('markdown_pandoc_input_flags', [])
+call ale#Set('markdown_pandoc_target_flags', [])
+call ale#Set('markdown_pandoc_options', [])
 
 function! ale#fixers#pandoc#Var(buffer, name) abort
-    return ale#Var(a:buffer, 'pandoc_pandoc_' . a:name)
+    return ale#Var(a:buffer, 'markdown_pandoc_' . a:name)
 endfunction
 
 function! ale#fixers#pandoc#Fix(buffer) abort

--- a/autoload/ale/fixers/pandoc.vim
+++ b/autoload/ale/fixers/pandoc.vim
@@ -22,8 +22,7 @@ function! ale#fixers#pandoc#Fix(buffer) abort
     \   . ' -f markdown' . join(l:input_flags, '')
     \   . ' -t markdown' . join(l:target_flags, '')
     \   . ' -s '
-    \   . join(l:options, ' ')
-    \   . ' '
+    \   . (empty(l:options) ? '' : join(l:options, ' ') . ' ')
     \   . l:filename
 
     return {

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -62,7 +62,7 @@ g:ale_markdown_pandoc_target_flags         *g:ale_markdown_pandoc_target_flags*
 
 g:ale_markdown_pandoc_options                   *g:ale_markdown_pandoc_options*
                                                 *b:ale_markdown_pandoc_options*
-  Type: List
+  Type: |List|
   Default: `[]`
 
   This variable can be set to pass additional options to pandoc.

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -32,6 +32,40 @@ g:ale_markdown_mdl_options                         *g:ale_markdown_mdl_options*
 
   This variable can be set to pass additional options to mdl.
 
+===============================================================================
+pandoc                                                    *ale-markdown-pandoc*
+
+g:ale_markdown_pandoc_executable             *g:ale_markdown_pandoc_executable*
+                                             *b:ale_markdown_pandoc_executable*
+  Type: |String|
+  Default: `'pandoc'`
+
+  Override the invoked pandoc binary.
+
+
+g:ale_markdown_pandoc_input_flags           *g:ale_markdown_pandoc_input_flags*
+                                            *b:ale_markdown_pandoc_input_flags*
+  Type: |List|
+  Default: `[]`
+
+  This variable can be set to enable and disable extensions for reading
+  the input file. See https://pandoc.org/MANUAL.html#extensions.
+
+
+g:ale_markdown_pandoc_target_flags         *g:ale_markdown_pandoc_target_flags*
+                                           *b:ale_markdown_pandoc_target_flags*
+  Type: |List|
+  Default: `[]`
+
+  This variable can be set to enable and disable extensions for writing
+  the formatted text. See https://pandoc.org/MANUAL.html#extensions.
+
+g:ale_markdown_pandoc_options                   *g:ale_markdown_pandoc_options*
+                                                *b:ale_markdown_pandoc_options*
+  Type: List
+  Default: `[]`
+
+  This variable can be set to pass additional options to pandoc.
 
 ===============================================================================
 prettier                                                *ale-markdown-prettier*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -277,6 +277,7 @@ Notes:
   * `languagetool`!!
   * `markdownlint`!!
   * `mdl`
+  * `pandoc`
   * `prettier`
   * `proselint`
   * `redpen`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2704,6 +2704,7 @@ documented in additional help files.
   markdown................................|ale-markdown-options|
     markdownlint..........................|ale-markdown-markdownlint|
     mdl...................................|ale-markdown-mdl|
+    pandoc................................|ale-markdown-pandoc|
     prettier..............................|ale-markdown-prettier|
     remark-lint...........................|ale-markdown-remark-lint|
     textlint..............................|ale-markdown-textlint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -286,6 +286,7 @@ formatting.
   * [languagetool](https://languagetool.org/) :floppy_disk:
   * [markdownlint](https://github.com/DavidAnson/markdownlint) :floppy_disk:
   * [mdl](https://github.com/mivok/markdownlint)
+  * [pandoc](https://pandoc.org)
   * [prettier](https://github.com/prettier/prettier)
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)

--- a/test/fixers/test_pandoc_fixer_callback.vader
+++ b/test/fixers/test_pandoc_fixer_callback.vader
@@ -9,8 +9,12 @@ Before:
   let g:ale_markdown_pandoc_target_flags = []
   let g:ale_markdown_pandoc_options = []
 
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
 After:
   Restore
+
+  call ale#test#RestoreDirectory()
 
 Execute(The pandoc callback should return the correct default values):
   AssertEqual

--- a/test/fixers/test_pandoc_fixer_callback.vader
+++ b/test/fixers/test_pandoc_fixer_callback.vader
@@ -1,0 +1,84 @@
+Before:
+  Save g:ale_markdown_pandoc_executable
+  Save g:ale_markdown_pandoc_input_flags
+  Save g:ale_markdown_pandoc_target_flags
+  Save g:ale_markdown_pandoc_options
+
+  let g:ale_markdown_pandoc_executable = '/path/to/pandoc'
+  let g:ale_markdown_pandoc_input_flags = []
+  let g:ale_markdown_pandoc_target_flags = []
+  let g:ale_markdown_pandoc_options = []
+
+After:
+  Restore
+
+Execute(The pandoc callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/pandoc')
+  \     . ' -f markdown'
+  \     . ' -t markdown'
+  \     . ' -s '
+  \     . ale#Escape(bufname(bufnr('')))
+  \ },
+  \ ale#fixers#pandoc#Fix(bufnr(''))
+
+Execute(The pandoc callback should set the buffer name as file name):
+  call ale#test#SetFilename('../markdown_files/testfile.md')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/pandoc')
+  \     . ' -f markdown'
+  \     . ' -t markdown'
+  \     . ' -s '
+  \     . ale#Escape(bufname(bufnr('')))
+  \ },
+  \ ale#fixers#pandoc#Fix(bufnr(''))
+
+  AssertNotEqual
+  \ stridx(
+  \   ale#fixers#pandoc#Fix(bufnr('')).command,
+  \   'testfile.md',
+  \ ),
+  \ -1
+
+Execute(The pandoc callback should include custom input_flags):
+  let g:ale_markdown_pandoc_input_flags = ['+abbreviation', '+autolink_bare_uris']
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/pandoc')
+  \     . ' -f markdown+abbreviation+autolink_bare_uris'
+  \     . ' -t markdown'
+  \     . ' -s '
+  \     . ale#Escape(bufname(bufnr('')))
+  \ },
+  \ ale#fixers#pandoc#Fix(bufnr(''))
+
+Execute(The pandoc callback should include custom target_flags):
+  let g:ale_markdown_pandoc_target_flags = ['+raw_tex', '-native_spans']
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/pandoc')
+  \     . ' -f markdown'
+  \     . ' -t markdown+raw_tex-native_spans'
+  \     . ' -s '
+  \     . ale#Escape(bufname(bufnr('')))
+  \ },
+  \ ale#fixers#pandoc#Fix(bufnr(''))
+
+Execute(The pandoc callback should include custom options):
+  let g:ale_markdown_pandoc_options = ['--wrap=auto', '--atx-headers']
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/pandoc')
+  \     . ' -f markdown'
+  \     . ' -t markdown'
+  \     . ' -s'
+  \     . ' --wrap=auto --atx-headers '
+  \     . ale#Escape(bufname(bufnr('')))
+  \ },
+  \ ale#fixers#pandoc#Fix(bufnr(''))


### PR DESCRIPTION
Hi there, 

I'm not very experienced with Vim script, but I'd like to add [Pandoc](https://pandoc.org) as a fixer to format markdown files. This potentially closes issue #2469.

I'd imagine that this fixer would be better to have disabled by default, though I'm not sure how that's done.