### PR TITLE
feat: add intelephense support for php

### DIFF
--- a/ale_linters/php/intelephense.vim
+++ b/ale_linters/php/intelephense.vim
@@ -1,0 +1,32 @@
+" Author: Eric Stern <eric@ericstern.com>,
+"         Arnold Chand <creativenull@outlook.com>
+" Description: Intelephense language server integration for ALE
+
+call ale#Set('php_intelephense_executable', 'intelephense')
+call ale#Set('php_intelephense_use_global', 1)
+call ale#Set('php_intelephense_config', {})
+
+function! ale_linters#php#intelephense#GetProjectRoot(buffer) abort
+    let l:composer_path = ale#path#FindNearestFile(a:buffer, 'composer.json')
+
+    if (!empty(l:composer_path))
+        return fnamemodify(l:composer_path, ':h')
+    endif
+
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
+endfunction
+
+function! ale_linters#php#intelephense#GetInitializationOptions() abort
+    return ale#Get('php_intelephense_config')
+endfunction
+
+call ale#linter#Define('php', {
+\   'name': 'intelephense',
+\   'lsp': 'stdio',
+\   'initialization_options': function('ale_linters#php#intelephense#GetInitializationOptions'),
+\   'executable': {b -> ale#node#FindExecutable(b, 'php_intelephense', [])},
+\   'command': '%e --stdio',
+\   'project_root': function('ale_linters#php#intelephense#GetProjectRoot'),
+\})

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -244,4 +244,39 @@ g:ale_php_php_executable                             *g:ale_php_php_executable*
   This variable sets the executable used for php.
 
 ===============================================================================
+intelephense                                             *ale-php-intelephense*
+
+g:ale_php_intelephense_executable           *g:ale_php_intelephense_executable*
+                                            *b:ale_php_intelephense_executable*
+  Type: |String|
+  Default: `'intelephense'`
+
+  The variable can be set to configure the executable that will be used for
+  running the intelephense language server. `node_modules` directory
+  executable will be preferred instead of this setting if
+  |g:ale_php_intelephense_use_global| is `0`.
+
+  See: |ale-integrations-local-executables|
+
+
+g:ale_php_intelephense_use_global           *g:ale_php_intelephense_use_global*
+                                            *b:ale_php_intelephense_use_global*
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  This variable can be set to `1` to force the language server to be run with
+  the executable set for |g:ale_php_intelephense_executable|.
+
+  See: |ale-integrations-local-executables|
+
+g:ale_php_intelephense_config                   *g:ale_php_intelephense_config*
+                                                *b:ale_php_intelephense_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  The initialization options config specified by Intelephense. Refer to the
+  installation docs provided by intelephense (github.com/bmewburn/intelephense
+  -docs).
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -324,6 +324,7 @@ Notes:
 * Perl6
   * `perl6 -c`
 * PHP
+  * `intelephense`
   * `langserver`
   * `phan`
   * `phpcbf`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2752,6 +2752,7 @@ documented in additional help files.
     psalm.................................|ale-php-psalm|
     php-cs-fixer..........................|ale-php-php-cs-fixer|
     php...................................|ale-php-php|
+    intelephense..........................|ale-php-intelephense|
   po......................................|ale-po-options|
     write-good............................|ale-po-write-good|
   pod.....................................|ale-pod-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -333,6 +333,7 @@ formatting.
 * Perl6
   * [perl6 -c](https://perl6.org) :warning:
 * PHP
+  * [intelephense](https://github.com/bmewburn/intelephense-docs)
   * [langserver](https://github.com/felixfbecker/php-language-server)
   * [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions
   * [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer)

--- a/test/command_callback/test_php_intelephense_command_callback.vader
+++ b/test/command_callback/test_php_intelephense_command_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  call ale#assert#SetUpLinterTest('php', 'intelephense')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  AssertLinter 'intelephense',
+  \ ale#Escape('intelephense') . ' --stdio'
+
+Execute(The project path should be correct for .git directories):
+  call ale#test#SetFilename('php-intelephense-project/with-git/test.php')
+  silent! call mkdir('php-langserver-project/with-git/.git', 'p')
+  AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-git')
+
+Execute(The project path should be correct for composer.json file):
+  call ale#test#SetFilename('php-intelephense-project/with-composer/test.php')
+  AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-composer')
+
+Execute(The project should save to a temp dir):
+  call ale#test#SetFilename('php-intelephense-project/with-composer/test.php')
+  let g:ale_php_intelephense_config = { 'storagePath': '/tmp/intelephense' }
+  AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-composer')

--- a/test/command_callback/test_php_intelephense_command_callback.vader
+++ b/test/command_callback/test_php_intelephense_command_callback.vader
@@ -10,7 +10,7 @@ Execute(The default executable path should be correct):
 
 Execute(The project path should be correct for .git directories):
   call ale#test#SetFilename('php-intelephense-project/with-git/test.php')
-  silent! call mkdir('php-intelephense-project/with-git/.git')
+  silent! call mkdir('php-intelephense-project/with-git/.git', 'p')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-git')
 

--- a/test/command_callback/test_php_intelephense_command_callback.vader
+++ b/test/command_callback/test_php_intelephense_command_callback.vader
@@ -10,14 +10,17 @@ Execute(The default executable path should be correct):
 
 Execute(The project path should be correct for .git directories):
   call ale#test#SetFilename('php-intelephense-project/with-git/test.php')
-  silent! call mkdir('php-langserver-project/with-git/.git', 'p')
+  silent! call mkdir('php-intelephense-project/with-git/.git')
+
   AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-git')
 
 Execute(The project path should be correct for composer.json file):
   call ale#test#SetFilename('php-intelephense-project/with-composer/test.php')
+
   AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-composer')
 
-Execute(The project should save to a temp dir):
+Execute(The project cache should be saved in a temp dir):
   call ale#test#SetFilename('php-intelephense-project/with-composer/test.php')
   let g:ale_php_intelephense_config = { 'storagePath': '/tmp/intelephense' }
+
   AssertLSPProject ale#path#Simplify(g:dir . '/php-intelephense-project/with-composer')


### PR DESCRIPTION
This PR will add initial support for [intelephense](https://github.com/bmewburn/intelephense-docs) for PHP.

I've added some tests to go with it. I've never done vim tests with vader before so I took inspiration from the tests implemented from `test/command_callback/test_php_langserver_callbacks.vader` file.

For the config options, I'm not too sure how I can check if `initialization_options` were properly read by intelephense. But I have only one test case for that, if someone knows how to do this I won't mind updating this PR with it.