### PR TITLE
Make isort fixer recognize auto_pipenv flag

### DIFF
--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -24,7 +24,7 @@ function! ale#fixers#isort#Fix(buffer) abort
     \   ? ' run isort'
     \   : ''
 
-    if !executable(l:executable)
+    if !executable(l:executable) && l:executable != 'pipenv'
         return 0
     endif
 

--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -24,7 +24,7 @@ function! ale#fixers#isort#Fix(buffer) abort
     \   ? ' run isort'
     \   : ''
 
-    if !executable(l:executable) && l:executable !=# 'pipenv'
+    if !executable(l:executable) && l:executable isnot# 'pipenv'
         return 0
     endif
 

--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -24,7 +24,7 @@ function! ale#fixers#isort#Fix(buffer) abort
     \   ? ' run isort'
     \   : ''
 
-    if !executable(l:executable) && l:executable != 'pipenv'
+    if !executable(l:executable) && l:executable !=# 'pipenv'
         return 0
     endif
 

--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -2,8 +2,9 @@
 " Description: Fixing Python imports with isort.
 
 call ale#Set('python_isort_executable', 'isort')
-call ale#Set('python_isort_options', '')
 call ale#Set('python_isort_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('python_isort_options', '')
+call ale#Set('python_isort_auto_pipenv', 0)
 
 function! ale#fixers#isort#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_isort_auto_pipenv'))

--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -5,14 +5,23 @@ call ale#Set('python_isort_executable', 'isort')
 call ale#Set('python_isort_options', '')
 call ale#Set('python_isort_use_global', get(g:, 'ale_use_global_executables', 0))
 
+function! ale#fixers#isort#GetExecutable(buffer) abort
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_isort_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
+    return ale#python#FindExecutable(a:buffer, 'python_isort', ['isort'])
+endfunction
+
 function! ale#fixers#isort#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'python_isort_options')
 
-    let l:executable = ale#python#FindExecutable(
-    \   a:buffer,
-    \   'python_isort',
-    \   ['isort'],
-    \)
+    let l:executable = ale#fixers#isort#GetExecutable(a:buffer)
+
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? ' run isort'
+    \   : ''
 
     if !executable(l:executable)
         return 0
@@ -20,6 +29,7 @@ function! ale#fixers#isort#Fix(buffer) abort
 
     return {
     \   'command': ale#path#BufferCdString(a:buffer)
-    \   .   ale#Escape(l:executable) . (!empty(l:options) ? ' ' . l:options : '') . ' -',
+    \   . ale#Escape(l:executable) . l:exec_args
+    \   . (!empty(l:options) ? ' ' . l:options : '') . ' -',
     \}
 endfunction

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -280,6 +280,15 @@ g:ale_python_isort_use_global                   *g:ale_python_isort_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_python_isort_auto_pipenv                 *g:ale_python_isort_auto_pipenv*
+                                               *b:ale_python_isort_auto_pipenv*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a pipenv, and set the executable to `pipenv`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 mypy                                                          *ale-python-mypy*
 

--- a/test/fixers/test_isort_fixer_callback.vader
+++ b/test/fixers/test_isort_fixer_callback.vader
@@ -56,5 +56,5 @@ Execute(Pipenv is detected when python_isort_auto_pipenv is set):
   call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
 
   AssertEqual
-  \ {'command': 'cd %s:h && ' . ale#Escape('pipenv') . ' run isort -'},
+  \ {'command': ale#path#BufferCdString(bufnr('')) . ale#Escape('pipenv') . ' run isort -'},
   \ ale#fixers#isort#Fix(bufnr(''))

--- a/test/fixers/test_isort_fixer_callback.vader
+++ b/test/fixers/test_isort_fixer_callback.vader
@@ -5,6 +5,7 @@ Before:
   " Use an invalid global executable, so we don't match it.
   let g:ale_python_isort_executable = 'xxxinvalid'
   let g:ale_python_isort_options = ''
+  let g:ale_python_isort_auto_pipenv = 0
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
   silent cd ..
@@ -47,4 +48,13 @@ Execute(The isort callback should respect custom options):
   \     . ale#Escape(ale#path#Simplify(g:dir . '/python_paths/with_virtualenv/env/' . b:bin_dir . '/isort'))
   \     . ' --multi-line=3 --trailing-comma -',
   \ },
+  \ ale#fixers#isort#Fix(bufnr(''))
+
+Execute(Pipenv is detected when python_isort_auto_pipenv is set):
+  let g:ale_python_isort_auto_pipenv = 1
+
+  call ale#test#SetFilename('/testplugin/test/python_fixtures/pipenv/whatever.py')
+
+  AssertEqual
+  \ {'command': 'cd %s:h && ' . ale#Escape('pipenv') . ' run isort -'},
   \ ale#fixers#isort#Fix(bufnr(''))


### PR DESCRIPTION
I noticed with `python_auto_pipenv = 1` the `black` fixer would run on any file in a project containing a Pipfile whether vim was run inside the virtual environment or not. I wanted to make `isort`'s fixer behave the same way in conjunction with the `python_auto_pipenv` flag.

What I have below generally works although I do have one concern: the `!executable(l:executable)` check fails when the executable ends up being `pipenv`. I added a hacky workaround to exclude this case but ideally there would be a test fixture that makes `executable(pipenv)` evaluate as true. We would expect this for any user setting `python_auto_pipenv` or `python_isort_auto_pipenv` to 1.

Would appreciate some feedback here, thanks!