### PR TITLE
pass lsp intialization_options to rust-analyzer

### DIFF
--- a/ale_linters/rust/analyzer.vim
+++ b/ale_linters/rust/analyzer.vim
@@ -17,7 +17,7 @@ endfunction
 call ale#linter#Define('rust', {
 \   'name': 'analyzer',
 \   'lsp': 'stdio',
-\   'lsp_config': {b -> ale#Var(b, 'rust_analyzer_config')},
+\   'initialization_options': {b -> ale#Var(b, 'rust_analyzer_config')},
 \   'executable': {b -> ale#Var(b, 'rust_analyzer_executable')},
 \   'command': function('ale_linters#rust#analyzer#GetCommand'),
 \   'project_root': function('ale_linters#rust#analyzer#GetProjectRoot'),

--- a/test/command_callback/test_rust_analyzer_callbacks.vader
+++ b/test/command_callback/test_rust_analyzer_callbacks.vader
@@ -16,5 +16,5 @@ Execute(The project root should be detected correctly):
 
 Execute(Should accept configuration settings):
   AssertLSPConfig {}
-  let b:ale_rust_analyzer_config = {'rust': {'clippy_preference': 'on'}}
-  AssertLSPConfig {'rust': {'clippy_preference': 'on'}}
+  let b:ale_rust_analyzer_config = {'diagnostics': {'disabled': ['unresolved-import']}}
+  AssertLSPOptions {'diagnostics': {'disabled': ['unresolved-import']}}


### PR DESCRIPTION
`rust-analyzer` uses LSP initialization options for config, and [mostly ignores the DidChangeConfiguration] message. This PR starts sending passing `ale_rust_analyzer_config` options as init_options on new connections so that `rust-analyzer` actually picks them up.

Thanks to user @user827 in #3350 for the fix.