### PR TITLE
Fixes to code actions (cursor moving, tests, EOL/EOF corner cases)

### DIFF
--- a/autoload/ale/code_action.vim
+++ b/autoload/ale/code_action.vim
@@ -134,10 +134,18 @@ function! ale#code_action#ApplyChanges(filename, changes, should_save) abort
         let l:current_line_offset = len(l:lines) - l:lines_before_change
         let l:column_offset = len(l:middle[-1]) - l:end_line_len
 
-        let l:pos = s:UpdateCursor(l:pos,
-        \ [l:line, l:column],
-        \ [l:end_line, l:end_column],
-        \ [l:current_line_offset, l:column_offset])
+        " Keep cursor where it was (if outside of changes) or move it after
+        " the changed text (if inside), but don't touch it when the change
+        " spans the entire buffer, in which case we have no clue and it's
+        " better to not do anything.
+        if l:line isnot 1 || l:column isnot 1
+        \|| l:end_line < l:lines_before_change
+        \|| l:end_line == l:lines_before_change && l:end_column <= l:end_line_len
+            let l:pos = s:UpdateCursor(l:pos,
+            \ [l:line, l:column],
+            \ [l:end_line, l:end_column],
+            \ [l:current_line_offset, l:column_offset])
+        endif
     endfor
 
     if l:lines[-1] is# ''

--- a/autoload/ale/code_action.vim
+++ b/autoload/ale/code_action.vim
@@ -97,9 +97,20 @@ function! ale#code_action#ApplyChanges(filename, changes, should_save) abort
         let l:insertions = split(l:text, '\n', 1)
 
         " Special case when text must be added after new line
-        if l:column > len(l:lines[l:line - 1])
+        if l:column > len(l:lines[l:line - 1]) + 1
             let l:line += 1
             let l:column = 1
+        endif
+
+        " Adjust end if we moved start past end
+        if l:end_line < l:line || l:end_line == l:line && l:end_column < l:column
+            let [l:end_line, l:end_column] = [l:line, l:column]
+        endif
+
+        " Special case when end is after new line
+        if l:end_column > len(l:lines[l:end_line - 1]) + 1
+            let l:end_line += 1
+            let l:end_column = 1
         endif
 
         " Careful, [:-1] is not an empty list

--- a/test/test_code_action.vader
+++ b/test/test_code_action.vader
@@ -1,13 +1,10 @@
 Before:
   Save g:ale_enabled
-
   let g:ale_enabled = 0
 
   " Enable fix end-of-line as tests below expect that
+  Save &fixeol
   set fixeol
-
-  runtime autoload/ale/code_action.vim
-  runtime autoload/ale/util.vim
 
   let g:file1 = tempname()
   let g:file2 = tempname()
@@ -42,8 +39,6 @@ Before:
   endfunction!
 
 After:
-  Restore
-
   " Close the extra buffers if we opened it.
   if bufnr(g:file1) != -1
     execute ':bp! | :bd! ' . bufnr(g:file1)
@@ -65,8 +60,7 @@ After:
   unlet! g:changes
   delfunction WriteFileAndEdit
 
-  runtime autoload/ale/code_action.vim
-  runtime autoload/ale/util.vim
+  Restore
 
 
 Execute(It should modify and save multiple files):

--- a/test/test_code_action.vader
+++ b/test/test_code_action.vader
@@ -358,6 +358,15 @@ Execute(Cursor will not move when changes happening on lines >= cursor, but afte
   AssertEqual '  value: number', getline('.')
   AssertEqual [2, 3], getpos('.')[1:2]
 
+Execute(Cursor will not move when change covers entire file):
+  call WriteFileAndEdit()
+  call setpos('.', [0, 2, 3, 0])
+  call ale#code_action#HandleCodeAction(
+  \ g:test.create_change(1, 1, len(g:test.text) + 1, 1,
+  \   join(g:test.text + ['x'], "\n")),
+  \ {'should_save': 1})
+  AssertEqual [2, 3], getpos('.')[1:2]
+
 Execute(It should just modify file when should_save is set to v:false):
   call WriteFileAndEdit()
   let g:test.change = g:test.create_change(1, 1, 1, 1, "import { writeFile } from 'fs';\n")

