### PR TITLE
Revert "Improves fixer performance for large buffers"

### DIFF
--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -486,7 +486,7 @@ function! ale#util#Input(message, value) abort
 endfunction
 
 function! ale#util#HasBuflineApi() abort
-    return exists('*deletebufline') && exists('*appendbufline') && exists('*getpos') && exists('*setpos')
+    return exists('*deletebufline') && exists('*setbufline')
 endfunction
 
 " Sets buffer contents to lines
@@ -507,11 +507,8 @@ function! ale#util#SetBufferContents(buffer, lines) abort
 
     " Use a Vim API for setting lines in other buffers, if available.
     if l:has_bufline_api
-        let l:save_cursor = getpos('.')
-        call deletebufline(a:buffer, 1, '$')
-        call appendbufline(a:buffer, 1, l:new_lines)
-        call deletebufline(a:buffer, 1, 1)
-        call setpos('.', l:save_cursor)
+        call setbufline(a:buffer, 1, l:new_lines)
+        call deletebufline(a:buffer, l:first_line_to_remove, '$')
     " Fall back on setting lines the old way, for the current buffer.
     else
         let l:old_line_length = line('$')


### PR DESCRIPTION
Reverts dense-analysis/ale#3358 that caused several issues with fixers dense-analysis/ale#3504. The problems are a result of the way the PR updates the buffer that also result in changes in the jump list and undo list. This causes unwanted cursor jumps and messes the undo and folding.

The original PR fixes some performance issues on large files but the issues it causes may not be worth the speed up benefit. Testing a 68Kb kotlin file with the ktlint fixer works in less than a second without dense-analysis/ale#3358 and I get not unwanted jumps and undo works as expected.