### PR TITLE
Added linter for Godot Game Engine scripting language.

### DIFF
--- a/ale_linters/gdscript/gdscript.vim
+++ b/ale_linters/gdscript/gdscript.vim
@@ -1,0 +1,9 @@
+" Author: Wilson E. Alvarez <https://github.com/Rubonnek>
+" Description: Linter for the Godot game engine scripting language.
+
+call ale#linter#Define('gdscript', {
+\   'name': 'godot',
+\   'lsp': 'socket',
+\   'address': '127.0.0.1:6008',
+\   'project_root': 'project.godot',
+\})


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

This requires users to have an ftdetect as follows:
```
autocmd BufNewFile,BufRead *.gd set ft=gdscript
```
Which is already provided by other plugins such as:
- https://github.com/habamax/vim-godot, and
- https://github.com/clktmr/vim-gdscript3

Closes  #1887