### PR TITLE
Fix 3546 - check empty executable string.

### DIFF
--- a/autoload/ale/maven.vim
+++ b/autoload/ale/maven.vim
@@ -25,7 +25,7 @@ function! ale#maven#FindExecutable(buffer) abort
     let l:wrapper_cmd = has('unix') ? 'mvnw' : 'mvnw.cmd'
     let l:wrapper_path = ale#path#FindNearestFile(a:buffer, l:wrapper_cmd)
 
-    if executable(l:wrapper_path)
+    if !empty(l:wrapper_path) && executable(l:wrapper_path)
         return l:wrapper_path
     endif
 


### PR DESCRIPTION
At some point VIM/NVIM started throwing errors if the input string is
empty for some functions such as execute() and fnamemodify(). This
commit checks if the executable string is empty before passing it to the
executable() function.

Resources:
  - https://github.com/vim/vim/issues/7465
  - https://github.com/vim/vim/releases/tag/v8.2.2117

Closes #3546