### PR TITLE
Add support for `--ascii` for dhall format

### DIFF
--- a/autoload/ale/fixers/dhall.vim
+++ b/autoload/ale/fixers/dhall.vim
@@ -2,6 +2,7 @@
 " Description: Integration of dhall-format with ALE.
 
 call ale#Set('dhall_format_executable', 'dhall')
+call ale#Set('dhall_format_ascii', 0)
 
 function! ale#fixers#dhall#GetExecutable(buffer) abort
     let l:executable = ale#Var(a:buffer, 'dhall_format_executable')
@@ -13,11 +14,17 @@ endfunction
 function! ale#fixers#dhall#Fix(buffer) abort
     let l:executable = ale#fixers#dhall#GetExecutable(a:buffer)
 
-    return {
-    \   'command': l:executable
+    let l:command = l:executable
     \       . ' format'
     \       . ' --inplace'
-    \       . ' %t',
+    \       . ' %t'
+
+    if ale#Var(a:buffer, 'dhall_format_ascii')
+        let l:command .= ' --ascii'
+    endif
+
+    return {
+    \   'command': l:command,
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/doc/ale-dhall.txt
+++ b/doc/ale-dhall.txt
@@ -1,0 +1,20 @@
+===============================================================================
+ALE Dhall Integration                                       *ale-dhall-options*
+
+
+g:ale_dhall_format_executable                   *g:ale_dhall_format_executable*
+                                                *b:ale_dhall_format_executable*
+  Type: |String|
+  Default: `'dhall'`
+
+  See |ale-integrations-local-executables|
+
+g:ale_dhall_format_ascii                             *g:ale_dhall_format_ascii*
+                                                     *b:ale_dhall_format_ascii*
+  Type: |Boolean|
+  Default: 0
+
+  Tells dhall to format using ascii instead of unicode. Set variable to 1 to
+  enable --ascii when formatting.
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2624,6 +2624,7 @@ documented in additional help files.
   dart....................................|ale-dart-options|
     dartanalyzer..........................|ale-dart-dartanalyzer|
     dartfmt...............................|ale-dart-dartfmt|
+  dhall...................................|ale-dhall-options|
   dockerfile..............................|ale-dockerfile-options|
     dockerfile_lint.......................|ale-dockerfile-dockerfile_lint|
     hadolint..............................|ale-dockerfile-hadolint|

--- a/test/fixers/test_dhall_fixer_callback.vader
+++ b/test/fixers/test_dhall_fixer_callback.vader
@@ -9,3 +9,10 @@ Execute(The default command should be correct):
   \ { 'read_temporary_file': 1,
   \   'command': ale#Escape('dhall') . ' format --inplace %t'
   \ }
+
+Execute(Ascii flag is passed to fixer when dhall_format_ascii is set):
+  let g:ale_dhall_format_ascii = 1
+  AssertFixer
+  \ { 'read_temporary_file': 1,
+  \   'command': ale#Escape('dhall') . ' format --inplace %t --ascii'
+  \ }


### PR DESCRIPTION
I just started using dhall and prefer the ascii format to the unicode version. I've added an option `g:ale_dhall_format_ascii` (not on by default) so that the `--ascii` flag is passed the formatter. I've also added relevant documentation + tests.

(P.S super love the plugin, thanks for creating and sharing!)