### PR TITLE
dafny: include correct filename in lint results

### DIFF
--- a/ale_linters/dafny/dafny.vim
+++ b/ale_linters/dafny/dafny.vim
@@ -6,7 +6,7 @@ function! ale_linters#dafny#dafny#Handle(buffer, lines) abort
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
-        \    'bufnr': a:buffer,
+        \    'filename': l:match[1],
         \    'col': l:match[3] + 0,
         \    'lnum': l:match[2] + 0,
         \    'text': l:match[5],

--- a/test/handler/test_dafny_handler.vader
+++ b/test/handler/test_dafny_handler.vader
@@ -8,14 +8,14 @@ Execute(The Dafny handler should parse output correctly):
   AssertEqual
   \ [
   \   {
-  \     'bufnr': 0,
+  \     'filename': 'File.dfy',
   \     'col': 45,
   \     'lnum': 123,
   \     'text': 'A precondition for this call might not hold.',
   \     'type': 'E'
   \   },
   \   {
-  \     'bufnr': 0,
+  \     'filename': 'File.dfy',
   \     'col': 90,
   \     'lnum': 678,
   \     'text': 'This is the precondition that might not hold.',


### PR DESCRIPTION
Results can come from included files, not just the current buffer.
