### PR TITLE
Modified intelephense linter file to use new initialization

### DIFF
--- a/ale_linters/php/intelephense.vim
+++ b/ale_linters/php/intelephense.vim
@@ -18,8 +18,8 @@ function! ale_linters#php#intelephense#GetProjectRoot(buffer) abort
     return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
 endfunction
 
-function! ale_linters#php#intelephense#GetInitializationOptions() abort
-    return ale#Get('php_intelephense_config')
+function! ale_linters#php#intelephense#GetInitializationOptions(buffer) abort
+    return ale#Var(a:buffer, 'php_intelephense_config')
 endfunction
 
 call ale#linter#Define('php', {


### PR DESCRIPTION
`ale#Get` does not exist anymore. `ale#Var` needs the buffer. With this changes no error messages are dropped anymore when using intelephense.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
