### PR TITLE
Default to Hashicorp's terraform language server

### DIFF
--- a/ale_linters/terraform/terraform_lsp.vim
+++ b/ale_linters/terraform/terraform_lsp.vim
@@ -1,7 +1,7 @@
 " Author: OJFord <dev@ojford.com>
-" Description: terraform-lsp integration for ALE (cf. https://github.com/juliosueiras/terraform-lsp)
+" Description: terraform-ls integration for ALE (cf. https://github.com/hashicorp/terraform-ls)
 
-call ale#Set('terraform_langserver_executable', 'terraform-lsp')
+call ale#Set('terraform_langserver_executable', 'terraform-ls')
 call ale#Set('terraform_langserver_options', '')
 
 function! ale_linters#terraform#terraform_lsp#GetCommand(buffer) abort

--- a/doc/ale-terraform.txt
+++ b/doc/ale-terraform.txt
@@ -38,9 +38,15 @@ terraform-lsp                                     *ale-terraform-terraform-lsp*
 g:ale_terraform_langserver_executable   *g:ale_terraform_langserver_executable*
                                         *b:ale_terraform_langserver_executable*
   Type: |String|
-  Default: `'terraform-lsp'`
+  Default: `'terraform-ls'`
 
-  This variable can be changed to use a different executable for terraform-lsp.
+  This variable can be changed to use a different executable for the language
+  server. For example, there is also a more featureful, unstable, alternative:
+  https://github.com/juliosueiras/terraform-lsp
+
+  but which requires a specific terraform version in each release. For more
+  information, see Hashicorp's comment:
+  https://github.com/hashicorp/terraform-ls#terraform-ls-vs-terraform-lsp
 
 
 g:ale_terraform_langserver_options         *g:ale_terraform_langserver_options*


### PR DESCRIPTION
q.v. https://github.com/hashicorp/terraform-ls#terraform-ls-vs-terraform-lsp

> Both HashiCorp and the maintainer of terraform-lsp expressed interest in collaborating on a language server and are working towards a long-term goal of a single stable and feature-complete implementation.
>
> For the time being both projects continue to exist, giving users the choice:
>
>   * terraform-ls providing
>       * overall stability (by relying only on public APIs)
>       * compatibility with any provider and any Terraform >=0.12.0
>       * currently less features
>           * due to project being younger and relying on public APIs which may not offer the same functionality yet
>
>   * terraform-lsp providing
>       * currently more features
>       * compatibility with a single particular Terraform (0.12.20 at time of writing)
>           * configs designed for other 0.12 versions may work, but interpretation may be inaccurate
>       * less stability (due to reliance on Terraform's own internal packages)

The executable can currently (and with this PR can still) be changed, but I think the 'official', stable, project is a better default.

Also, once they do 'collaborate on a single stable and feature-complete implementation', it'll surely be under the Hashicorp organisation, so the `terraform-ls` packages on various platforms are less likely to break/stop updating than the `terraform-lsp` ones.
