### PR TITLE
Add Ruby sorbet option to enable watchman

### DIFF
--- a/ale_linters/ruby/sorbet.vim
+++ b/ale_linters/ruby/sorbet.vim
@@ -1,14 +1,17 @@
 call ale#Set('ruby_sorbet_executable', 'srb')
 call ale#Set('ruby_sorbet_options', '')
+call ale#Set('ruby_sorbet_enable_watchman', 0)
 
 function! ale_linters#ruby#sorbet#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_sorbet_executable')
     let l:options = ale#Var(a:buffer, 'ruby_sorbet_options')
+    let l:enable_watchman = ale#Var(a:buffer, 'ruby_sorbet_enable_watchman')
 
     return ale#ruby#EscapeExecutable(l:executable, 'srb')
     \   . ' tc'
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' --lsp --disable-watchman'
+    \   . ' --lsp'
+    \   . (l:enable_watchman ? '' : ' --disable-watchman')
 endfunction
 
 call ale#linter#Define('ruby', {

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -177,6 +177,16 @@ g:ale_ruby_sorbet_options                           *g:ale_ruby_sorbet_options*
   This variable can be changed to modify flags given to sorbet.
 
 
+g:ale_ruby_sorbet_enable_watchman           *g:ale_ruby_sorbet_enable_watchman*
+                                            *b:ale_ruby_sorbet_enable_watchman*
+  Type: |Number|
+  Default: `0`
+
+  Whether or not to use watchman to let the LSP server to know about changes
+  to files from outside of vim. Defaults to disable watchman because it
+  requires watchman to be installed separately from sorbet.
+
+
 ===============================================================================
 standardrb                                                *ale-ruby-standardrb*
 

--- a/test/command_callback/test_sorbet_command_callback.vader
+++ b/test/command_callback/test_sorbet_command_callback.vader
@@ -5,6 +5,7 @@ Before:
 
   let g:ale_ruby_sorbet_executable = 'srb'
   let g:ale_ruby_sorbet_options = ''
+  let g:ale_ruby_sorbet_enable_watchman = 0
 
 After:
   call ale#assert#TearDownLinterTest()
@@ -12,6 +13,12 @@ After:
 Execute(Executable should default to srb):
   AssertLinter 'srb', ale#Escape('srb')
   \   . ' tc --lsp --disable-watchman'
+
+Execute(Able to enable watchman):
+  let g:ale_ruby_sorbet_enable_watchman = 1
+
+  AssertLinter 'srb', ale#Escape('srb')
+  \   . ' tc --lsp'
 
 Execute(Should be able to set a custom executable):
   let g:ale_ruby_sorbet_executable = 'bin/srb'


### PR DESCRIPTION
Follow up to https://github.com/dense-analysis/ale/pull/2614

The sorbet support already in ale works great, and I think it makes sense to default to `--disable-watchman` as @rintaun did in the original PR. 

A little while ago I had hacked up my copy in my `.vim` dir to remove that though, so files changed outside of vim (such as auto generated rbi files) would be picked up by the lsp server. 

I figured it'd be better to contribute that back up to ale though. I've done very little vim script though, so this was all just done by looking around the project a bit, so I'm not sure if things are wrong. It seems to work for me though, for what it's worth.