--- a/test/test_code_action.vader
+++ b/test/test_code_action.vader
@@ -2,10 +2,6 @@ Before:
   Save g:ale_enabled
   let g:ale_enabled = 0
 
-  " Enable fix end-of-line as tests below expect that
-  Save &fixeol
-  set fixeol
-
   let g:file1 = tempname()
   let g:file2 = tempname()
   let g:test = {}

--- a/test/test_code_action.vader
+++ b/test/test_code_action.vader
@@ -204,7 +204,6 @@ Execute(End of file can be modified):
   \)
 
   AssertEqual g:test.text + [
-  \  '',
   \  'type A: string',
   \  'type B: number',
   \  '',

--- a/test/test_code_action_corner_cases.vader
+++ b/test/test_code_action_corner_cases.vader
@@ -1,0 +1,75 @@
+Before:
+  Save &fixeol
+  set nofixeol
+
+  Save &fileformats
+  set fileformats=unix
+
+  " two files, one accessed through a buffer, the other using write/readfile only
+  let g:files = [tempname(), tempname()]
+
+  function! TestChanges(contents, changes, mode) abort
+    let l:file = g:files[a:mode is 'file' ? 0 : 1]
+    call writefile(split(a:contents, '\n', 1), l:file, 'bS')
+    if a:mode isnot 'file'
+      execute 'edit ' . l:file
+    endif
+    call ale#code_action#ApplyChanges(l:file, a:changes, a:mode isnot 'buffer')
+    if a:mode is 'buffer'
+      execute 'write ' . l:file
+    endif
+    return join(readfile(l:file, 'b'), "\n")
+  endfunction!
+
+  function! MkPos(line, offset) abort
+    return {'line': a:line, 'offset': a:offset}
+  endfunction!
+
+  function! MkDelete(start, end) abort
+    return {'start': a:start, 'end': a:end, 'newText': ''}
+  endfunction!
+
+After:
+  for g:file in g:files
+    if bufnr(g:file) != -1
+      execute ':bp! | :bd! ' . bufnr(g:file)
+    endif
+    if filereadable(g:file)
+      call delete(g:file)
+    endif
+  endfor
+  unlet! g:files g:file
+
+  unlet! g:mode
+
+  delfunction TestChanges
+  delfunction MkPos
+  delfunction MkDelete
+
+  Restore
+
+Execute(Preserve (no)eol at eof):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "noeol",    TestChanges("noeol",    [], g:mode)
+    AssertEqual "eol\n",    TestChanges("eol\n",    [], g:mode)
+    AssertEqual "eols\n\n", TestChanges("eols\n\n", [], g:mode)
+  endfor
+
+  " there doesn't seem to be a way to tell if a buffer is empty or contains one
+  " empty line :-(
+  AssertEqual "", TestChanges("", [], 'file')
+
+Execute(Respect fixeol):
+  set fixeol
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "noeol\n", TestChanges("noeol", [], g:mode)
+    AssertEqual "eol\n",   TestChanges("eol\n", [], g:mode)
+  endfor
+
+Execute(Del eol at eof):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "deleol", TestChanges("deleolx\n", [MkDelete(MkPos(1, 7), MkPos(2, 1))], g:mode)
+  endfor

--- a/test/test_code_action_corner_cases.vader
+++ b/test/test_code_action_corner_cases.vader
@@ -83,6 +83,7 @@ Execute(Add/del eol at eof):
 Execute(One character insertions to first line):
   for g:mode in ['save', 'file', 'buffer']
     Log g:mode
+    AssertEqual "xabc\ndef1\nghi\n", TestChanges("abc\ndef1\nghi\n", [MkInsert(MkPos(1, 0), "x")], g:mode)
     AssertEqual "xabc\ndef2\nghi\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(1, 1), "x")], g:mode)
     AssertEqual "axbc\ndef3\nghi\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(1, 2), "x")], g:mode)
     AssertEqual "abcx\ndef4\nghi\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(1, 4), "x")], g:mode)
@@ -93,6 +94,7 @@ Execute(One character insertions to first line):
 Execute(One character + newline insertions to first line):
   for g:mode in ['save', 'file', 'buffer']
     Log g:mode
+    AssertEqual "x\nabc\ndef1\nghi\n", TestChanges("abc\ndef1\nghi\n", [MkInsert(MkPos(1, 0), "x\n")], g:mode)
     AssertEqual "x\nabc\ndef2\nghi\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(1, 1), "x\n")], g:mode)
     AssertEqual "ax\nbc\ndef3\nghi\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(1, 2), "x\n")], g:mode)
     AssertEqual "abcx\n\ndef4\nghi\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(1, 4), "x\n")], g:mode)
@@ -108,6 +110,9 @@ Execute(One character insertions near end):
     AssertEqual "abc\ndef3\nghi\nx", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(3, 5), "x")], g:mode)
     AssertEqual "abc\ndef4\nghi\nx", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(3, 6), "x")], g:mode)
     AssertEqual "abc\ndef5\nghi\nx", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(4, 1), "x")], g:mode)
