### PR TITLE
Code actions fix: diagnostics end character change

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -304,7 +304,7 @@ function! s:OnReady(line, column, end_line, end_column, linter, lsp_details) abo
                 \ 'message': l:nearest_error.text,
                 \ 'range': {
                 \     'start': { 'line': l:nearest_error.lnum - 1, 'character': l:nearest_error.col - 1 },
-                \     'end': { 'line': l:nearest_error.end_lnum - 1, 'character': l:nearest_error.end_col - 1 }
+                \     'end': { 'line': l:nearest_error.end_lnum - 1, 'character': l:nearest_error.end_col }
                 \}
                 \}]
             endif

--- a/test/test_codefix.vader
+++ b/test/test_codefix.vader
@@ -555,7 +555,7 @@ Execute(LSP code action requests should be sent):
   \   }],
   \   [0, 'textDocument/codeAction', {
   \     'context': {
-  \       'diagnostics': [{'range': {'end': {'character': 5, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'code': 2304, 'message': 'oops'}]
+  \       'diagnostics': [{'range': {'end': {'character': 6, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'code': 2304, 'message': 'oops'}]
   \     },
   \     'range': {'end': {'character': 5, 'line': 1}, 'start': {'character': 4, 'line': 1}},
   \     'textDocument': {'uri': ale#path#ToURI(expand('%:p'))}
@@ -595,7 +595,7 @@ Execute(LSP code action requests should be sent only for error with code):
   \   }],
   \   [0, 'textDocument/codeAction', {
   \     'context': {
-  \       'diagnostics': [{'range': {'end': {'character': 5, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'code': 2304, 'message': 'oops'}]
+  \       'diagnostics': [{'range': {'end': {'character': 6, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'code': 2304, 'message': 'oops'}]
   \     },
   \     'range': {'end': {'character': 5, 'line': 1}, 'start': {'character': 4, 'line': 1}},
   \     'textDocument': {'uri': ale#path#ToURI(expand('%:p'))}


### PR DESCRIPTION
@leo60228 proposed fix for clangd here:
https://github.com/dense-analysis/ale/issues/1466#issuecomment-729091829

This specific fix is not harming `typescript-language-server` and
`jedi-language-server` code actions (the only LSPs that were tested with
code actions implementation). Therefore if it is helping with `clangd` I
think that's what we want to have.