### PR TITLE
Support going to type definition with tsserver

### DIFF
--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -104,9 +104,6 @@ function! s:OnReady(line, column, options, capability, linter, lsp_details) abor
             \   a:line,
             \   a:column
             \)
-        else
-            " XXX: log here?
-            return
         endif
     else
         " Send a message saying the buffer has changed first, or the

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -36,7 +36,7 @@ function! ale#definition#UpdateTagStack() abort
 endfunction
 
 function! ale#definition#HandleTSServerResponse(conn_id, response) abort
-    if get(a:response, 'command', '') is# 'definition'
+    if has_key(a:response, 'request_seq')
     \&& has_key(s:go_to_definition_map, a:response.request_seq)
         let l:options = remove(s:go_to_definition_map, a:response.request_seq)
 
@@ -92,11 +92,22 @@ function! s:OnReady(line, column, options, capability, linter, lsp_details) abor
     call ale#lsp#RegisterCallback(l:id, l:Callback)
 
     if a:linter.lsp is# 'tsserver'
-        let l:message = ale#lsp#tsserver_message#Definition(
-        \   l:buffer,
-        \   a:line,
-        \   a:column
-        \)
+        if a:capability is# 'definition'
+            let l:message = ale#lsp#tsserver_message#Definition(
+            \   l:buffer,
+            \   a:line,
+            \   a:column
+            \)
+        elseif a:capability is# 'typeDefinition'
+            let l:message = ale#lsp#tsserver_message#TypeDefinition(
+            \   l:buffer,
+            \   a:line,
+            \   a:column
+            \)
+        else
+            " XXX: log here?
+            return
+        endif
     else
         " Send a message saying the buffer has changed first, or the
         " definition position probably won't make sense.
@@ -145,12 +156,6 @@ endfunction
 function! ale#definition#GoToType(options) abort
     for l:linter in ale#linter#Get(&filetype)
         if !empty(l:linter.lsp)
-            " TODO: handle typeDefinition for tsserver if supported by the
-            " protocol
-            if l:linter.lsp is# 'tsserver'
-                continue
-            endif
-
             call s:GoToLSPDefinition(l:linter, a:options, 'typeDefinition')
         endif
     endfor

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -357,6 +357,7 @@ function! ale#lsp#MarkConnectionAsTsserver(conn_id) abort
     let l:conn.capabilities.completion = 1
     let l:conn.capabilities.completion_trigger_characters = ['.']
     let l:conn.capabilities.definition = 1
+    let l:conn.capabilities.typeDefinition = 1
     let l:conn.capabilities.symbol_search = 1
     let l:conn.capabilities.rename = 1
     let l:conn.capabilities.code_actions = 1

--- a/autoload/ale/lsp/tsserver_message.vim
+++ b/autoload/ale/lsp/tsserver_message.vim
@@ -64,6 +64,14 @@ function! ale#lsp#tsserver_message#Definition(buffer, line, column) abort
     \}]
 endfunction
 
+function! ale#lsp#tsserver_message#TypeDefinition(buffer, line, column) abort
+    return [0, 'ts@typeDefinition', {
+    \   'line': a:line,
+    \   'offset': a:column,
+    \   'file': expand('#' . a:buffer . ':p'),
+    \}]
+endfunction
+
 function! ale#lsp#tsserver_message#References(buffer, line, column) abort
     return [0, 'ts@references', {
     \   'line': a:line,

--- a/test/lsp/test_lsp_client_messages.vader
+++ b/test/lsp/test_lsp_client_messages.vader
@@ -307,6 +307,19 @@ Execute(ale#lsp#tsserver_message#Definition() should return correct messages):
   \ ],
   \ ale#lsp#tsserver_message#Definition(bufnr(''), 347, 12)
 
+Execute(ale#lsp#tsserver_message#TypeDefinition() should return correct messages):
+  AssertEqual
+  \ [
+  \   0,
+  \   'ts@typeDefinition',
+  \   {
+  \     'file': ale#path#Simplify(g:dir . '/foo/bar.ts'),
+  \     'line': 347,
+  \     'offset': 12,
+  \   }
+  \ ],
+  \ ale#lsp#tsserver_message#TypeDefinition(bufnr(''), 347, 12)
+
 Execute(ale#lsp#tsserver_message#References() should return correct messages):
   AssertEqual
   \ [

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -242,6 +242,30 @@ Execute(tsserver definition requests should be sent):
   \ g:message_list
   AssertEqual {'42': {'open_in': 'current-buffer'}}, ale#definition#GetMap()
 
+Execute(tsserver type definition requests should be sent):
+  runtime ale_linters/typescript/tsserver.vim
+  call setpos('.', [bufnr(''), 2, 5, 0])
+
+  ALEGoToTypeDefinition
+
+  " We shouldn't register the callback yet.
+  AssertEqual '''''', string(g:Callback)
+
+  AssertEqual type(function('type')), type(g:InitCallback)
+  call g:InitCallback()
+
+  AssertEqual 'typeDefinition', g:capability_checked
+  AssertEqual
+  \ 'function(''ale#definition#HandleTSServerResponse'')',
+  \ string(g:Callback)
+  AssertEqual
+  \ [
+  \   ale#lsp#tsserver_message#Change(bufnr('')),
+  \   [0, 'ts@typeDefinition', {'file': expand('%:p'), 'line': 2, 'offset': 5}]
+  \ ],
+  \ g:message_list
+  AssertEqual {'42': {'open_in': 'current-buffer'}}, ale#definition#GetMap()
+
 Execute(tsserver tab definition requests should be sent):
   runtime ale_linters/typescript/tsserver.vim
   call setpos('.', [bufnr(''), 2, 5, 0])


### PR DESCRIPTION
`ale.vim` supports going to a type definition, `tsserver` supports going to a type definition, but `ale.vim` doesn't support _using_ `tsserver` to go to a type definition!

This adds support for going to a type definition using `tsserver`.

I added tests to the best of my ability by duplicating/altering some of the existing tests. I ran the `./run-tests` script locally and everything seems to be passing, but let me know if there are parts that I missed!