+    AssertEqual "abc\ndef6\nghi\nx", TestChanges("abc\ndef6\nghi\n", [MkInsert(MkPos(4, 2), "x")], g:mode)
+    AssertEqual "abc\ndef7\nghi\nx", TestChanges("abc\ndef7\nghi\n", [MkInsert(MkPos(5, 1), "x")], g:mode)
+    AssertEqual "abc\ndef8\nghi\nx", TestChanges("abc\ndef8\nghi\n", [MkInsert(MkPos(5, 2), "x")], g:mode)
   endfor
 
 Execute(One character + newline insertions near end):
@@ -118,6 +123,7 @@ Execute(One character + newline insertions near end):
     AssertEqual "abc\ndef3\nghi\nx\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(3, 5), "x\n")], g:mode)
     AssertEqual "abc\ndef4\nghi\nx\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(3, 6), "x\n")], g:mode)
     AssertEqual "abc\ndef5\nghi\nx\n", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(4, 1), "x\n")], g:mode)
+    AssertEqual "abc\ndef6\nghi\nx\n", TestChanges("abc\ndef6\nghi\n", [MkInsert(MkPos(4, 2), "x\n")], g:mode)
   endfor
 
 Execute(Newline insertions near end):

--- a/test/test_code_action_corner_cases.vader
+++ b/test/test_code_action_corner_cases.vader
@@ -1,3 +1,32 @@
+" Tests for various corner cases of applying code changes from LSP.
+"
+" These can be verified against the reference vscode implementation using the
+" following javascript program:
+"
+"   const { TextDocument } = require('vscode-languageserver-textdocument');
+"   const { TextEdit, Position, Range } = require('vscode-languageserver-types');
+"   function MkPos(line, offset) { return Position.create(line - 1, offset - 1); }
+"   function MkInsert(pos, newText) { return TextEdit.insert(pos, newText); }
+"   function MkDelete(start, end) { return TextEdit.del(Range.create(start, end)); }
+"   function TestChanges(s, es) {
+"     return TextDocument.applyEdits(TextDocument.create(null, null, null, s), es);
+"   }
+"
+"   const fs = require("fs");
+"   const assert = require('assert').strict;
+"   const testRegex = /(?<!vscode skip.*)AssertEqual\s+("[^"]*"),\s*TestChanges\(("[^"]*"),\s*(\[[^\]]*\])/g;
+"   const data = fs.readFileSync(0, "utf-8");
+"   const tests = data.matchAll(testRegex);
+"   for (const test of tests) {
+"     console.log(test[0]);
+"     assert.equal(eval(test[1]), TestChanges(eval(test[2]), eval(test[3])));
+"   }
+"
+" Save it to test_code_action_corner_cases.js and invoke it using:
+"
+"   $ npm install vscode-languageserver-{textdocument,types}
+"   $ node test_code_action_corner_cases.js <test_code_action_corner_cases.vader
+
 Before:
   Save &fixeol
   set nofixeol
@@ -69,8 +98,8 @@ Execute(Respect fixeol):
   set fixeol
   for g:mode in ['save', 'file', 'buffer']
     Log g:mode
-    AssertEqual "noeol\n", TestChanges("noeol", [], g:mode)
-    AssertEqual "eol\n",   TestChanges("eol\n", [], g:mode)
+    silent echo "vscode skip" | AssertEqual "noeol\n", TestChanges("noeol", [], g:mode)
+    silent echo "vscode skip" | AssertEqual "eol\n",   TestChanges("eol\n", [], g:mode)
   endfor
 
 Execute(Add/del eol at eof):

--- a/test/test_code_action_corner_cases.vader
+++ b/test/test_code_action_corner_cases.vader
@@ -25,6 +25,10 @@ Before:
     return {'line': a:line, 'offset': a:offset}
   endfunction!
 
+  function! MkInsert(pos, newText) abort
+    return {'start': a:pos, 'end': a:pos, 'newText': a:newText}
+  endfunction!
+
   function! MkDelete(start, end) abort
     return {'start': a:start, 'end': a:end, 'newText': ''}
   endfunction!
@@ -44,6 +48,7 @@ After:
 
   delfunction TestChanges
   delfunction MkPos
+  delfunction MkInsert
   delfunction MkDelete
 
   Restore
@@ -68,8 +73,72 @@ Execute(Respect fixeol):
     AssertEqual "eol\n",   TestChanges("eol\n", [], g:mode)
   endfor
 
-Execute(Del eol at eof):
+Execute(Add/del eol at eof):
   for g:mode in ['save', 'file', 'buffer']
     Log g:mode
-    AssertEqual "deleol", TestChanges("deleolx\n", [MkDelete(MkPos(1, 7), MkPos(2, 1))], g:mode)
+    AssertEqual "addeol\n", TestChanges("addeol",   [MkInsert(MkPos(1, 7), "\n")], g:mode)
+    AssertEqual "deleol",   TestChanges("deleol\n", [MkDelete(MkPos(1, 7), MkPos(1, 8))], g:mode)
+  endfor
+
+Execute(One character insertions to first line):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "xabc\ndef2\nghi\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(1, 1), "x")], g:mode)
+    AssertEqual "axbc\ndef3\nghi\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(1, 2), "x")], g:mode)
+    AssertEqual "abcx\ndef4\nghi\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(1, 4), "x")], g:mode)
+    AssertEqual "abc\nxdef5\nghi\n", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(1, 5), "x")], g:mode)
+    AssertEqual "abc\nxdef6\nghi\n", TestChanges("abc\ndef6\nghi\n", [MkInsert(MkPos(1, 6), "x")], g:mode)
+  endfor
+
+Execute(One character + newline insertions to first line):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "x\nabc\ndef2\nghi\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(1, 1), "x\n")], g:mode)
+    AssertEqual "ax\nbc\ndef3\nghi\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(1, 2), "x\n")], g:mode)
+    AssertEqual "abcx\n\ndef4\nghi\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(1, 4), "x\n")], g:mode)
+    AssertEqual "abc\nx\ndef5\nghi\n", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(1, 5), "x\n")], g:mode)
+    AssertEqual "abc\nx\ndef6\nghi\n", TestChanges("abc\ndef6\nghi\n", [MkInsert(MkPos(1, 6), "x\n")], g:mode)
+  endfor
+
+Execute(One character insertions near end):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "abc\ndef1\nghxi\n", TestChanges("abc\ndef1\nghi\n", [MkInsert(MkPos(3, 3), "x")], g:mode)
+    AssertEqual "abc\ndef2\nghix\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(3, 4), "x")], g:mode)
+    AssertEqual "abc\ndef3\nghi\nx", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(3, 5), "x")], g:mode)
+    AssertEqual "abc\ndef4\nghi\nx", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(3, 6), "x")], g:mode)
+    AssertEqual "abc\ndef5\nghi\nx", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(4, 1), "x")], g:mode)
+  endfor
+
+Execute(One character + newline insertions near end):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "abc\ndef1\nghx\ni\n", TestChanges("abc\ndef1\nghi\n", [MkInsert(MkPos(3, 3), "x\n")], g:mode)
+    AssertEqual "abc\ndef2\nghix\n\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(3, 4), "x\n")], g:mode)
+    AssertEqual "abc\ndef3\nghi\nx\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(3, 5), "x\n")], g:mode)
+    AssertEqual "abc\ndef4\nghi\nx\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(3, 6), "x\n")], g:mode)
+    AssertEqual "abc\ndef5\nghi\nx\n", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(4, 1), "x\n")], g:mode)
+  endfor
+
+Execute(Newline insertions near end):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "abc\ndef1\ngh\ni\n", TestChanges("abc\ndef1\nghi\n", [MkInsert(MkPos(3, 3), "\n")], g:mode)
+    AssertEqual "abc\ndef2\nghi\n\n", TestChanges("abc\ndef2\nghi\n", [MkInsert(MkPos(3, 4), "\n")], g:mode)
+    AssertEqual "abc\ndef3\nghi\n\n", TestChanges("abc\ndef3\nghi\n", [MkInsert(MkPos(3, 5), "\n")], g:mode)
+    AssertEqual "abc\ndef4\nghi\n\n", TestChanges("abc\ndef4\nghi\n", [MkInsert(MkPos(3, 6), "\n")], g:mode)
+    AssertEqual "abc\ndef5\nghi\n\n", TestChanges("abc\ndef5\nghi\n", [MkInsert(MkPos(4, 1), "\n")], g:mode)
+  endfor
+
+Execute(Single char deletions):
+  for g:mode in ['save', 'file', 'buffer']
+    Log g:mode
+    AssertEqual "bc\ndef1\nghi\n",  TestChanges("abc\ndef1\nghi\n", [MkDelete(MkPos(1, 1), MkPos(1, 2))], g:mode)
+    AssertEqual "ab\ndef2\nghi\n",  TestChanges("abc\ndef2\nghi\n", [MkDelete(MkPos(1, 3), MkPos(1, 4))], g:mode)
+    AssertEqual "abcdef3\nghi\n",   TestChanges("abc\ndef3\nghi\n", [MkDelete(MkPos(1, 4), MkPos(1, 5))], g:mode)
+    AssertEqual "abcdef4\nghi\n",   TestChanges("abc\ndef4\nghi\n", [MkDelete(MkPos(1, 4), MkPos(1, 6))], g:mode)
+    AssertEqual "abc\ndef5\ngh\n",  TestChanges("abc\ndef5\nghi\n", [MkDelete(MkPos(3, 3), MkPos(3, 4))], g:mode)
+    AssertEqual "abc\ndef6\nghi",   TestChanges("abc\ndef6\nghi\n", [MkDelete(MkPos(3, 4), MkPos(3, 5))], g:mode)
+    AssertEqual "abc\ndef7\nghi",   TestChanges("abc\ndef7\nghi\n", [MkDelete(MkPos(3, 4), MkPos(3, 6))], g:mode)
+    AssertEqual "abc\ndef8\nghi\n", TestChanges("abc\ndef8\nghi\n", [MkDelete(MkPos(4, 1), MkPos(4, 2))], g:mode)
   endfor

