### PR TITLE
Add verible verilog linter

### DIFF
--- a/ale_linters/verilog/verible.vim
+++ b/ale_linters/verilog/verible.vim
@@ -1,0 +1,45 @@
+" Author: Zeger Van de Vannet
+" Description: Verible (verilog_lint) for verilog files
+
+" Set this option to change verible lint options
+if !exists('g:ale_verilog_verible_options')
+    let g:ale_verilog_verible_options = ''
+endif
+
+function! ale_linters#verilog#verible#GetCommand(buffer) abort
+    let l:filename = ale#util#Tempname() . '_verible_linted.v'
+    call ale#command#ManageFile(a:buffer, l:filename)
+    let l:lines = getbufline(a:buffer, 1, '$')
+    call ale#util#Writefile(a:buffer, l:lines, l:filename)
+
+    return 'verible-verilog-lint '
+    \ . ale#Var(a:buffer, 'verilog_verible_options') . ' '
+    \ . ale#Escape(l:filename)
+endfunction
+
+function! ale_linters#verilog#verible#Handle(buffer, lines) abort
+    let l:output = []
+
+    let l:pattern = '\([^:]\+\):\(\d\+\):\(\d\+\): \([^(]\+\)'
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:item = {
+        \  'lnum': l:match[2],
+        \  'col': l:match[3],
+        \  'text': l:match[4]
+        \}
+
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('verilog', {
+\   'name': 'verible',
+\   'output_stream': 'stdout',
+\   'executable': 'verible-verilog-lint',
+\   'command': function('ale_linters#verilog#verible#GetCommand'),
+\   'callback': 'ale_linters#verilog#verible#Handle',
+\   'read_buffer': 0,
+\})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -491,6 +491,7 @@ Notes:
 * Verilog
   * `hdl-checker`
   * `iverilog`
+  * `verible`
   * `verilator`
   * `vlog`
   * `xvlog`

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -500,6 +500,7 @@ formatting.
 * Verilog
   * [hdl-checker](https://pypi.org/project/hdl-checker)
   * [iverilog](https://github.com/steveicarus/iverilog)
+  * [verible](https://github.com/google/verible)
   * [verilator](http://www.veripool.org/projects/verilator/wiki/Intro)
   * [vlog](https://www.mentor.com/products/fv/questa/)
   * [xvlog](https://www.xilinx.com/products/design-tools/vivado.html)

--- a/test/test_filetype_linter_defaults.vader
+++ b/test/test_filetype_linter_defaults.vader
@@ -61,7 +61,7 @@ Execute(The defaults for the zsh filetype should be correct):
 Execute(The defaults for the verilog filetype should be correct):
   " This filetype isn't configured with default, so we can test loading all
   " available linters with this.
-  AssertEqual ['hdl-checker', 'iverilog', 'verilator', 'vlog', 'xvlog'], GetLinterNames('verilog')
+  AssertEqual ['hdl-checker', 'iverilog', 'verible', 'verilator', 'vlog', 'xvlog'], GetLinterNames('verilog')
 
   let g:ale_linters_explicit = 1
 

--- a/test/test_verilog_verible_options.vader
+++ b/test/test_verilog_verible_options.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_verilog_verible_options
+  let g:ale_verilog_verible_options = ''
+
+After:
+  Restore
+  call ale#linter#Reset()
+
+Execute(Set Verilog verible linter additional options to `--ruleset=all`):
+  runtime! ale_linters/verilog/verible.vim
+
+  " Additional args for the linter
+  let g:ale_verilog_verible_options = '--ruleset=all'
+
+  call ale#Queue(0)
+
+  let g:run_cmd = ale_linters#verilog#verible#GetCommand(bufnr(''))
+  let g:matched = match(g:run_cmd, '\s' . g:ale_verilog_verible_options . '\s')
+
+  " match returns -1 if not found
+  AssertNotEqual
+  \   g:matched ,
+  \   -1 ,
+  \  'Additionnal arguments not found in the run command'


### PR DESCRIPTION
Adds [verible](https://github.com/google/verible) linting for verilog/SystemVerilog.

I've added an options test and updated the default linters test.