### PR TITLE
(#3115) ale#Env quoting bug on Windows

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -208,7 +208,7 @@ endfunction
 " valid for cmd on Windows, or most shells on Unix.
 function! ale#Env(variable_name, value) abort
     if has('win32')
-        return 'set ' . a:variable_name . '=' . ale#Escape(a:value) . ' && '
+        return 'set "' . a:variable_name . '=' . a:value . '" && '
     endif
 
     return a:variable_name . '=' . ale#Escape(a:value) . ' '


### PR DESCRIPTION
#3115 . Thethe ale#Env function [here](https://github.com/dense-analysis/ale/blob/1365dce921c1fb84a668ae121d5d5aeebef99fbc/autoload/ale.vim#L209) was changed from this
```
if has('win32')
        return 'set ' . a:variable_name . '=' . ale#Escape(a:value) . ' && '
    endif
```
To this
```
    if has('win32')
        return 'set "' . a:variable_name . '=' . a:value . '" && '
    endif
```

I removed `ale#Escape` because the note [here](https://github.com/dense-analysis/ale/blob/1365dce921c1fb84a668ae121d5d5aeebef99fbc/autoload/ale.vim#L218) claims that it does not work in windows. (btw, what works on windows?)

This works perfectly in my actual configuration of ALE without any collateral effect. 