--- a/test/test_code_action_python.vader
+++ b/test/test_code_action_python.vader
@@ -7,7 +7,7 @@ Execute():
   let g:changes = [
   \ {'end': {'offset': 7, 'line': 1}, 'newText': 'func_qtffgsv', 'start': {'offset': 5, 'line': 1}},
   \ {'end': {'offset': 9, 'line': 1}, 'newText': '', 'start': {'offset': 8, 'line': 1}},
-  \ {'end': {'offset': 1, 'line': 4}, 'newText': "    return c\n\n\ndef main():\n    c = func_qtffgsvi()\n", 'start': {'offset': 15, 'line': 3}}
+  \ {'end': {'offset': 15, 'line': 3}, 'newText': "    return c\n\n\ndef main():\n    c = func_qtffgsvi()\n", 'start': {'offset': 15, 'line': 3}}
   \]
 
   call ale#code_action#ApplyChanges(expand('%:p'), g:changes, 0)
@@ -35,9 +35,9 @@ Given python(Second python example):
 
 Execute():
   let g:changes = [
-  \ {'end': {'offset': 16, 'line': 2}, 'newText': "\n\ndef func_ivlpdpao(f):\n    exif = exifread.process_file(f)\n    dt = str(exif['Image DateTime'])\n    date = dt[:10].replace(':', '-')\n    return date\n", 'start': {'offset': 16, 'line': 2}},
+  \ {'end': {'offset': 16, 'line': 2}, 'newText': "\n\n\ndef func_ivlpdpao(f):\n    exif = exifread.process_file(f)\n    dt = str(exif['Image DateTime'])\n    date = dt[:10].replace(':', '-')\n    return date\n", 'start': {'offset': 16, 'line': 2}},
   \ {'end': {'offset': 32, 'line': 6}, 'newText': 'date = func', 'start': {'offset': 9, 'line': 6}},
-  \ {'end': {'offset': 1, 'line': 9}, 'newText': "ivlpdpao(f)\n", 'start': {'offset': 33, 'line': 6}}
+  \ {'end': {'offset': 42, 'line': 8}, 'newText': "ivlpdpao(f)\n", 'start': {'offset': 33, 'line': 6}}
   \]
 
   call ale#code_action#ApplyChanges(expand('%:p'), g:changes, 0)

