### PR TITLE
Allow erlfmt as fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -12,6 +12,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['help'],
 \       'description': 'Align help tags to the right margin',
 \   },
+\   'erl_fmt': {
+\       'function': 'ale#fixers#erl_fmt#Fix',
+\       'suggested_filetypes': ['erlang'],
+\       'description': 'Applies WhatsApp erlfmt to current buffer.',
+\   },
 \   'autopep8': {
 \       'function': 'ale#fixers#autopep8#Fix',
 \       'suggested_filetypes': ['python'],

--- a/autoload/ale/fixers/erl_fmt.vim
+++ b/autoload/ale/fixers/erl_fmt.vim
@@ -2,7 +2,7 @@
 " Description: Fixing erlang files with WhatsApp erlfmt `rebar3 fmt`.
 
 call ale#Set('rebar3_executable', 'rebar3')
-call ale#Set('erlfmt_options', '')
+call ale#Set('erl_fmt_options', '')
 
 function! ale#fixers#erl_fmt#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'rebar3_executable')
@@ -10,9 +10,9 @@ endfunction
 
 function! ale#fixers#erl_fmt#GetCommand(buffer) abort
     let l:executable = ale#Escape(ale#fixers#erl_fmt#GetExecutable(a:buffer))
-    let l:options = ale#Var(a:buffer, 'erlfmt_options')
+    let l:options = ale#Var(a:buffer, 'erl_fmt_options')
 
-    return l:executable . ' fmt'
+    return l:executable . ' format'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' %t'
 endfunction

--- a/autoload/ale/fixers/erl_fmt.vim
+++ b/autoload/ale/fixers/erl_fmt.vim
@@ -1,0 +1,25 @@
+" Author: pepo <josepgiraltdlacoste@gmail.com>, Josep Lluis Giralt D'Lacoste
+" Description: Fixing erlang files with WhatsApp erlfmt `rebar3 fmt`.
+
+call ale#Set('rebar3_executable', 'rebar3')
+call ale#Set('erlfmt_options', '')
+
+function! ale#fixers#erl_fmt#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'rebar3_executable')
+endfunction
+
+function! ale#fixers#erl_fmt#GetCommand(buffer) abort
+    let l:executable = ale#Escape(ale#fixers#erl_fmt#GetExecutable(a:buffer))
+    let l:options = ale#Var(a:buffer, 'erlfmt_options')
+
+    return l:executable . ' fmt'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' %t'
+endfunction
+
+function! ale#fixers#erl_fmt#Fix(buffer) abort
+    return {
+    \   'command': ale#fixers#erl_fmt#GetCommand(a:buffer),
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -42,7 +42,6 @@ g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
   This variable controls additional parameters passed to `erlc`, such as `-I`
   or `-pa`.
 
-
 -------------------------------------------------------------------------------
 syntaxerl                                                *ale-erlang-syntaxerl*
 
@@ -53,6 +52,17 @@ g:ale_erlang_syntaxerl_executable           *g:ale_erlang_syntaxerl_executable*
 
   This variable can be changed to specify the syntaxerl executable.
 
+-------------------------------------------------------------------------------
+erlfmt                                                     *ale-erlang-erlfmt*
+
+g:ale_rebar3_executable                    *g:ale_rebar3_executable*
+                                           *b:ale_rebar3_executable*
+  Type: |String|
+  Default: `'rebar3'`
+
+  This variable can be changed to specify the rebar3 executable.
+
+  You require erlfmt as plugin in the `rebar.config`.
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -53,10 +53,10 @@ g:ale_erlang_syntaxerl_executable           *g:ale_erlang_syntaxerl_executable*
   This variable can be changed to specify the syntaxerl executable.
 
 -------------------------------------------------------------------------------
-erlfmt                                                     *ale-erlang-erlfmt*
+erlfmt                                                      *ale-erlang-erlfmt*
 
-g:ale_rebar3_executable                    *g:ale_rebar3_executable*
-                                           *b:ale_rebar3_executable*
+g:ale_rebar3_executable                               *g:ale_rebar3_executable*
+                                                      *b:ale_rebar3_executable*
   Type: |String|
   Default: `'rebar3'`
 

--- a/test/fixers/test_erl_fmt_fixer.vader
+++ b/test/fixers/test_erl_fmt_fixer.vader
@@ -1,0 +1,36 @@
+Before:
+  Save g:ale_rebar3_executable
+  Save g:ale_erl_fmt_options
+
+  let g:ale_rebar3_executable = 'xxxinvalid'
+  let g:ale_erl_fmt_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The erl_fmt callback should return the correct default values):
+  call ale#test#SetFilename('../erlang-test-files/testfile.erl')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format %t',
+  \ },
+  \ ale#fixers#erl_fmt#Fix(bufnr(''))
+
+Execute(The erl_fmt callback should include the correct format options):
+  let g:ale_erl_fmt_options = 'invalid_options'
+  call ale#test#SetFilename('../erlang-test-files/testfile.erl')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format invalid_options %t',
+  \ },
+  \ ale#fixers#erl_fmt#Fix(bufnr(''))


### PR DESCRIPTION
Adds the WhatsApp's [erlfmt](https://github.com/WhatsApp/erlfmt) formatter. In order to use this you need erlfmt in your `rebar.config`.