### PR TITLE
ALEInfo now shows enabled fixers

### DIFF
--- a/autoload/ale/debugging.vim
+++ b/autoload/ale/debugging.vim
@@ -197,6 +197,18 @@ function! s:EchoLSPErrorMessages(all_linter_names) abort
     endfor
 endfunction
 
+function! ale#debugging#FormatFixer(fixer) abort
+    let [l:name, l:Func] = a:fixer
+
+    if type(l:name) is v:t_string
+        return l:name
+    elseif type(l:Func) is v:t_func
+        return execute('function l:Func')
+    else
+        throw printf('Unexpected value. %s', a:fixer)
+    endif
+endfunction
+
 function! ale#debugging#Info() abort
     let l:buffer = bufnr('')
     let l:filetype = &filetype
@@ -225,6 +237,9 @@ function! ale#debugging#Info() abort
     let l:fixers = uniq(sort(l:fixers[0] + l:fixers[1]))
     let l:fixers_string = join(map(copy(l:fixers), '"\n  " . v:val'), '')
 
+    let l:enabled_fixers = deepcopy(ale#fix#Get(l:buffer, '', []))
+    let l:enabled_fixers = map(copy(l:enabled_fixers), 'ale#debugging#FormatFixer(v:val)')
+
     let l:non_ignored_names = map(
     \   copy(ale#linter#RemoveIgnored(l:buffer, l:filetype, l:enabled_linters)),
     \   'v:val[''name'']',
@@ -239,6 +254,7 @@ function! ale#debugging#Info() abort
     call s:EchoLinterAliases(l:all_linters)
     call s:Echo('  Enabled Linters: ' . string(l:enabled_names))
     call s:Echo('  Ignored Linters: ' . string(l:ignored_names))
+    call s:Echo('   Enabled Fixers: ' . string(l:enabled_fixers))
     call s:Echo(' Suggested Fixers: ' . l:fixers_string)
     call s:Echo(' Linter Variables:')
     call s:Echo('')

--- a/autoload/ale/fix.vim
+++ b/autoload/ale/fix.vim
@@ -259,7 +259,13 @@ function! s:IgnoreFixers(callback_list, filetype, config) abort
     call filter(a:callback_list, 'index(l:ignore_list, v:val) < 0')
 endfunction
 
-function! s:GetCallbacks(buffer, fixing_flag, fixers) abort
+function! ale#fix#Get(buffer, fixing_flag, fixers) abort
+    " Don't return fixers in the sandbox.
+    " Otherwise a sandboxed script could modify them.
+    if ale#util#InSandbox()
+        return []
+    endif
+
     if len(a:fixers)
         let l:callback_list = a:fixers
     elseif type(get(b:, 'ale_fixers')) is v:t_list
@@ -348,7 +354,7 @@ function! ale#fix#Fix(buffer, fixing_flag, ...) abort
     endif
 
     try
-        let l:callback_list = s:GetCallbacks(a:buffer, a:fixing_flag, a:000)
+        let l:callback_list = ale#fix#Get(a:buffer, a:fixing_flag, a:000)
     catch /E700\|BADNAME/
         if a:fixing_flag isnot# '!'
             let l:function_name = join(split(split(v:exception, ':')[3]))

--- a/test/test_ale_info.vader
+++ b/test/test_ale_info.vader
@@ -222,6 +222,7 @@ After:
 
   unlet! g:testlinter1
   unlet! g:testlinter2
+  unlet! b:ale_fixers
   unlet! b:ale_history
   unlet! b:ale_linters
   unlet! g:output
@@ -250,6 +251,7 @@ Execute (ALEInfo with no linters should return the right output):
   \   'Available Linters: []',
   \   '  Enabled Linters: []',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -273,6 +275,7 @@ Execute (ALEInfo should return buffer-local global ALE settings):
   \   'Available Linters: []',
   \   '  Enabled Linters: []',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -288,6 +291,7 @@ Execute (ALEInfo with no filetype should return the right output):
   \   'Available Linters: []',
   \   '  Enabled Linters: []',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -305,6 +309,7 @@ Execute (ALEInfo with a single linter should return the right output):
   \   'Available Linters: [''testlinter1'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -323,6 +328,7 @@ Execute (ALEInfo with two linters should return the right output):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -345,12 +351,77 @@ Execute (ALEInfo should calculate enabled linters correctly):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
   \ + g:globals_lines
   \ + g:command_header
   \)
+
+Given testft (Empty buffer):
+Execute (ALEInfo should calculate enabled fixers correctly):
+  function! Myfix() abort
+  endfunction
+  call ale#fix#registry#Add('testfixer1', 'Myfix', ['testft'], 'Fix things the #1 way')
+  call ale#fix#registry#Add('testfixer2', 'Myfix', ['testft'], 'Fix things the #2 way')
+  let g:ale_fixers = {'testft': ['testfixer2']}
+
+  let g:globals_lines[index(g:globals_lines, 'let g:ale_fixers = {}')]
+  \ = 'let g:ale_fixers = {''testft'': [''testfixer2'']}'
+
+  call CheckInfo(
+  \ [
+  \   ' Current Filetype: testft',
+  \   'Available Linters: []',
+  \   '  Enabled Linters: []',
+  \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: [''testfixer2'']',
+  \ ]
+  \ + g:fixer_lines
+  \ + [
+  \  '  ''testfixer1'' - Fix things the #1 way',
+  \  '  ''testfixer2'' - Fix things the #2 way',
+  \ ]
+  \ + g:variables_lines
+  \ + g:globals_lines
+  \ + g:command_header
+  \)
+
+Given testft (Empty buffer):
+Execute (ALEInfo can display lambda fixers):
+  if has('lambda')
+    let b:ale_fixers = [
+    \   {buffer -> 0},
+    \   {buffer -> ale#command#Run(buffer, 'cat', {... -> 0})},
+    \]
+
+    call insert(
+    \   g:globals_lines,
+    \   'let b:ale_fixers = [function(''<lambda>1''), function(''<lambda>2'')]',
+    \   index(g:globals_lines, 'let g:ale_fixers = {}') + 1,
+    \)
+
+    call CheckInfo(
+    \ [
+    \   ' Current Filetype: testft',
+    \   'Available Linters: []',
+    \   '  Enabled Linters: []',
+    \   '  Ignored Linters: []',
+    \   '   Enabled Fixers: [''',
+    \   '   function <lambda>1(buffer, ...)',
+    \   '1  return 0',
+    \   '   endfunction'', ''',
+    \   '   function <lambda>2(buffer, ...)',
+    \   '1  return ale#command#Run(buffer, ''''cat'''', {... -> 0})',
+    \   '   endfunction'']',
+    \ ]
+    \ + g:fixer_lines
+    \ + g:variables_lines
+    \ + g:globals_lines
+    \ + g:command_header
+    \)
+  endif
 
 Given testft (Empty buffer):
 Execute (ALEInfo should only return linters for current filetype):
@@ -363,6 +434,7 @@ Execute (ALEInfo should only return linters for current filetype):
   \   'Available Linters: [''testlinter1'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -381,6 +453,7 @@ Execute (ALEInfo with compound filetypes should return linters for both of them)
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -404,6 +477,7 @@ Execute (ALEInfo should return appropriately named global variables):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + [
@@ -436,6 +510,7 @@ Execute (ALEInfoToFile should write to a file correctly):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + [
@@ -464,6 +539,7 @@ Execute (ALEInfo should buffer-local linter variables):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + [
@@ -496,6 +572,7 @@ Execute (ALEInfo should output linter aliases):
   \   '''testlinter2'' -> [''testftalias3'', ''testftalias4'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + [
@@ -524,6 +601,7 @@ Execute (ALEInfo should return command history):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -552,6 +630,7 @@ Execute (ALEInfo command history should print exit codes correctly):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -601,6 +680,7 @@ Execute (ALEInfo command history should print command output if logging is on):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -640,6 +720,7 @@ Execute (ALEInfo should include executable checks in the history):
   \   'Available Linters: [''testlinter1'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -670,6 +751,7 @@ Execute (The option for caching failing executable checks should work):
   \   'Available Linters: [''testlinter1'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -693,6 +775,7 @@ Execute (LSP errors for a linter should be outputted):
   \   'Available Linters: [''testlinter1'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -718,6 +801,7 @@ Execute (LSP errors for other linters shouldn't appear):
   \   'Available Linters: [''testlinter1'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -741,6 +825,7 @@ Execute (ALEInfo should include linter global options):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines
@@ -767,6 +852,7 @@ Execute (ALEInfo should include linter global options for enabled linters):
   \   'Available Linters: [''testlinter1'', ''testlinter2'']',
   \   '  Enabled Linters: [''testlinter1'']',
   \   '  Ignored Linters: []',
+  \   '   Enabled Fixers: []',
   \ ]
   \ + g:fixer_lines
   \ + g:variables_lines


### PR DESCRIPTION
> Where are the tests? Have you added tests? Have you updated the tests? 

Test added to `test/test_ale_info.vader`: `ALEInfo should calculate enabled fixers correctly`