--- a/test/test_code_action_python.vader
+++ b/test/test_code_action_python.vader
@@ -7,7 +7,7 @@ Execute():
   let g:changes = [
   \ {'end': {'offset': 7, 'line': 1}, 'newText': 'func_qtffgsv', 'start': {'offset': 5, 'line': 1}},
   \ {'end': {'offset': 9, 'line': 1}, 'newText': '', 'start': {'offset': 8, 'line': 1}},
-  \ {'end': {'offset': 15, 'line': 3}, 'newText': "    return c\n\n\ndef main():\n    c = func_qtffgsvi()\n", 'start': {'offset': 15, 'line': 3}}
+  \ {'end': {'offset': 1, 'line': 4}, 'newText': "    return c\n\n\ndef main():\n    c = func_qtffgsvi()\n", 'start': {'offset': 15, 'line': 3}}
   \]
 
   call ale#code_action#ApplyChanges(expand('%:p'), g:changes, 0)
@@ -37,7 +37,7 @@ Execute():
   let g:changes = [
   \ {'end': {'offset': 16, 'line': 2}, 'newText': "\n\ndef func_ivlpdpao(f):\n    exif = exifread.process_file(f)\n    dt = str(exif['Image DateTime'])\n    date = dt[:10].replace(':', '-')\n    return date\n", 'start': {'offset': 16, 'line': 2}},
   \ {'end': {'offset': 32, 'line': 6}, 'newText': 'date = func', 'start': {'offset': 9, 'line': 6}},
-  \ {'end': {'offset': 42, 'line': 8}, 'newText': "ivlpdpao(f)\n", 'start': {'offset': 33, 'line': 6}}
+  \ {'end': {'offset': 1, 'line': 9}, 'newText': "ivlpdpao(f)\n", 'start': {'offset': 33, 'line': 6}}
   \]
 
   call ale#code_action#ApplyChanges(expand('%:p'), g:changes, 0)


