### PR TITLE
feat(erlang/dialyzer): add custom options passing

### DIFF
--- a/ale_linters/erlang/dialyzer.vim
+++ b/ale_linters/erlang/dialyzer.vim
@@ -3,6 +3,8 @@
 
 let g:ale_erlang_dialyzer_executable =
 \   get(g:, 'ale_erlang_dialyzer_executable', 'dialyzer')
+let g:ale_erlang_dialyzer_options =
+\   get(g:, 'ale_erlang_dialyzer_options', '')
 let g:ale_erlang_dialyzer_plt_file =
 \   get(g:, 'ale_erlang_dialyzer_plt_file', '')
 let g:ale_erlang_dialyzer_rebar3_profile =
@@ -47,14 +49,20 @@ function! ale_linters#erlang#dialyzer#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#erlang#dialyzer#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'erlang_dialyzer_options')
+
+    if len(l:options) == 0
+        let l:options = '-Wunmatched_returns'
+        \             . ' -Werror_handling'
+        \             . ' -Wrace_conditions'
+        \             . ' -Wunderspecs'
+        \             . ' %s'
+    endif
+
     let l:command = ale#Escape(ale_linters#erlang#dialyzer#GetExecutable(a:buffer))
     \   . ' -n'
     \   . ' --plt ' . ale#Escape(ale_linters#erlang#dialyzer#GetPlt(a:buffer))
-    \   . ' -Wunmatched_returns'
-    \   . ' -Werror_handling'
-    \   . ' -Wrace_conditions'
-    \   . ' -Wunderspecs'
-    \   . ' %s'
+    \   . ' ' . l:options
 
     return l:command
 endfunction

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -13,6 +13,14 @@ g:ale_erlang_dialyzer_executable             *g:ale_erlang_dialyzer_executable*
   This variable can be changed to specify the dialyzer executable.
 
 
+g:ale_erlang_dialyzer_options                   *g:ale_erlang_dialyzer_options*
+                                                *b:ale_erlang_dialyzer_options*
+  Type: |String|
+  Default: `'-Wunmatched_returns -Werror_handling -Wrace_conditions -Wunderspec %s'`
+
+  This variable can be changed to specify the options to the dialyzer
+  executable. The `%s` marker can be used to denote the current file.
+
 g:ale_erlang_dialyzer_plt_file                 *g:ale_erlang_dialyzer_plt_file*
                                                *b:ale_erlang_dialyzer_plt_file*
   Type: |String|

--- a/test/command_callback/test_erlang_dialyzer_command_callback.vader
+++ b/test/command_callback/test_erlang_dialyzer_command_callback.vader
@@ -25,6 +25,13 @@ Execute(The command should accept configured executable.):
     \ . ' -Wunderspecs'
     \ . ' %s'
 
+Execute(The command should accept configured options.):
+    let b:ale_erlang_dialyzer_options = '-r ' . expand('$HOME')
+    AssertLinter 'dialyzer',
+    \ ale#Escape('dialyzer')
+    \ . ' -n --plt ' . ale#Escape(expand('$HOME/.dialyzer_plt'))
+    \ . ' -r ' . expand('$HOME')
+
 Execute(The command should accept configured PLT file.):
     let b:ale_erlang_dialyzer_plt_file = 'custom-plt'
     AssertLinter 'dialyzer',


### PR DESCRIPTION
Add an option to specify command line options for the Erlang `dialyzer` linter.