### PR TITLE
Support options for rufo

### DIFF
--- a/autoload/ale/fixers/rufo.vim
+++ b/autoload/ale/fixers/rufo.vim
@@ -5,11 +5,12 @@ call ale#Set('ruby_rufo_executable', 'rufo')
 
 function! ale#fixers#rufo#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_rufo_executable')
+    let l:options = ale#Var(a:buffer, 'ruby_rufo_options')
     let l:exec_args = l:executable =~? 'bundle$'
     \   ? ' exec rufo'
     \   : ''
 
-    return ale#Escape(l:executable) . l:exec_args . ' %t'
+    return ale#Escape(l:executable) . l:exec_args . ' ' . l:options . ' ' . '%t'
 endfunction
 
 function! ale#fixers#rufo#Fix(buffer) abort

--- a/test/fixers/test_rufo_fixer_callback.vader
+++ b/test/fixers/test_rufo_fixer_callback.vader
@@ -3,6 +3,7 @@ Before:
 
   " Use an invalid global executable, so we don't match it.
   let g:ale_ruby_rufo_executable = 'xxxinvalid'
+  let g:ale_ruby_rufo_options = ''
 
   call ale#test#SetDirectory('/testplugin/test/command_callback')
   let g:dir = getcwd()
@@ -17,7 +18,15 @@ Execute(The rufo command should contain `bundle exec` when executable is `bundle
   call ale#test#SetFilename('ruby_paths/dummy.rb')
 
   AssertEqual
-  \ ale#Escape('bundle') . ' exec rufo %t',
+  \ ale#Escape('bundle') . ' exec rufo   %t',
+  \ ale#fixers#rufo#GetCommand(bufnr(''))
+
+Execute(The rufo callback should include custom rufo options):
+  let g:ale_ruby_rufo_options = '--filename=.rufo'
+  call ale#test#SetFilename('ruby_paths/dummy.rb')
+
+  AssertEqual
+  \ '''xxxinvalid'' --filename=.rufo  %t',
   \ ale#fixers#rufo#GetCommand(bufnr(''))
 
 Execute(The rufo callback should return the correct default values):
@@ -26,6 +35,6 @@ Execute(The rufo callback should return the correct default values):
   AssertEqual
   \ {
   \   'read_temporary_file': 1,
-  \   'command': ale#Escape('xxxinvalid') . ' %t'
+  \   'command': ale#Escape('xxxinvalid') . '   %t'
   \ },
   \ ale#fixers#rufo#Fix(bufnr(''))


### PR DESCRIPTION
Introduces `g:ale_ruby_rufo_options`.

Needed that to add the flag `--filename=.rufo` to be able to use a project specific `.rufo` file.