### PR TITLE
hadolint: Recognize message type

### DIFF
--- a/ale_linters/dockerfile/hadolint.vim
+++ b/ale_linters/dockerfile/hadolint.vim
@@ -9,7 +9,7 @@ function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
     "
     " /dev/stdin:19 DL3001 Pipe chain should start with a raw value.
     " /dev/stdin:19:3 unexpected thing
-    let l:pattern = '\v^/dev/stdin:(\d+):?(\d+)? ((DL|SC)(\d+) )?(.+)$'
+    let l:pattern = '\v^/dev/stdin:(\d+):?(\d+)? ((DL|SC)(\d+) )?((.+)?: )?(.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
@@ -24,9 +24,19 @@ function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
             let l:colnum = l:match[2] + 0
         endif
 
-        let l:type = 'W'
-        let l:text = l:match[6]
-        let l:detail = l:match[6]
+        " Shellcheck knows a 'style' severity - pin it to info level as well.
+        if l:match[7] is# 'style'
+            let l:type = 'I'
+        elseif l:match[7] is# 'info'
+            let l:type = 'I'
+        elseif l:match[7] is# 'warning'
+            let l:type = 'W'
+        else
+            let l:type = 'E'
+        endif
+
+        let l:text = l:match[8]
+        let l:detail = l:match[8]
         let l:domain = 'https://github.com/hadolint/hadolint/wiki/'
 
         if l:match[4] is# 'SC'

--- a/test/handler/test_hadolint.vader
+++ b/test/handler/test_hadolint.vader
@@ -1,0 +1,49 @@
+Before:
+  runtime ale_linters/dockerfile/hadolint.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The hadolint handler should handle an empty string response):
+  AssertEqual
+  \ [],
+  \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [])
+
+Execute(The hadolint handler should handle a normal example):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': "Always tag the version of an image explicitly",
+  \     'detail': "DL3006 ( https://github.com/hadolint/hadolint/wiki/DL3006 )\n\nAlways tag the version of an image explicitly",
+  \   },
+#  \   {
+#  \     'lnum': 2,
+#  \     'col': 0,
+#  \     'type': 'E',
+#  \     'text': "MAINTAINER is deprecated",
+#  \     'detail': "DL4000 ( https://github.com/hadolint/hadolint/wiki/DL4000 )\n\nMAINTAINER is deprecated",
+#  \   },
+#  \   {
+#  \     'lnum': 4,
+#  \     'col': 0,
+#  \     'type': 'W',
+#  \     'text': "Specify version with `yum install -y <package>-<version>`.",
+#  \     'detail': "DL3033 ( https://github.com/hadolint/hadolint/wiki/DL3033 )\n\nSpecify version with `yum install -y <package>-<version>`.",
+#  \   },
+#  \   {
+#  \     'lnum': 12,
+#  \     'col': 0,
+#  \     'type': 'W',
+#  \     'text': "In POSIX sh, brace expansion is undefined.",
+#  \     'detail': "SC2039 ( https://github.com/koalaman/shellcheck/wiki/SC2039 )\n\nIn POSIX sh, brace expansion is undefined.",
+#  \   },
+  \ ],
+  \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
+  \ '/dev/stdin:1 DL3006 warning: Always tag the version of an image explicitly',
+#  \ '/dev/stdin:2 DL4000 error: MAINTAINER is deprecated',
+#  \ '/dev/stdin:4 DL3033 warning: Specify version with `yum install -y <package>-<version>`.',
+#  \ '/dev/stdin:12 SC2039 warning: In POSIX sh, brace expansion is undefined.'
+  \ ])

--- a/test/test_dockerfile_hadolint_linter.vader
+++ b/test/test_dockerfile_hadolint_linter.vader
@@ -70,14 +70,14 @@ Execute(test warnings from hadolint):
   AssertEqual
   \ [{'lnum': 10, 'col': 0, 'type': 'W', 'text': 'Using latest is prone to errors', 'detail': "DL3007 ( https://github.com/hadolint/hadolint/wiki/DL3007 )\n\nUsing latest is prone to errors"}],
   \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
-  \ '/dev/stdin:10 DL3007 Using latest is prone to errors',
+  \ '/dev/stdin:10 DL3007 warning: Using latest is prone to errors',
   \ ])
 
 Execute(test warnings from shellcheck):
   AssertEqual
   \ [{'lnum': 3, 'col': 0, 'type': 'W', 'text': 'bar is referenced but not assigned.', 'detail': "SC2154 ( https://github.com/koalaman/shellcheck/wiki/SC2154 )\n\nbar is referenced but not assigned."}],
   \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
-  \ '/dev/stdin:3 SC2154 bar is referenced but not assigned.',
+  \ '/dev/stdin:3 SC2154 warning: bar is referenced but not assigned.',
   \ ])
 
 Execute(test errors from dockerfile parser):


### PR DESCRIPTION
Hadolint is in the process of adding the severity of a lint rule to the
command line output: https://github.com/hadolint/hadolint/pull/501

This change utilizes that to show the severity in vim.
This change also updates the tests on the Hadolint handler.
