### PR TITLE
Collapse spaces and lines in the completion menu.

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -606,11 +606,14 @@ function! ale#completion#ParseLSPCompletions(response) abort
             let l:doc = l:doc.value
         endif
 
+        " Collapse whitespaces and line breaks into a single space.
+        let l:detail = substitute(get(l:item, 'detail', ''), '\_s\+', ' ', 'g')
+
         let l:result = {
         \   'word': l:word,
         \   'kind': ale#completion#GetCompletionSymbols(get(l:item, 'kind', '')),
         \   'icase': 1,
-        \   'menu': get(l:item, 'detail', ''),
+        \   'menu': l:detail,
         \   'info': (type(l:doc) is v:t_string ? l:doc : ''),
         \}
         " This flag is used to tell if this completion came from ALE or not.

--- a/test/completion/test_lsp_completion_parsing.vader
+++ b/test/completion/test_lsp_completion_parsing.vader
@@ -40,6 +40,7 @@ Execute(Should handle Rust completion results correctly):
   \   {'word': 'from', 'menu': 'fn from(s: &''a str) -> String', 'info': '', 'kind': 'f', 'icase': 1, 'user_data': json_encode({'_ale_completion_item': 1})},
   \   {'word': 'from', 'menu': 'fn from(s: Box<str>) -> String', 'info': '', 'kind': 'f', 'icase': 1, 'user_data': json_encode({'_ale_completion_item': 1})},
   \   {'word': 'from', 'menu': 'fn from(s: Cow<''a, str>) -> String', 'info': '', 'kind': 'f', 'icase': 1, 'user_data': json_encode({'_ale_completion_item': 1})},
+  \   {'word': 'to_vec', 'menu': 'pub fn to_vec(&self) -> Vec<T> where T: Clone,', 'info': '', 'kind': 'f', 'icase': 1, 'user_data': json_encode({'_ale_completion_item': 1})},
   \],
   \ ale#completion#ParseLSPCompletions({
   \   "jsonrpc":"2.0",
@@ -184,6 +185,11 @@ Execute(Should handle Rust completion results correctly):
   \       "label":"from",
   \       "kind":3,
   \       "detail":"fn from(s: Cow<'a, str>) -> String"
+  \     },
+  \     {
+  \       "label":"to_vec",
+  \       "kind":3,
+  \       "detail":"pub fn to_vec(&self) -> Vec<T>\nwhere\n        T: Clone,"
   \     }
   \   ]
   \ })


### PR DESCRIPTION
Some language servers (i.e., Rust's) send line breaks (which Vim renders as `^@`) and indentations on the completion details, which ends up taking a lot of space on the popup menu.

This patch collapses those characters into a single space.