### PR TITLE
Make test/scripts/custom-checks portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV PACKAGES="\
     git \
     python \
     py-pip \
+    grep \
+    sed \
 "
 RUN apk --update add $PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -49,8 +49,8 @@ Notes:
   * `astyle`
   * `ccls`
   * `clang` (`cc`)
-  * `clangd`
   * `clang-format`
+  * `clangd`
   * `clangtidy`!!
   * `cppcheck`
   * `cpplint`!!
@@ -67,9 +67,9 @@ Notes:
   * `astyle`
   * `ccls`
   * `clang` (`cc`)
+  * `clang-format`
   * `clangcheck`!!
   * `clangd`
-  * `clang-format`
   * `clangtidy`!!
   * `clazy`!!
   * `cppcheck`
@@ -140,9 +140,9 @@ Notes:
   * `erubis`
   * `ruumba`
 * Erlang
+  * `SyntaxErl`
   * `elvis`!!
   * `erlc`
-  * `SyntaxErl`
 * Fish
   * `fish` (-n flag)
 * Fortran
@@ -160,17 +160,17 @@ Notes:
 * Go
   * `bingo`
   * `go build`!!
+  * `go mod`!!
+  * `go vet`!!
   * `gofmt`
   * `goimports`
   * `golangci-lint`!!
   * `golangserver`
   * `golint`
   * `gometalinter`!!
-  * `go mod`!!
   * `gopls`
   * `gosimple`!!
   * `gotype`!!
-  * `go vet`!!
   * `revive`!!
   * `staticcheck`!!
 * GraphQL
@@ -203,10 +203,10 @@ Notes:
 * HCL
   * `terraform-fmt`
 * HTML
+  * `HTMLHint`
   * `alex`!!
   * `fecs`
   * `html-beautify`
-  * `HTMLHint`
   * `prettier`
   * `proselint`
   * `tidy`
@@ -218,12 +218,12 @@ Notes:
 * ISPC
   * `ispc`!!
 * Java
+  * `PMD`
   * `checkstyle`
   * `eclipselsp`
   * `google-java-format`
   * `javac`
   * `javalsp`
-  * `PMD`
   * `uncrustify`
 * JavaScript
   * `eslint`
@@ -330,10 +330,10 @@ Notes:
   * `intelephense`
   * `langserver`
   * `phan`
+  * `php -l`
+  * `php-cs-fixer`
   * `phpcbf`
   * `phpcs`
-  * `php-cs-fixer`
-  * `php -l`
   * `phpmd`
   * `phpstan`
   * `psalm`!!
@@ -394,6 +394,8 @@ Notes:
   * `styler`
 * Racket
   * `raco`
+* Re:VIEW
+  * `redpen`
 * ReasonML
   * `merlin`
   * `ols`
@@ -407,8 +409,6 @@ Notes:
   * `textlint`
   * `vale`
   * `write-good`
-* Re:VIEW
-  * `redpen`
 * RPM spec
   * `rpmlint`
 * Ruby
@@ -453,10 +453,10 @@ Notes:
   * `solium`
 * SQL
   * `pgformatter`
+  * `sql-lint`
   * `sqlfmt`
   * `sqlformat`
   * `sqlint`
-  * `sql-lint`
 * Stylus
   * `stylelint`
 * SugarSS

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2956,11 +2956,11 @@ documented in additional help files.
     hdl-checker...........................|ale-vhdl-hdl-checker|
     vcom..................................|ale-vhdl-vcom|
     xvhdl.................................|ale-vhdl-xvhdl|
+  vim help................................|ale-vim-help-options|
+    write-good............................|ale-vim-help-write-good|
   vim.....................................|ale-vim-options|
     vimls.................................|ale-vim-vimls|
     vint..................................|ale-vim-vint|
-  vim help................................|ale-vim-help-options|
-    write-good............................|ale-vim-help-write-good|
   vue.....................................|ale-vue-options|
     prettier..............................|ale-vue-prettier|
     vls...................................|ale-vue-vls|

