### PR TITLE
codefix: Fix LSP MenuCallback invocation (E119, not enough args)

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -261,7 +261,10 @@ function! ale#codefix#HandleLSPResponse(conn_id, response) abort
 
         " Send the results to the menu callback, if set.
         if l:MenuCallback isnot v:null
-            call l:MenuCallback(map(copy(l:result), '[''lsp'', v:val]'))
+            call l:MenuCallback(
+            \   l:data,
+            \   map(copy(l:result), '[''lsp'', v:val]')
+            \)
 
             return
         endif


### PR DESCRIPTION
> Where are the tests? Have you added tests? Have you updated the tests? Read the
> comment above and the documentation referenced in it first. Write tests!
> Seriously, read `:help ale-dev` and write tests.

Can the right-click menu be tested somehow? Dunno. :-(
