### PR TITLE
Improves fixer performance for large buffers

### DIFF
--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -486,7 +486,7 @@ function! ale#util#Input(message, value) abort
 endfunction
 
 function! ale#util#HasBuflineApi() abort
-    return exists('*deletebufline') && exists('*setbufline')
+    return exists('*deletebufline') && exists('*appendbufline') && exists('*getpos') && exists('*setpos')
 endfunction
 
 " Sets buffer contents to lines
@@ -507,8 +507,11 @@ function! ale#util#SetBufferContents(buffer, lines) abort
 
     " Use a Vim API for setting lines in other buffers, if available.
     if l:has_bufline_api
-        call setbufline(a:buffer, 1, l:new_lines)
-        call deletebufline(a:buffer, l:first_line_to_remove, '$')
+        let l:save_cursor = getpos('.')
+        call deletebufline(a:buffer, 1, '$')
+        call appendbufline(a:buffer, 1, l:new_lines)
+        call deletebufline(a:buffer, 1, 1)
+        call setpos('.', l:save_cursor)
     " Fall back on setting lines the old way, for the current buffer.
     else
         let l:old_line_length = line('$')


### PR DESCRIPTION
Hi,

The usecase here is using the default trim_whitespace fixer.

This commit improves performance of ale#util#SetBufferContents . It turns out that setbufline function takes really long time (over 400 seconds for 7k lines file), which effectively made the fixer part of the plugin unusable for me. I found out that if I save the cursor pos, delete contents, append new contents, and restore cursor pos, then the same task is accomplished in less than 3 seconds for 7k lines file.

I didn't make a bug report or anything, because I don't think it is a problem of Ale plugin, but the internals of setbufline function. I also didn't bother to test this on different setups than mine, so it definitely needs further checking. 