### PR TITLE
Use ale_echo_msg_format with cursor details

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -137,7 +137,8 @@ function! s:ShowCursorDetailForItem(loc, options) abort
     let l:stay_here = get(a:options, 'stay_here', 0)
 
     let s:last_detailed_line = line('.')
-    let l:message = get(a:loc, 'detail', a:loc.text)
+    let l:format = ale#Var(bufnr(''), 'echo_msg_format')
+    let l:message = ale#GetLocItemMessage(a:loc, l:format)
     let l:lines = split(l:message, "\n")
     call ale#preview#Show(l:lines, {'stay_here': l:stay_here})
 


### PR DESCRIPTION
This was raised in [this comment on the floating-preview pr](https://github.com/dense-analysis/ale/pull/3470#issuecomment-752225184) where it became apparent that cursor-details were using the ale_echo_message_format code but the preview window path wasn't.

Seems reasonable to want consistent data coming through the different view paths. If this is worth doing, I'll write up a test before merge.