### PR TITLE
Add -imacros to C flags

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -152,6 +152,7 @@ function! ale#c#ParseCFlags(path_prefix, should_quote, raw_arguments) abort
         \ || stridx(l:option, '-idirafter') == 0
         \ || stridx(l:option, '-iframework') == 0
         \ || stridx(l:option, '-include') == 0
+        \ || stridx(l:option, '-imacros') == 0
             if stridx(l:option, '-I') == 0 && l:option isnot# '-I'
                 let l:arg = join(split(l:option, '\zs')[2:], '')
                 let l:option = '-I'

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -482,6 +482,7 @@ Execute(We should include several important flags):
   \ . ' -idirafter ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incafter'))
   \ . ' -iframework ' . ale#Escape(ale#path#Simplify(g:dir . '/test_c_projects/makefile_project/incframework'))
   \ . ' -include ' . ale#Escape(ale#path#Simplify(g:dir . '/test_c_projects/makefile_project/foo bar'))
+  \ . ' -imacros ' . ale#Escape(ale#path#Simplify(g:dir . '/test_c_projects/makefile_project/incmacros'))
   \ . ' -Dmacro="value"'
   \ . ' -DGoal=9'
   \ . ' -D macro2'
@@ -511,6 +512,8 @@ Execute(We should include several important flags):
   \     'incframework',
   \     '-include',
   \     '''foo bar''',
+  \     '-imacros',
+  \     'incmacros',
   \     '-Dmacro="value"',
   \     '-DGoal=9',
   \     '-D',
@@ -559,6 +562,7 @@ Execute(We should quote the flags we need to quote):
   \ . ' -idirafter ' . ale#Escape(ale#path#Simplify(g:dir. '/test_c_projects/makefile_project/incafter'))
   \ . ' -iframework ' . ale#Escape(ale#path#Simplify(g:dir . '/test_c_projects/makefile_project/incframework'))
   \ . ' -include ' . ale#Escape(ale#path#Simplify(g:dir . '/test_c_projects/makefile_project/foo bar'))
+  \ . ' -imacros ' . ale#Escape(ale#path#Simplify(g:dir . '/test_c_projects/makefile_project/incmacros'))
   \ . ' ' . ale#Escape('-Dmacro="value"')
   \ . ' -DGoal=9'
   \ . ' -D macro2'
@@ -591,6 +595,8 @@ Execute(We should quote the flags we need to quote):
   \     'incframework',
   \     '-include',
   \     '''foo bar''',
+  \     '-imacros',
+  \     'incmacros',
   \     '-Dmacro="value"',
   \     '-DGoal=9',
   \     '-D',


### PR DESCRIPTION
I am working in a project, that has some `-imacros`, using the [Zephyr RTOS](https://github.com/zephyrproject-rtos/zephyr).
One problem was, that the compiler from the special toolchain was ignored, even though it is mentioned in the `compile_commands.json` file. I did fix it locally, with `b:ale_c_cc_executable`.The other problem is that the `-imacros` flag is ignored, hence this pull request.

Here is an extract from the `compile_commands.json`:
```json
{
  "directory": "/home/mbrunnen/projects/embedded-system/applications/arbitrary-firmware/build",
  "command": "/home/mbrunnen/.local/opt/zephyr-sdk-0.11.4/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc \
    -DBUILD_VERSION=zephyr-v2.4.0-1136-gcf1bd1780417 \
    -DHSE_VALUE=8000000 \
    -DKERNEL \
    -DLV_CONF_INCLUDE_SIMPLE=1 \
    -DSTM32F103xB \
    -DUSE_FULL_LL_DRIVER \
    -DUSE_HAL_DRIVER \
    -D_FORTIFY_SOURCE=2 \
    -D__PROGRAM_START \
    -D__ZEPHYR__=1 \
    -I/home/mbrunnen/projects/embedded-system/system/zephyr/include \
    -Izephyr/include/generated \
    -I/home/mbrunnen/projects/embedded-system/system/zephyr/soc/arm/st_stm32/stm32f1 \
    -I/home/mbrunnen/projects/embedded-system/system/zephyr/drivers \
    -I/home/mbrunnen/projects/embedded-system/system/zephyr/soc/arm/st_stm32/common/. \
    -I/home/mbrunnen/projects/embedded-system/system/zephyr/soc/arm/st_stm32/common \
    -I/home/mbrunnen/projects/embedded-system/modules/hal/cmsis/CMSIS/Core/Include \
    -I/home/mbrunnen/projects/embedded-system/modules/hal/stm32/stm32cube/stm32f1xx/soc \
    -I/home/mbrunnen/projects/embedded-system/modules/hal/stm32/stm32cube/stm32f1xx/drivers/include \
    -I/home/mbrunnen/projects/embedded-system/modules/hal/stm32/stm32cube/stm32f1xx/drivers/include/Legacy \
    -I/home/mbrunnen/projects/embedded-system/system/zephyr/lib/gui/lvgl \
    -I/home/mbrunnen/projects/embedded-system/modules/lib/gui/lvgl \
    -isystem /home/mbrunnen/projects/embedded-system/system/zephyr/lib/libc/minimal/include \
    -isystem /home/mbrunnen/.local/opt/zephyr-sdk-0.11.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/9.2.0/include \
    -isystem /home/mbrunnen/.local/opt/zephyr-sdk-0.11.4/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/9.2.0/include-fixed    \
    -Os \
    -imacros /home/mbrunnen/projects/embedded-system/applications/arbitrary-firmware/build/zephyr/include/generated/autoconf.h \
    -ffreestanding \
    -fno-common \
    -g \
    -mcpu=cortex-m3 \
    -mthumb \
    -mabi=aapcs \
    -imacros /home/mbrunnen/projects/embedded-system/system/zephyr/include/toolchain/zephyr_stdint.h \
    -Wall \
    -Wformat \
    -Wformat-security \
    -Wno-format-zero-length \
    -Wno-main \
    -Wno-pointer-sign \
    -Wpointer-arith \
    -Wno-address-of-packed-member \
    -Wno-unused-but-set-variable \
    -Werror=implicit-int \
    -fno-asynchronous-unwind-tables \
    -fno-pie \
    -fno-pic \
    -fno-strict-overflow \
    -fno-reorder-functions \
    -fno-defer-pop \
    -fmacro-prefix-map=/home/mbrunnen/projects/embedded-system/applications/arbitrary-firmware=CMAKE_SOURCE_DIR \
    -fmacro-prefix-map=/home/mbrunnen/projects/embedded-system/system/zephyr=ZEPHYR_BASE \
    -fmacro-prefix-map=/home/mbrunnen/projects/embedded-system=WEST_TOPDIR \
    -ffunction-sections \
    -fdata-sections \
    -std=c99 \
    -nostdinc \
    -o CMakeFiles/app.dir/src/main.c.obj   \
    -c /home/mbrunnen/projects/embedded-system/applications/arbitrary-firmware/src/main.c",
  "file": "/home/mbrunnen/projects/embedded-system/applications/arbitrary-firmware/src/main.c"
}
```