### PR TITLE
fix: proper initialization options call in php intelephense

### DIFF
--- a/ale_linters/php/intelephense.vim
+++ b/ale_linters/php/intelephense.vim
@@ -18,8 +18,8 @@ function! ale_linters#php#intelephense#GetProjectRoot(buffer) abort
     return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
 endfunction
 
-function! ale_linters#php#intelephense#GetInitializationOptions() abort
-    return ale#Get('php_intelephense_config')
+function! ale_linters#php#intelephense#GetInitializationOptions(buffer) abort
+    return ale#Var(a:buffer, 'php_intelephense_config')
 endfunction
 
 call ale#linter#Define('php', {


### PR DESCRIPTION
Addresses issue #3458. This will add a `buffer` argument and get the proper config variable for Initialization Options.
