### PR TITLE
Use stdin/stdout to communicate with gofmt

### DIFF
--- a/autoload/ale/fixers/gofmt.vim
+++ b/autoload/ale/fixers/gofmt.vim
@@ -11,9 +11,6 @@ function! ale#fixers#gofmt#Fix(buffer) abort
 
     return {
     \   'command': l:env . ale#Escape(l:executable)
-    \       . ' -l -w'
     \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' %t',
-    \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_gofmt_fixer_callback.vader
+++ b/test/fixers/test_gofmt_fixer_callback.vader
@@ -21,10 +21,7 @@ Execute(The gofmt callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid')
-  \     . ' -l -w'
-  \     . ' %t',
+  \   'command': ale#Escape('xxxinvalid'),
   \ },
   \ ale#fixers#gofmt#Fix(bufnr(''))
 
@@ -35,11 +32,8 @@ Execute(The gofmt callback should include custom gofmt options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' -l -w'
-  \     . ' ' . g:ale_go_gofmt_options
-  \     . ' %t',
+  \     . ' ' . g:ale_go_gofmt_options,
   \ },
   \ ale#fixers#gofmt#Fix(bufnr(''))
 
@@ -50,9 +44,7 @@ Execute(The gofmt callback should support Go environment variables):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Env('GO111MODULE', 'off')
-  \     . ale#Escape('xxxinvalid') . ' -l -w'
-  \     . ' %t',
+  \     . ale#Escape('xxxinvalid')
   \ },
   \ ale#fixers#gofmt#Fix(bufnr(''))


### PR DESCRIPTION
Problem: I use docker based workflow where all devtools including `gofmt` are inside a container. The vim is running on host system though and runs `gofmt` via a wrapper script which does `docker exec gofmt`. Because currently fixer uses temp files `gofmt` cannot see those files produced on the host system.

Solution: use stdin/stdout to communicate with `gofmt`

I might be missing something why it's not using stdin/stdout currently.

cc @aliou @eliath as contributors to this fixer