### PR TITLE
Make executable for nix linter configurable

### DIFF
--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -1,6 +1,8 @@
 " Author: Alistair Bill <@alibabzo>
 " Description: nix-instantiate linter for nix files
 
+call ale#Set('nix_instantiate_executable', 'nix-instantiate')
+
 function! ale_linters#nix#nix#Handle(buffer, lines) abort
     let l:pattern = '^\(.\+\): \(.\+\), at .*:\(\d\+\):\(\d\+\)$'
     let l:output = []
@@ -20,7 +22,7 @@ endfunction
 call ale#linter#Define('nix', {
 \   'name': 'nix',
 \   'output_stream': 'stderr',
-\   'executable': 'nix-instantiate',
-\   'command': 'nix-instantiate --parse -',
+\   'executable': {b -> ale#Var(b, 'nix_instantiate_executable')},
+\   'command': '%e --parse -',
 \   'callback': 'ale_linters#nix#nix#Handle',
 \})

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -3,10 +3,21 @@ ALE Nix Integration                                           *ale-nix-options*
 
 
 ===============================================================================
-nixpkgs-fmt                                                 *ale-nix-nixpkgs-fmt*
+nix                                                                   *ale-nix*
 
-g:ale_nix_nixpkgsfmt_executable                *g:ale_nix_nixpkgsfmt_executable*
-                                               *b:ale_nix_nixpkgsfmt_executable*
+g:ale_nix_instantiate_executable             *g:ale_nix_instantiate_executable*
+                                             *b:ale_nix_instantiate_executable*
+  Type: |String|
+  Default: `'nix-instantiate'`
+
+  This variable sets executable used for nix-instantiate expression parsing.
+
+
+===============================================================================
+nixpkgs-fmt                                               *ale-nix-nixpkgs-fmt*
+
+g:ale_nix_nixpkgsfmt_executable               *g:ale_nix_nixpkgsfmt_executable*
+                                              *b:ale_nix_nixpkgsfmt_executable*
   Type: |String|
   Default: `'nixpkgs-fmt'`
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2717,6 +2717,7 @@ documented in additional help files.
     nimlsp................................|ale-nim-nimlsp|
     nimpretty.............................|ale-nim-nimpretty|
   nix.....................................|ale-nix-options|
+    nix...................................|ale-nix|
     nixpkgs-fmt...........................|ale-nix-nixpkgs-fmt|
   nroff...................................|ale-nroff-options|
     write-good............................|ale-nroff-write-good|


### PR DESCRIPTION
Especially useful when using the development release of nix, since the error format changed there.