### PR TITLE
Fix 3537 - remove -T argument from ruby linter

### DIFF
--- a/ale_linters/ruby/ruby.vim
+++ b/ale_linters/ruby/ruby.vim
@@ -6,7 +6,7 @@ call ale#Set('ruby_ruby_executable', 'ruby')
 call ale#linter#Define('ruby', {
 \   'name': 'ruby',
 \   'executable': {b -> ale#Var(b, 'ruby_ruby_executable')},
-\   'command': '%e -w -c -T1 %t',
+\   'command': '%e -w -c %t',
 \   'output_stream': 'stderr',
 \   'callback': 'ale#handlers#ruby#HandleSyntaxErrors',
 \})

--- a/test/command_callback/test_ruby_command_callback.vader
+++ b/test/command_callback/test_ruby_command_callback.vader
@@ -5,9 +5,9 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'ruby', ale#Escape('ruby') . ' -w -c -T1 %t'
+  AssertLinter 'ruby', ale#Escape('ruby') . ' -w -c %t'
 
 Execute(The executable should be configurable):
   let g:ale_ruby_ruby_executable = 'foobar'
 
-  AssertLinter 'foobar', ale#Escape('foobar') . ' -w -c -T1 %t'
+  AssertLinter 'foobar', ale#Escape('foobar') . ' -w -c %t'


### PR DESCRIPTION
Fixes #3537 
