### PR TITLE
Fix checkstyle regexp pattern to work correctly in NVim on Windows

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -9,7 +9,7 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     let l:output = []
 
     " modern checkstyle versions
-    let l:pattern = '\v\[(WARN|ERROR)\] [a-zA-Z]?:?[^:]+:(\d+):(\d+)?:? (.*) \[(.+)\]$'
+    let l:pattern = '\v\[(WARN|ERROR)\] [a-zA-Z]?:?[^:]+:(\d+):(\d+)?:? (.*) \[(.+)\]'
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {


### PR DESCRIPTION
This patch fixes a problem I found recently in Ale's support for the Java checkstyler linter.  The problem is seen only when using checkstyle in Neovim on the Windows platform.  It is not raised on Vim running on Windows, or in either Nvim or Vim running on Linux.  (I don't have a Mac and did not test on that platform.)

Versions:
NVim 0.4.4
checkstyle 8.37 and 8.36.2
Windows 10

When using checkstyle to lint various Java classes in Ale, I found that no warning/errors were displayed or marked with signs when linting the files in NVim when running on Windows 10.  The same files were linted correctly when displayed in Vim on Windows, and on both NVim and Vim on Linux.  Also, the :ALEInfo output for all tests were the same, with the same expected warning messages included in the output list and no sign of problems in the checkstyle processing.

After debugging, I found that the regexp pattern used by Ale to match the checkstyle output failed to match any lines when run on NVim and Windows.  Removing the final end-of-line anchor "$" from the pattern fixed the problem.  With this change, the pattern matching worked in NVim and Vim running on both Windows and Linux.  The changed pattern could be set conditionally based on has('Nvim) and has('win32) of course, but I did not find that necessary in my testing.

For reference, here are the Ale-related settings used in my .vimrc and init.vim files on both platforms, which did not require any changes for this issue.

" Ale linting                                                                   
let g:checkstyle_jar_path = has("win32") ? 'C:/checkstyle/checkstyle-8.37-all.jar' :      
        \'/usr/local/checkstyle/checkstyle-8.37-all.jar'                        
let g:ale_java_checkstyle_config = has("win32") ? 'C:/checkstyle/sun_checks.xml' :      
        \'/usr/local/checkstyle/sun_checks.xml'                                                 
let g:ale_java_checkstyle_executable = 'java'                                   
let g:ale_java_checkstyle_options = '-jar ' . g:checkstyle_jar_path             
if has("win32")                                                                 
    " Command line too long on Windows with classpath included for javac        
    let g:ale_linters_ignore = {'java': ['javac']}                              
endif 
