### PR TITLE
Feature: Add support for named-pipe sockets for LSPs

### DIFF
--- a/autoload/ale/socket.vim
+++ b/autoload/ale/socket.vim
@@ -72,9 +72,8 @@ function! ale#socket#Open(address, options) abort
     elseif exists('*chansend') && exists('*sockconnect')
         " NeoVim 0.3+
         try
-            let l:channel_id = sockconnect('tcp', a:address, {
-            \   'on_data': function('s:NeoVimOutputCallback'),
-            \})
+            let l:channel_id = sockconnect(stridx(a:address, ':') != -1 ? 'tcp' : 'pipe',
+            \   a:address, {'on_data': function('s:NeoVimOutputCallback')})
             let l:channel_info.last_line = ''
         catch /connection failed/
             let l:channel_id = -1

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -228,8 +228,8 @@ A minimal configuration for a language server linter might look so. >
   \   'project_root': '/path/to/root_of_project',
   \})
 <
-For language servers that use a TCP socket connection, you should define the
-address to connect to instead. >
+For language servers that use a TCP or named pipe socket connection, you
+should define the address to connect to instead. >
 
   call ale#linter#Define('filetype_here', {
   \   'name': 'any_name_you_want',
@@ -3852,7 +3852,7 @@ ale#linter#Define(filetype, linter)                       *ale#linter#Define()*
 
                          When this argument is set to `'socket'`, then the
                          linter will be defined as an LSP linter via a TCP
-                         socket connection. `address` must be set.
+                         or named pipe socket connection. `address` must be set.
 
                          ALE will not start a server automatically.
 
@@ -3877,7 +3877,10 @@ ale#linter#Define(filetype, linter)                       *ale#linter#Define()*
 
   `address`                A |String| representing an address to connect to,
                          or a |Funcref| accepting a buffer number and
-                         returning the |String|.
+                         returning the |String|. If the value contains a
+                         colon, it is interpreted as referring to a TCP
+                         socket; otherwise it is interpreted as the path of a
+                         named pipe.
 
                          The result can be computed with |ale#command#Run()|.
 

--- a/test/dumb_named_pipe_server.py
+++ b/test/dumb_named_pipe_server.py
@@ -1,0 +1,42 @@
+"""
+This Python script creates a named pipe server that does nothing but send its input
+back to the client that connects to it. Only one argument must be given, the path
+of a named pipe to bind to.
+"""
+import os
+import socket
+import sys
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit('You must specify a filepath')
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if os.path.exists(sys.argv[1]):
+        os.remove(sys.argv[1])
+    sock.bind(sys.argv[1])
+    sock.listen(0)
+
+    pid = os.fork()
+
+    if pid:
+        print(pid)
+        sys.exit()
+
+    while True:
+        connection = sock.accept()[0]
+        connection.settimeout(5)
+
+        while True:
+            try:
+                connection.send(connection.recv(1024))
+            except socket.timeout:
+                break
+
+        connection.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_socket_connections.vader
+++ b/test/test_socket_connections.vader
@@ -28,10 +28,16 @@ Before:
     endfunction
 
     let g:port = 10347
-    let g:pid = str2nr(system(
+    let g:pid_tcp = str2nr(system(
     \ 'python'
     \ . ' ' . ale#Escape(g:dir . '/dumb_tcp_server.py')
     \ . ' ' . g:port
+    \))
+    let g:pipe_path = 'tmp_named_pipe'
+    let g:pid_pipe = str2nr(system(
+    \ 'python'
+    \ . ' ' . ale#Escape(g:dir . '/dumb_named_pipe_server.py')
+    \ . ' ' . g:pipe_path
     \))
   endif
 
@@ -46,17 +52,23 @@ After:
     delfunction WaitForData
     delfunction TestCallback
 
-    if has_key(g:, 'pid')
-      call system('kill ' . g:pid)
+    if has_key(g:, 'pid_tcp')
+      call system('kill ' . g:pid_tcp)
     endif
 
-    unlet! g:pid
+    if has_key(g:, 'pid_pipe')
+      call system('kill ' . g:pid_pipe)
+    endif
+
+    unlet! g:pid_tcp
     unlet! g:port
+    unlet! g:pid_pipe
+    unlet! g:pipe_path
   endif
 
   unlet! g:can_run_socket_tests
 
-Execute(Sending and receiving connections to sockets should work):
+Execute(Sending and receiving connections to tcp sockets should work):
   if g:can_run_socket_tests
     let g:channel_id = ale#socket#Open(
     \ '127.0.0.1:' . g:port,
@@ -87,6 +99,41 @@ Execute(Sending and receiving connections to sockets should work):
   if has('nvim') && !exists('*chanclose')
     AssertEqual -1, ale#socket#Open(
     \ '127.0.0.1:1111',
+    \ {'callback': function('function')}
+    \)
+  endif
+
+Execute(Sending and receiving connections to named pipe sockets should work):
+  if g:can_run_socket_tests && has('nvim')
+    let g:channel_id = ale#socket#Open(
+    \ g:pipe_path,
+    \ {'callback': function('TestCallback')}
+    \)
+
+    Assert g:channel_id >= 0, 'The socket was not opened!'
+
+    call ale#socket#Send(g:channel_id, 'hello')
+    call ale#socket#Send(g:channel_id, ' world')
+
+    AssertEqual 1, ale#socket#IsOpen(g:channel_id)
+
+    " Wait up to 1 second for the expected data to arrive.
+    call WaitForData('hello world', 1000)
+
+    AssertEqual g:channel_id, g:channel_id_received
+    AssertEqual 'hello world', g:data_received
+    AssertEqual g:pipe_path, ale#socket#GetAddress(g:channel_id)
+
+    call ale#socket#Close(g:channel_id)
+
+    AssertEqual 0, ale#socket#IsOpen(g:channel_id)
+    AssertEqual '', ale#socket#GetAddress(g:channel_id)
+  endif
+
+  " NeoVim versions which can't connect to sockets should just fail.
+  if has('nvim') && !exists('*chanclose')
+    AssertEqual -1, ale#socket#Open(
+    \ 'tmp_named_pipe',
     \ {'callback': function('function')}
     \)
   endif


### PR DESCRIPTION
**Overview:**

Previously, ALE assumed that for all linters with `lsp == 'socket'` that the socket referred to by `address` was a TCP socket. Neovim's `sockconnect` also supports named pipes [[1]](http://github.com/dense-analysis/ale/pull/3509#user-content-footnote-1) which have lower overhead than TCP sockets. This pull-request thus adds support for using sockets which are named pipes. The very simple heuristic of checking if `address` contains a colon or not is used to determine if the given socket is TCP or a named pipe, in order to maintain backwards compatibility, and to avoid adding an additional configuration option to `ale#linter#Define`. 

**Tests:**
A new test case has been added to `test/test_socket_connections.vader` in order to test named pipe sockets. To support this test, I wrote a very simple named-pipe-based server `test/dumb_named_pipe_server.py` (which is largely copied from `test/dumb_tcp_server.py`)

**Documentation:**

The documentation has been updated with information about this new feature.

<sup id="footnote-1">
[1] What I'm calling "named pipes" here are not actually named pipes (i.e. the things you'd get from calling `mkfifo`), but unix domain sockets. For whatever reason Neovim's documentation conflates these things (see `:help sockconnect`), so I've just tried to be consistent with their terminology 
</sup>