### PR TITLE
3498 change standardrb fixer to use stdin

### DIFF
--- a/autoload/ale/fixers/standardrb.vim
+++ b/autoload/ale/fixers/standardrb.vim
@@ -12,12 +12,12 @@ function! ale#fixers#standardrb#GetCommand(buffer) abort
     return ale#ruby#EscapeExecutable(l:executable, 'standardrb')
     \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' --fix --force-exclusion %t'
+    \   . ' --fix --force-exclusion --stdin %s'
 endfunction
 
 function! ale#fixers#standardrb#Fix(buffer) abort
     return {
     \   'command': ale#fixers#standardrb#GetCommand(a:buffer),
-    \   'read_temporary_file': 1,
+    \   'process_with': 'ale#fixers#rubocop#PostProcess'
     \}
 endfunction

--- a/test/fixers/test_standardrb_fixer_callback.vader
+++ b/test/fixers/test_standardrb_fixer_callback.vader
@@ -21,9 +21,9 @@ Execute(The standardrb callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
+  \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_standardrb_executable)
-  \     . ' --fix --force-exclusion %t',
+  \     . ' --fix --force-exclusion --stdin %s',
   \ },
   \ ale#fixers#standardrb#Fix(bufnr(''))
 
@@ -32,10 +32,10 @@ Execute(The standardrb callback should include configuration files):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
+  \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_standardrb_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.standard.yml'))
-  \     . ' --fix --force-exclusion %t',
+  \     . ' --fix --force-exclusion --stdin %s',
   \ },
   \ ale#fixers#standardrb#Fix(bufnr(''))
 
@@ -45,10 +45,10 @@ Execute(The standardrb callback should include custom rubocop options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
+  \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_standardrb_executable)
   \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/ruby_paths/with_config/.standard.yml'))
   \     . ' --except Lint/Debugger'
-  \     . ' --fix --force-exclusion %t',
+  \     . ' --fix --force-exclusion --stdin %s',
   \ },
   \ ale#fixers#standardrb#Fix(bufnr(''))


### PR DESCRIPTION
Seems standardrb fails to properly use the --config option when using temporary files but works fine when reading from stdin. This commit changes the fixer so it uses stdin instead of temporary files.