--- a/run-tests
+++ b/run-tests
@@ -9,8 +9,8 @@ set -u
 # options, or read the output below.
 #
 
-image=w0rp/ale
-current_image_id=f58c7bf8900f
+image=akevinclark/ale
+current_image_id=8e1802ca34b5
 
 # Used in all test scripts for running the selected Docker image.
 DOCKER_RUN_IMAGE="$image"

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -58,8 +58,8 @@ formatting.
   * [astyle](http://astyle.sourceforge.net/)
   * [ccls](https://github.com/MaskRay/ccls)
   * [clang](http://clang.llvm.org/)
-  * [clangd](https://clang.llvm.org/extra/clangd.html)
   * [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
+  * [clangd](https://clang.llvm.org/extra/clangd.html)
   * [clangtidy](http://clang.llvm.org/extra/clang-tidy/) :floppy_disk:
   * [cppcheck](http://cppcheck.sourceforge.net)
   * [cpplint](https://github.com/google/styleguide/tree/gh-pages/cpplint)
@@ -76,9 +76,9 @@ formatting.
   * [astyle](http://astyle.sourceforge.net/)
   * [ccls](https://github.com/MaskRay/ccls)
   * [clang](http://clang.llvm.org/)
+  * [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
   * [clangcheck](http://clang.llvm.org/docs/ClangCheck.html) :floppy_disk:
   * [clangd](https://clang.llvm.org/extra/clangd.html)
-  * [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
   * [clangtidy](http://clang.llvm.org/extra/clang-tidy/) :floppy_disk:
   * [clazy](https://github.com/KDE/clazy) :floppy_disk:
   * [cppcheck](http://cppcheck.sourceforge.net)
@@ -149,9 +149,9 @@ formatting.
   * [erubis](https://github.com/kwatch/erubis)
   * [ruumba](https://github.com/ericqweinstein/ruumba)
 * Erlang
+  * [SyntaxErl](https://github.com/ten0s/syntaxerl)
   * [elvis](https://github.com/inaka/elvis) :floppy_disk:
   * [erlc](http://erlang.org/doc/man/erlc.html)
-  * [SyntaxErl](https://github.com/ten0s/syntaxerl)
 * Fish
   * fish [-n flag](https://linux.die.net/man/1/fish)
 * Fortran
@@ -169,17 +169,17 @@ formatting.
 * Go
   * [bingo](https://github.com/saibing/bingo) :warning:
   * [go build](https://golang.org/cmd/go/) :warning: :floppy_disk:
+  * [go mod](https://golang.org/cmd/go/) :warning: :floppy_disk:
+  * [go vet](https://golang.org/cmd/vet/) :floppy_disk:
   * [gofmt](https://golang.org/cmd/gofmt/)
   * [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) :warning:
   * [golangci-lint](https://github.com/golangci/golangci-lint) :warning: :floppy_disk:
   * [golangserver](https://github.com/sourcegraph/go-langserver) :warning:
   * [golint](https://godoc.org/github.com/golang/lint)
   * [gometalinter](https://github.com/alecthomas/gometalinter) :warning: :floppy_disk:
-  * [go mod](https://golang.org/cmd/go/) :warning: :floppy_disk:
   * [gopls](https://github.com/golang/go/wiki/gopls) :warning:
   * [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) :warning: :floppy_disk:
   * [gotype](https://godoc.org/golang.org/x/tools/cmd/gotype) :warning: :floppy_disk:
-  * [go vet](https://golang.org/cmd/vet/) :floppy_disk:
   * [revive](https://github.com/mgechev/revive) :warning: :floppy_disk:
   * [staticcheck](https://github.com/dominikh/go-tools/tree/master/cmd/staticcheck) :warning: :floppy_disk:
 * GraphQL
@@ -212,10 +212,10 @@ formatting.
 * HCL
   * [terraform-fmt](https://github.com/hashicorp/terraform)
 * HTML
+  * [HTMLHint](http://htmlhint.com/)
   * [alex](https://github.com/wooorm/alex) :floppy_disk:
   * [fecs](http://fecs.baidu.com/)
   * [html-beautify](https://beautifier.io/)
-  * [HTMLHint](http://htmlhint.com/)
   * [prettier](https://github.com/prettier/prettier)
   * [proselint](http://proselint.com/)
   * [tidy](http://www.html-tidy.org/)
@@ -227,12 +227,12 @@ formatting.
 * ISPC
   * [ispc](https://ispc.github.io/) :floppy_disk:
 * Java
+  * [PMD](https://pmd.github.io/)
   * [checkstyle](http://checkstyle.sourceforge.net)
   * [eclipselsp](https://github.com/eclipse/eclipse.jdt.ls)
   * [google-java-format](https://github.com/google/google-java-format)
   * [javac](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
   * [javalsp](https://github.com/georgewfraser/vscode-javac)
-  * [PMD](https://pmd.github.io/)
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * JavaScript
   * [eslint](http://eslint.org/)
@@ -339,10 +339,10 @@ formatting.
   * [intelephense](https://github.com/bmewburn/intelephense-docs)
   * [langserver](https://github.com/felixfbecker/php-language-server)
   * [phan](https://github.com/phan/phan) see `:help ale-php-phan` to instructions
+  * [php -l](https://secure.php.net/)
+  * [php-cs-fixer](http://cs.sensiolabs.org/)
   * [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer)
   * [phpcs](https://github.com/squizlabs/PHP_CodeSniffer)
-  * [php-cs-fixer](http://cs.sensiolabs.org/)
-  * [php -l](https://secure.php.net/)
   * [phpmd](https://phpmd.org)
   * [phpstan](https://github.com/phpstan/phpstan)
   * [psalm](https://getpsalm.org) :floppy_disk:
@@ -403,6 +403,8 @@ formatting.
   * [styler](https://github.com/r-lib/styler)
 * Racket
   * [raco](https://docs.racket-lang.org/raco/)
+* Re:VIEW
+  * [redpen](http://redpen.cc/)
 * ReasonML
   * [merlin](https://github.com/the-lambda-church/merlin) see `:help ale-reasonml-ols` for configuration instructions
   * [ols](https://github.com/freebroccolo/ocaml-language-server)
@@ -416,8 +418,6 @@ formatting.
   * [textlint](https://textlint.github.io/)
   * [vale](https://github.com/ValeLint/vale)
   * [write-good](https://github.com/btford/write-good)
-* Re:VIEW
-  * [redpen](http://redpen.cc/)
 * RPM spec
   * [rpmlint](https://github.com/rpm-software-management/rpmlint) :warning: (see `:help ale-integration-spec`)
 * Ruby
@@ -462,10 +462,10 @@ formatting.
   * [solium](https://github.com/duaraghav8/Solium)
 * SQL
   * [pgformatter](https://github.com/darold/pgFormatter)
+  * [sql-lint](https://github.com/joereynolds/sql-lint)
   * [sqlfmt](https://github.com/jackc/sqlfmt)
   * [sqlformat](https://github.com/andialbrecht/sqlparse)
   * [sqlint](https://github.com/purcell/sqlint)
-  * [sql-lint](https://github.com/joereynolds/sql-lint)
 * Stylus
   * [stylelint](https://github.com/stylelint/stylelint)
 * SugarSS

--- a/test/script/check-duplicate-tags
+++ b/test/script/check-duplicate-tags
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+grep --exclude=tags -roh '\*.*\*$' doc | sort | uniq -d

--- a/test/script/check-supported-tools-tables
+++ b/test/script/check-supported-tools-tables
@@ -15,14 +15,13 @@ while read -r; do
     if [[ "$REPLY" =~ ^! ]]; then
         language="${REPLY/!/}"
     else
-        # shellcheck disable=SC2001
         echo "$language - $REPLY"
     fi
 done < <(
     grep '^\*\|^  *\*' doc/ale-supported-languages-and-tools.txt \
     | sed -e '1,2d' \
     | sed 's/^\* */!/' \
-    | sed -E 's/^ *\* *|!!|\^|(.*)|`//g' \
+    | sed -E 's/^ *\* *|!!|\^|\(.*\)|`//g' \
     | sed 's/ *$//'
 ) > "$doc_file"
 
@@ -30,7 +29,6 @@ while read -r; do
     if [[ "$REPLY" =~ ^! ]]; then
         language="${REPLY/!/}"
     else
-        # shellcheck disable=SC2001
         echo "$language - $REPLY"
     fi
 done < <(

--- a/test/script/check-supported-tools-tables
+++ b/test/script/check-supported-tools-tables
@@ -22,7 +22,7 @@ done < <(
     grep '^\*\|^  *\*' doc/ale-supported-languages-and-tools.txt \
     | sed -e '1,2d' \
     | sed 's/^\* */!/' \
-    | sed 's/^ *\* *\|!!\|\^\|(.*)\|`//g' \
+    | sed -E 's/^ *\* *|!!|\^|(.*)|`//g' \
     | sed 's/ *$//'
 ) > "$doc_file"
 
@@ -36,7 +36,7 @@ while read -r; do
 done < <(
     grep '^\*\|^  *\*' supported-tools.md \
     | sed 's/^\* */!/' \
-    | sed 's/^ *\* *\|:floppy_disk:\|:warning:\|(.*)\|\[\|\].*\|-n flag//g' \
+    | sed -E 's/^ *\* *|:floppy_disk:|:warning:|\(.*\)|\[|\].*|-n flag//g' \
     | sed 's/ *$//'
 ) > "$readme_file"
 

--- a/test/script/check-tag-alignment
+++ b/test/script/check-tag-alignment
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+exit_code=0
+
+# Documentation tags need to be aligned to the right margin, so look for
+# tags which aren't at the right margin.
+grep ' \*[^*]\+\*$' doc/ -r \
+    | awk '{ sep = index($0, ":"); if (length(substr($0, sep + 1 )) < 79) { print } }' \
+    | grep . && exit_code=1
+
+exit $exit_code

--- a/test/script/check-tag-references
+++ b/test/script/check-tag-references
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+exit_code=0
+tag_regex='[gb]\?:\?\(ale\|ALE\)[a-zA-Z_\-]\+'
+
+tags="$(mktemp -t tags.XXXXXXXX)"
+refs="$(mktemp -t refs.XXXXXXXX)"
+# Grep for tags and references, and complain if we find a reference without
+# a tag for the reference. Only our tags will be included.
+grep --exclude=tags -roh "\\*$tag_regex\\*" doc | sed 's/*//g' | sort -u > "$tags"
+grep --exclude=tags -roh "|$tag_regex|" doc | sed 's/|//g' | sort -u > "$refs"
+
+exit_code=0
+
+if ! [[ $(comm -23 $refs $tags | wc -l) -eq 0 ]]; then
+  exit_code=1
+fi
+
+rm "$tags"
+rm "$refs"

--- a/test/script/check-toc
+++ b/test/script/check-toc
@@ -35,7 +35,7 @@ sed -n "$toc_start_line,$toc_end_line"p doc/ale.txt \
     > "$toc_file"
 
 # Get all of the doc files in a natural sorted order.
-doc_files="$(/usr/bin/env ls -1v doc | grep ^ale- | sed 's/^/doc\//' | paste -sd ' ' -)"
+doc_files="$(/usr/bin/env ls -1 doc | awk '/ale-/' | sed 's/^/doc\//' | paste -sd ' ' -)"
 
 # shellcheck disable=SC2086
 grep -h '\*ale-.*-options\|^[a-z].*\*ale-.*\*$' $doc_files \

--- a/test/script/check-toc
+++ b/test/script/check-toc
@@ -35,7 +35,7 @@ sed -n "$toc_start_line,$toc_end_line"p doc/ale.txt \
     > "$toc_file"
 
 # Get all of the doc files in a natural sorted order.
-doc_files="$(/usr/bin/env ls -1 doc | awk '/ale-/' | sed 's/^/doc\//' | paste -sd ' ' -)"
+doc_files="$(/usr/bin/env ls -1 doc | grep '^ale-' | sed 's/^/doc\//' | paste -sd ' ' -)"
 
 # shellcheck disable=SC2086
 grep -h '\*ale-.*-options\|^[a-z].*\*ale-.*\*$' $doc_files \

--- a/test/script/check-toc
+++ b/test/script/check-toc
@@ -35,7 +35,7 @@ sed -n "$toc_start_line,$toc_end_line"p doc/ale.txt \
     > "$toc_file"
 
 # Get all of the doc files in a natural sorted order.
-doc_files="$(/usr/bin/env ls -1 doc | grep '^ale-' | sed 's/^/doc\//' | paste -sd ' ' -)"
+doc_files="$(/usr/bin/env ls -1v doc | grep '^ale-' | sed 's/^/doc\//' | paste -sd ' ' -)"
 
 # shellcheck disable=SC2086
 grep -h '\*ale-.*-options\|^[a-z].*\*ale-.*\*$' $doc_files \

--- a/test/script/custom-checks
+++ b/test/script/custom-checks
@@ -46,7 +46,9 @@ echo '========================================'
 echo 'Differences follow:'
 echo
 
-test/script/check-supported-tools-tables || exit_code=$?
+set -o pipefail
+docker run "${docker_flags[@]}" test/script/check-supported-tools-tables || exit_code=$?
+set +o pipefail
 
 echo '========================================'
 echo 'Look for badly aligned doc tags'

--- a/test/script/custom-checks
+++ b/test/script/custom-checks
@@ -13,7 +13,7 @@ echo 'Custom warnings/errors follow:'
 echo
 
 set -o pipefail
-docker run -a stdout "${docker_flags[@]}" test/script/custom-linting-rules . || exit_code=$?
+docker run "${docker_flags[@]}" test/script/custom-linting-rules . || exit_code=$?
 set +o pipefail
 echo
 
@@ -23,7 +23,10 @@ echo '========================================'
 echo 'Duplicate tags follow:'
 echo
 
-grep --exclude=tags -roh '\*.*\*$' doc | sort | uniq -d || exit_code=$?
+set -o pipefail
+docker run "${docker_flags[@]}" test/script/check-duplicate-tags . || exit_code=$?
+set +o pipefail
+echo
 
 echo '========================================'
 echo 'Checking for invalid tag references'
@@ -31,14 +34,9 @@ echo '========================================'
 echo 'Invalid tag references tags follow:'
 echo
 
-tag_regex='[gb]\?:\?\(ale\|ALE\)[a-zA-Z_\-]\+'
-
-# Grep for tags and references, and complain if we find a reference without
-# a tag for the reference. Only our tags will be included.
-diff -u \
-    <(grep --exclude=tags -roh "\\*$tag_regex\\*" doc | sort -u | sed 's/*//g') \
-    <(grep --exclude=tags -roh "|$tag_regex|" doc | sort -u | sed 's/|//g') \
-    | grep '^+[^+]' && exit_code=1
+set -o pipefail
+docker run "${docker_flags[@]}" test/script/check-tag-references || exit_code=$?
+set +o pipefail
 
 echo '========================================'
 echo 'diff supported-tools.md and doc/ale-supported-languages-and-tools.txt tables'
@@ -56,18 +54,18 @@ echo '========================================'
 echo 'Badly aligned tags follow:'
 echo
 
-# Documentation tags need to be aligned to the right margin, so look for
-# tags which aren't at the right margin.
-grep ' \*[^*]\+\*$' doc/ -r \
-    | awk '{ sep = index($0, ":"); if (length(substr($0, sep + 1 )) < 79) { print } }' \
-    | grep . && exit_code=1
+set -o pipefail
+docker run "${docker_flags[@]}" test/script/check-tag-alignment || exit_code=$?
+set +o pipefail
 
 echo '========================================'
 echo 'Look for table of contents issues'
 echo '========================================'
 echo
 
-test/script/check-toc || exit_code=$?
+set -o pipefail
+docker run "${docker_flags[@]}" test/script/check-toc || exit_code=$?
+set +o pipefail
 
 echo '========================================'
 echo 'Check Python code'

--- a/test/script/custom-linting-rules
+++ b/test/script/custom-linting-rules
@@ -53,9 +53,21 @@ check_errors() {
     regex="$1"
     message="$2"
     include_arg=''
+    exclude_arg=''
 
     if [ $# -gt 2 ]; then
         include_arg="--include $3"
+    fi
+
+    if [ $# -gt 3 ]; then
+        shift
+        shift
+        shift
+
+        while (( "$#" )); do
+          exclude_arg="$exclude_arg --exclude $1"
+          shift
+        done
     fi
 
     for directory in "${directories[@]}"; do
@@ -63,7 +75,7 @@ check_errors() {
         while read -r; do
             RETURN_CODE=1
             echo "$REPLY $message"
-        done < <(grep -H -n "$regex" $include_arg "$directory"/**/*.vim \
+        done < <(grep -H -n "$regex" $include_arg $exclude_arg "$directory"/**/*.vim \
             | grep -v 'no-custom-checks' \
             | grep -o '^[^:]\+:[0-9]\+' \
             | sed 's:^\./::')
@@ -92,7 +104,7 @@ if (( FIX_ERRORS )); then
     done
 fi
 
-# The arguments are: regex, explanation, [filename_filter]
+# The arguments are: regex, explanation, [filename_filter], [list, of, exclusions]
 check_errors \
     '^function.*) *$' \
     'Function without abort keyword (See :help except-compat)'
@@ -114,7 +126,10 @@ check_errors '==?' "Use 'is?' instead of '==?'. 0 ==? 'foobar' is true"
 check_errors '!=#' "Use 'isnot#' instead of '!=#'. 0 !=# 'foobar' is false"
 check_errors '!=?' "Use 'isnot?' instead of '!=?'. 0 !=? 'foobar' is false"
 check_errors '^ *:\?echo' "Stray echo line. Use \`execute echo\` if you want to echo something"
-check_errors $'name.:.*\'[a-z_]*[^a-z_0-9][a-z_0-9]*\',$' 'Use snake_case names for linters' '*/ale_linters/*'
+# Exclusions for grandfathered-in exceptions
+exclusions="clojure/clj_kondo.vim elixir/elixir_ls.vim go/golangci_lint.vim swift/swiftformat.vim"
+# shellcheck disable=SC2086
+check_errors $'name.:.*\'[a-z_]*[^a-z_0-9][a-z_0-9]*\',$' 'Use snake_case names for linters' '*/ale_linters/*' $exclusions
 # Checks for improving type checks.
 check_errors $'\\(==.\\?\\|is\\) type([\'"]\+)' "Use 'is v:t_string' instead"
 check_errors '\(==.\?\|is\) type([0-9]\+)' "Use 'is v:t_number' instead"


### PR DESCRIPTION
As reported in #3448, `./run-tests` doesn't work universally. The issue appears to be partly a dependence on system tools (grep and sed in particular) from the user environment which aren't exactly equivalent across systems. This PR moves the execution of those checks into the docker environment, which is updated to use gnu versions of the tools which are more robust than the busybox equivalent.

As a result of the change, the TOC and supported-tools tests, which rely on sort order, where changed slightly. The custom-linter-rules test now, seemingly correctly, fails because there are several lint names that aren't snake case. It's an open question what to do about that as I suspect there are users of those lints that need to be supported. Grandfathered in whitelist?