### PR TITLE
Add salt-lint support

### DIFF
--- a/ale_linters/salt/salt_lint.vim
+++ b/ale_linters/salt/salt_lint.vim
@@ -1,0 +1,32 @@
+" Author: Benjamin BINIER <poulpatine@gmail.com>
+" Description: salt-lint, saltstack linter
+
+call ale#Set('salt_salt_lint_executable', 'salt-lint')
+call ale#Set('salt_salt_lint_options', '')
+
+function! ale_linters#salt#salt_lint#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'salt_salt_lint_options'))
+    \   . ' --json'
+endfunction
+
+function! ale_linters#salt#salt_lint#Handle(buffer, lines) abort
+    let l:output = []
+
+    for l:error in ale#util#FuzzyJSONDecode(a:lines, [])
+        call add(l:output, {
+        \   'lnum': l:error.linenumber + 0,
+        \   'code': l:error.id + 0,
+        \   'text': l:error.message,
+        \   'type': l:error.severity is# 'HIGH' ? 'E' : 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('salt', {
+\   'name': 'salt-lint',
+\   'executable': {b -> ale#Var(b, 'salt_salt_lint_executable')},
+\   'command': function('ale_linters#salt#salt_lint#GetCommand'),
+\   'callback': 'ale_linters#salt#salt_lint#Handle'
+\})

--- a/doc/ale-salt.tmt
+++ b/doc/ale-salt.tmt
@@ -1,0 +1,43 @@
+===============================================================================
+ALE SALT Integration                                         *ale-salt-options*
+
+===============================================================================
+salt-lint                                                  *ale-salt-salt-lint*
+
+Website: https://github.com/warpnet/salt-lint
+
+
+Installation
+-------------------------------------------------------------------------------
+
+Install salt-lint in your a virtualenv directory, locally, or globally: >
+
+  pip install salt-lint # After activating virtualenv
+  pip install --user salt-lint # Install to ~/.local/bin
+  sudo pip install salt-lint # Install globally
+
+See |g:ale_virtualenv_dir_names| for configuring how ALE searches for
+virtualenv directories.
+
+
+Options
+-------------------------------------------------------------------------------
+
+g:ale_salt_salt-lint_executable                *g:ale_salt_salt_lint_executable*
+                                               *b:ale_salt_salt_lint_executable*
+  Type: |String|
+  Default: `'salt-lint'`
+
+  This variable can be set to change the path to salt-lint.
+
+
+g:ale_salt_salt-lint_options                      *g:ale_salt_salt-lint_options*
+                                                  *b:ale_salt_salt-lint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to salt-lint.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -428,6 +428,8 @@ Notes:
   * `rust-analyzer`
   * `rustc` (see |ale-integration-rust|)
   * `rustfmt`
+* Salt
+  * `salt-lint`
 * Sass
   * `sass-lint`
   * `stylelint`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2882,6 +2882,8 @@ documented in additional help files.
     rls...................................|ale-rust-rls|
     rustc.................................|ale-rust-rustc|
     rustfmt...............................|ale-rust-rustfmt|
+  salt....................................|ale-salt-options|
+    salt-lint.............................|ale-salt-salt-lint|
   sass....................................|ale-sass-options|
     sasslint..............................|ale-sass-sasslint|
     stylelint.............................|ale-sass-stylelint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -437,6 +437,8 @@ formatting.
   * [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer) :warning:
   * [rustc](https://www.rust-lang.org/) :warning:
   * [rustfmt](https://github.com/rust-lang-nursery/rustfmt)
+* Salt
+  * [salt-lint](https://github.com/warpnet/salt-lint)
 * Sass
   * [sass-lint](https://www.npmjs.com/package/sass-lint)
   * [stylelint](https://github.com/stylelint/stylelint)

--- a/test/handler/test_salt_salt_lint.vader
+++ b/test/handler/test_salt_salt_lint.vader
@@ -1,0 +1,34 @@
+Before:
+  runtime ale_linters/salt/salt_lint.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The salt handler should parse lines correctly and show error in severity HIGH):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 5,
+  \     'code': 207,
+  \     'text': 'File modes should always be encapsulated in quotation marks',
+  \     'type': 'E'
+  \   }
+  \ ],
+  \ ale_linters#salt#salt_lint#Handle(255, [
+  \ '[{"id": "207", "message": "File modes should always be encapsulated in quotation marks", "filename": "test.sls", "linenumber": 5, "line": "    - mode: 0755", "severity": "HIGH"}]'
+  \ ])
+
+
+Execute(The salt handler should parse lines correctly and show error in severity not HIGH):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 27,
+  \     'code': 204,
+  \     'text': 'Lines should be no longer that 160 chars',
+  \     'type': 'W'
+  \   }
+  \ ],
+  \ ale_linters#salt#salt_lint#Handle(255, [
+  \ '[{"id": "204", "message": "Lines should be no longer that 160 chars", "filename": "test2.sls", "linenumber": 27, "line": "this line is definitely longer than 160 chars, this line is definitely longer than 160 chars, this line is definitely longer than 160 chars", "severity": "VERY_LOW"}]'
+  \ ])


### PR DESCRIPTION
This PR adds support for salt-lint which is a linter for salt-stack files (see https://github.com/warpnet/salt-lint and https://github.com/saltstack/salt ).
