### PR TITLE
Custom erlc executable

### DIFF
--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -1,14 +1,22 @@
 " Author: Magnus Ottenklinger - https://github.com/evnu
 
+let g:ale_erlang_erlc_executable = get(g:, 'ale_erlang_erlc_executable', 'erlc')
 let g:ale_erlang_erlc_options = get(g:, 'ale_erlang_erlc_options', '')
+
+function! ale_linters#erlang#erlc#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'erlang_erlc_executable')
+endfunction
 
 function! ale_linters#erlang#erlc#GetCommand(buffer) abort
     let l:output_file = ale#util#Tempname()
     call ale#command#ManageFile(a:buffer, l:output_file)
 
-    return 'erlc -o ' . ale#Escape(l:output_file)
-    \   . ' ' . ale#Var(a:buffer, 'erlang_erlc_options')
-    \   . ' %t'
+    let l:command = ale#Escape(ale_linters#erlang#erlc#GetExecutable(a:buffer))
+    \             . ' -o ' . ale#Escape(l:output_file)
+    \             . ' ' . ale#Var(a:buffer, 'erlang_erlc_options')
+    \             . ' %t'
+
+    return l:command
 endfunction
 
 function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
@@ -90,7 +98,7 @@ endfunction
 
 call ale#linter#Define('erlang', {
 \   'name': 'erlc',
-\   'executable': 'erlc',
+\   'executable': function('ale_linters#erlang#erlc#GetExecutable'),
 \   'command': function('ale_linters#erlang#erlc#GetCommand'),
 \   'callback': 'ale_linters#erlang#erlc#Handle',
 \})

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -34,6 +34,14 @@ g:ale_erlang_dialyzer_rebar3_profile     *g:ale_erlang_dialyzer_rebar3_profile*
 -------------------------------------------------------------------------------
 erlc                                                          *ale-erlang-erlc*
 
+g:ale_erlang_erlc_executable                     *g:ale_erlang_erlc_executable*
+                                                 *b:ale_erlang_erlc_executable*
+  Type: |String|
+  Default: `'erlc'`
+
+  This variable can be changed to specify the erlc executable.
+
+
 g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
                                                     *b:ale_erlang_erlc_options*
   Type: |String|

--- a/test/command_callback/test_erlang_erlc_command_callback.vader
+++ b/test/command_callback/test_erlang_erlc_command_callback.vader
@@ -6,7 +6,7 @@ After:
 
 Execute(The default command should be correct.):
     let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
-    let g:regex = '^''\?erlc''\?\s\+-o\s\+[^\s]\+\s\+%t'
+    let g:regex = 'erlc.\+-o.\+%t'
     let g:matched = match(g:cmd, g:regex)
 
     " match returns -1 if not found
@@ -18,7 +18,7 @@ Execute(The default command should be correct.):
 Execute(The command should accept configured executable.):
     let b:ale_erlang_erlc_executable = '/usr/bin/erlc'
     let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
-    let g:regex = '^''\?/usr/bin/erlc''\?\s\+-o\s\+[^\s]\+\s\+%t'
+    let g:regex = '/usr/bin/erlc.\+-o.\+%t'
     let g:matched = match(g:cmd, g:regex)
 
     " match returns -1 if not found
@@ -30,7 +30,7 @@ Execute(The command should accept configured executable.):
 Execute(The command should accept configured options.):
     let b:ale_erlang_erlc_options = '-I include'
     let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
-    let g:regex = '^''\?erlc''\?\s\+-o\s\+[^\s]\+\s\+-I include\s\+%t'
+    let g:regex = 'erlc.\+-o.\+-I include.\+%t'
     let g:matched = match(g:cmd, g:regex)
 
     " match returns -1 if not found

--- a/test/command_callback/test_erlang_erlc_command_callback.vader
+++ b/test/command_callback/test_erlang_erlc_command_callback.vader
@@ -6,7 +6,7 @@ After:
 
 Execute(The default command should be correct.):
     let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
-    let g:regex = '^''erlc''\s\+-o\s\+[^\s]\+\s\+%t'
+    let g:regex = '^''\?erlc''\?\s\+-o\s\+[^\s]\+\s\+%t'
     let g:matched = match(g:cmd, g:regex)
 
     " match returns -1 if not found
@@ -18,7 +18,7 @@ Execute(The default command should be correct.):
 Execute(The command should accept configured executable.):
     let b:ale_erlang_erlc_executable = '/usr/bin/erlc'
     let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
-    let g:regex = '^''/usr/bin/erlc''\s\+-o\s\+[^\s]\+\s\+%t'
+    let g:regex = '^''\?/usr/bin/erlc''\?\s\+-o\s\+[^\s]\+\s\+%t'
     let g:matched = match(g:cmd, g:regex)
 
     " match returns -1 if not found
@@ -30,7 +30,7 @@ Execute(The command should accept configured executable.):
 Execute(The command should accept configured options.):
     let b:ale_erlang_erlc_options = '-I include'
     let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
-    let g:regex = '^''erlc''\s\+-o\s\+[^\s]\+\s\+-I include\s\+%t'
+    let g:regex = '^''\?erlc''\?\s\+-o\s\+[^\s]\+\s\+-I include\s\+%t'
     let g:matched = match(g:cmd, g:regex)
 
     " match returns -1 if not found

--- a/test/command_callback/test_erlang_erlc_command_callback.vader
+++ b/test/command_callback/test_erlang_erlc_command_callback.vader
@@ -1,0 +1,40 @@
+Before:
+  call ale#assert#SetUpLinterTest('erlang', 'erlc')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct.):
+    let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
+    let g:regex = '^''erlc''\s\+-o\s\+[^\s]\+\s\+%t'
+    let g:matched = match(g:cmd, g:regex)
+
+    " match returns -1 if not found
+    AssertNotEqual
+    \   g:matched,
+    \   -1,
+    \   'Command error: expected [' . g:cmd . '] to match [' . g:regex . ']'
+
+Execute(The command should accept configured executable.):
+    let b:ale_erlang_erlc_executable = '/usr/bin/erlc'
+    let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
+    let g:regex = '^''/usr/bin/erlc''\s\+-o\s\+[^\s]\+\s\+%t'
+    let g:matched = match(g:cmd, g:regex)
+
+    " match returns -1 if not found
+    AssertNotEqual
+    \   g:matched,
+    \   -1,
+    \   'Command error: expected [' . g:cmd . '] to match [' . g:regex . ']'
+
+Execute(The command should accept configured options.):
+    let b:ale_erlang_erlc_options = '-I include'
+    let g:cmd = ale_linters#erlang#erlc#GetCommand(bufnr(''))
+    let g:regex = '^''erlc''\s\+-o\s\+[^\s]\+\s\+-I include\s\+%t'
+    let g:matched = match(g:cmd, g:regex)
+
+    " match returns -1 if not found
+    AssertNotEqual
+    \   g:matched,
+    \   -1,
+    \   'Command error: expected [' . g:cmd . '] to match [' . g:regex . ']'


### PR DESCRIPTION
The stale bot closed #3414 but this PR is still relevant to add an option to specify executable for the Erlang erlc linter.