### PR TITLE
feat: Add support for Erlang escript

### DIFF
--- a/ale_linters/escript/escript.vim
+++ b/ale_linters/escript/escript.vim
@@ -1,5 +1,5 @@
 scriptencoding utf-8
-" Author: Moritz Röhirch - https://github.com/m-ildefons
+" Author: Moritz Röhrich - https://github.com/m-ildefons
 
 let g:ale_erlang_escript_executable = get(g:, 'ale_erlang_escript_executable', 'escript')
 let g:ale_erlang_escript_options = get(g:, 'ale_erlang_escript_options', '')

--- a/ale_linters/escript/escript.vim
+++ b/ale_linters/escript/escript.vim
@@ -1,0 +1,87 @@
+scriptencoding utf-8
+" Author: Moritz Röhirch - https://github.com/m-ildefons
+
+let g:ale_erlang_escript_executable = get(g:, 'ale_erlang_escript_executable', 'escript')
+let g:ale_erlang_escript_options = get(g:, 'ale_erlang_escript_options', '')
+
+function! ale_linters#escript#escript#GetCommand(buffer) abort
+    let l:output_file = ale#util#Tempname()
+    call ale#command#ManageFile(a:buffer, l:output_file)
+
+    return ale#Var(a:buffer, 'erlang_escript_executable') . ' -s '
+    \   . ale#Var(a:buffer, 'erlang_escript_options')
+    \   . ' %t'
+endfunction
+
+function! ale_linters#escript#escript#Handle(buffer, lines) abort
+    " Matches patterns like the following:
+    "
+    " error.erl:4: variable 'B' is unbound
+    " error.erl:3: Warning: function main/0 is unused
+    " error.erl:4: Warning: variable 'A' is unused
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+): (Warning: )?(.+)$'
+
+    " parse_transforms are a special case. The error message does not indicate
+    " a location:
+    " error.erl: undefined parse transform 'some_parse_transform'
+    let l:pattern_parse_transform = '\v(undefined parse transform .*)$'
+
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        " Determine if the output indicates an error. We distinguish between two
+        " cases:
+        "
+        " 1) normal errors match l:pattern
+        " 2) parse_transform errors match l:pattern_parse_transform
+        "
+        " If none of the patterns above match, the line can be ignored
+        if len(l:match) == 0  " not a 'normal' warning or error
+            let l:match_parse_transform = matchlist(l:line, l:pattern_parse_transform)
+
+            " also not a parse_transform error
+            if len(l:match_parse_transform) == 0
+                continue
+            endif
+
+            call add(l:output, {
+            \   'bufnr': a:buffer,
+            \   'lnum': 0,
+            \   'col': 0,
+            \   'type': 'E',
+            \   'text': l:match_parse_transform[0],
+            \})
+
+            continue
+        endif
+
+        let l:line = l:match[2]
+        let l:warning_or_text = l:match[3]
+        let l:text = l:match[4]
+
+        if !empty(l:warning_or_text)
+            let l:type = 'W'
+        else
+            let l:type = 'E'
+        endif
+
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'lnum': l:line,
+        \   'col': 0,
+        \   'type': l:type,
+        \   'text': l:text,
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('escript', {
+\   'name': 'escript',
+\   'executable': 'escript',
+\   'command': function('ale_linters#escript#escript#GetCommand'),
+\   'callback': 'ale_linters#escript#escript#Handle',
+\})

--- a/doc/ale-erlang-escript.txt
+++ b/doc/ale-erlang-escript.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE Erlang escript Integration                     *ale-erlang-escript-options*
+
+
+===============================================================================
+escript                                                    *ale-erlang-escript*
+
+g:ale_erlang_escript_executable               g:ale_erlang_escript_executable
+                                              b:ale_erlang_escript_executable
+  Type: String
+  Default: 'escript'
+
+  Specify the escript executable with with variable.
+
+g:ale_erlang_escript_options                     g:ale_erlang_escript_options
+                                                 b:ale_erlang_escript_options
+  Type: String
+  Default: ''
+
+  This variable can be used to pass additional parameters to `escript`, such
+  as `-n` or `-i`.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -142,6 +142,8 @@ Notes:
 * Erlang
   * `erlc`
   * `SyntaxErl`
+* Erlang escript
+  * `escript`
 * Fish
   * `fish` (-n flag)
 * Fortran

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2591,6 +2591,8 @@ documented in additional help files.
     dialyzer..............................|ale-erlang-dialyzer|
     erlc..................................|ale-erlang-erlc|
     syntaxerl.............................|ale-erlang-syntaxerl|
+  erlang escript..........................|ale-erlang-escript-options|
+    escript...............................|ale-erlang-escript|
   eruby...................................|ale-eruby-options|
     ruumba................................|ale-eruby-ruumba|
   fish....................................|ale-fish-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -151,6 +151,8 @@ formatting.
 * Erlang
   * [erlc](http://erlang.org/doc/man/erlc.html)
   * [SyntaxErl](https://github.com/ten0s/syntaxerl)
+* Erlang escript
+  * [escript](http://erlang.org/doc/man/escript.html)
 * Fish
   * fish [-n flag](https://linux.die.net/man/1/fish)
 * Fortran

--- a/test/handler/test_erlang_escript_handler.vader
+++ b/test/handler/test_erlang_escript_handler.vader
@@ -1,0 +1,41 @@
+Before:
+  runtime ale_linters/escript/escript.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The escript handler should handle error messages.):
+  AssertEqual
+  \[
+  \  {
+  \      'lnum': '0',
+  \      'bufnr': 3,
+  \      'col': 0,
+  \      'text': 'function main/1 undefined',
+  \      'type': 'E'
+  \  }
+  \],
+  \ ale_linters#escript#escript#Handle(bufnr(''), ['test.erl:0: function main/1 undefined'])
+
+Execute(The escript handler should handle warning messages.):
+  AssertEqual
+  \[
+  \  {
+  \      'lnum': '5',
+  \      'bufnr': 3,
+  \      'col': 0,
+  \      'text': "variable 'Argv' is unused",
+  \      'type': 'W'
+  \  }
+  \],
+  \ ale_linters#escript#escript#Handle(bufnr(''), ["test.erl:5: Warning: variable 'Argv' is unused"])
+
+Execute(The escript handler should handle empty files.):
+  AssertEqual
+  \[],
+  \ ale_linters#escript#escript#Handle(bufnr(''), [])
+
+Execute(The escript handler should handle empty lines.):
+  AssertEqual
+  \[],
+  \ ale_linters#escript#escript#Handle(bufnr(''), [''])


### PR DESCRIPTION
Add support and documentation for Erlang escript.

Conventional erlang linters like `erlc` choke on shebangs in escript
files, which can cause them to not report on other language violations
or report false-positives. `escript` does have a syntax and semantics
check mode of its own. This linter utilizes that to check escript files.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