### PR DESCRIPTION
This PR adds tests for many corner cases (mostly involving newlines and changes near newlines) around applying changes from LSP, fixes these corner cases, and also adds a workaround for LSPs that just replace the entire document instead of sending individual changes.

More details in the individual commits:

---

commit fa8398970918200d1237988a2fd5598e51571ae0


    Minor cleanup in test/test_code_action.vader
    
    Dropped unnecessary sourcing, which probably originated from
    test_codefix.vader which overrides some functions, but
    test_code_action.vader does not.
    
    Also, Save &fixeol before changing it, and Restore at the end after
    closing buffers, otherwise fixeol isn't fully restored.

commit 354b5b74a96f68cd7f66836678831b1a19443b9d


    code_action: Don't move cursor when change covers entire file
    
    This prevents the cursor jumping to end of file after every
    rename/refactor. This happens with e.g. python-language-server which
    rewrites the entire buffer regardless of backend:
    
    https://github.com/palantir/python-language-server/blob/3d045b8db9b53d688f433fb2f2e5df27cbc1f788/pyls/plugins/jedi_rename.py#L31-L37
    https://github.com/palantir/python-language-server/blob/10cd98c898c89a8c9961b25725a6cd913485e1d0/pyls/plugins/rope_rename.py#L43-L49

