### PR TITLE
Check for Vim's shell type buffer variables before falling back to the file type

### DIFF
--- a/autoload/ale/handlers/sh.vim
+++ b/autoload/ale/handlers/sh.vim
@@ -11,6 +11,17 @@ function! ale#handlers#sh#GetShellType(buffer) abort
         let l:command = substitute(l:shebang, ' --\?[a-zA-Z0-9]\+', '', 'g')
     endif
 
+    " With no shebang line, attempt to use Vim's buffer-local variables.
+    if l:command is# ''
+        if getbufvar(a:buffer, 'is_bash', 0)
+            let l:command = 'bash'
+        elseif getbufvar(a:buffer, 'is_sh', 0)
+            let l:command = 'sh'
+        elseif getbufvar(a:buffer, 'is_kornshell', 0)
+            let l:command = 'ksh'
+        endif
+    endif
+
     " If we couldn't find a shebang, try the filetype
     if l:command is# ''
         let l:command = &filetype

--- a/autoload/ale/handlers/sh.vim
+++ b/autoload/ale/handlers/sh.vim
@@ -1,6 +1,5 @@
 " Author: w0rp <devw0rp@gmail.com>
 
-" Get the shell type for a buffer, based on the hashbang line.
 function! ale#handlers#sh#GetShellType(buffer) abort
     let l:bang_line = get(getbufline(a:buffer, 1), 0, '')
 

--- a/autoload/ale/handlers/sh.vim
+++ b/autoload/ale/handlers/sh.vim
@@ -1,17 +1,17 @@
 " Author: w0rp <devw0rp@gmail.com>
 
 function! ale#handlers#sh#GetShellType(buffer) abort
-    let l:bang_line = get(getbufline(a:buffer, 1), 0, '')
+    let l:shebang = get(getbufline(a:buffer, 1), 0, '')
 
     let l:command = ''
 
-    " Take the shell executable from the hashbang, if we can.
-    if l:bang_line[:1] is# '#!'
+    " Take the shell executable from the shebang, if we can.
+    if l:shebang[:1] is# '#!'
         " Remove options like -e, etc.
-        let l:command = substitute(l:bang_line, ' --\?[a-zA-Z0-9]\+', '', 'g')
+        let l:command = substitute(l:shebang, ' --\?[a-zA-Z0-9]\+', '', 'g')
     endif
 
-    " If we couldn't find a hashbang, try the filetype
+    " If we couldn't find a shebang, try the filetype
     if l:command is# ''
         let l:command = &filetype
     endif

--- a/autoload/ale/handlers/shellcheck.vim
+++ b/autoload/ale/handlers/shellcheck.vim
@@ -13,15 +13,6 @@ function! ale#handlers#shellcheck#GetDialectArgument(buffer) abort
         return l:shell_type
     endif
 
-    " If there's no hashbang, try using Vim's buffer variables.
-    if getbufvar(a:buffer, 'is_bash', 0)
-        return 'bash'
-    elseif getbufvar(a:buffer, 'is_sh', 0)
-        return 'sh'
-    elseif getbufvar(a:buffer, 'is_kornshell', 0)
-        return 'ksh'
-    endif
-
     return ''
 endfunction
 


### PR DESCRIPTION
This PR fixes an interesting error I noticed when working on shell scripts that don't have a `#!` line.

To reproduce:
1. create a "test.bash" file, with no `#!` line
2. open the file and verify that `b:is_bash` is set
3. notice that, when using `shellcheck` the file is linted as a simple `sh` file

This is because we fall back to the file type before checking for buffer-local shell type variables.

See my commit messages for more details.

Thanks!