commit a4b7069e7f80345731848e21a506966da765dc90

    code_action: Refactor/simplify ApplyChanges
    
    No behaviour change, just simplification that will make further fixes
    a bit easier.

commit 53f8856288bc454dbbe2fcc4804869dd06e5515f

    code_action: Fix EOL at EOF corner cases while performing no changes
    
    Instead of always removing the trailing empty line and hoping it wasn't
    supposed to be there, only remove it when we know ale#util#Writefile
    will add a trailing newline, and additionally tell ale#util#Writefile to
    not add that newline if any change explicitly deleted that newline.
    
    (Unfortunately with a:should_save=0, adding a trailing newline that
    wasn't there results in noeol and empty line at end of buffer, because
    for some reason setbufvar(l:buffer, '&eol', 1) doesn't work in buffers
    that started as noeol. This is likely a bug in vim itself.)
    
    Includes a minor fix that prevents invoking ale#util#SetBufferContents
    without a buffer. Not sure whether that might really happen anywhere.
    
    (test_code_action_python.vader depends on two incorrect behaviours
    cancelling each other, so it's temporarily adjusted to pass)

commit bae3c8bc528ae4f134b680544caa0e9d8764d693

    code_action: Fix column around EOL corner cases
    
    The original code didn't allow changing the last character in a line
    without also replacing the newline, due to an off-by-one error.
    
    Or, from a different point of view, it didn't allow replacing the
    newline without also replacing the preceding character. Therefore it
    comes as no surprise that it didn't correctly handle whether to replace
    or leave the newline at the end of the changed range.
    
    This commit fixes both, and also adjusts two tests that depended on the
    incorrect behaviour. Also, the temporary change to
    test_code_action_python.vader introduced earlier can now be reverted.
    
    Finally, this adds a _lot_ of tiny unit tests for various corner cases.
    These were verified against the reference implementation in
    [vscode-languageserver-node][], and a javascript source to run them is
    added in a followup commit. The added tests take an additional second or
    two. It might be worth reducing them somewhat to only test what was
    broken…?
    
    [vscode-languageserver-node]: https://github.com/microsoft/vscode-languageserver-node/

commit b96472443a102ee63fd21c176cdbdaf47981d5c7

    code_action: Handle positions out of bounds
    
    This makes the code more robust, and perhaps even a little easier to
    understand: less exceptional cases, more bounds clamping.

commit 12b40b7e7a8f8cb46df689d1be6a8a91ce7c40c4

    code_action: Add instructions for verifying corner case tests against vscode