### PR TITLE
Fix clang-tidy ignoring compile-commands.json

### DIFF
--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -23,11 +23,13 @@ function! ale_linters#cpp#clangtidy#GetCommand(buffer, output) abort
         let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
         let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
         let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
-    endif
 
-    " Tell clang-tidy a .h header with a C++ filetype in Vim is a C++ file.
-    if expand('#' . a:buffer) =~# '\.h$'
-        let l:options .= !empty(l:options) ? ' -x c++' : '-x c++'
+        " Tell clang-tidy a .h header with a C++ filetype in Vim is a C++ file
+        " only when compile-commands.json file is not there. Adding these
+        " flags makes clang-tidy completely ignore compile commmands.
+        if expand('#' . a:buffer) =~# '\.h$'
+            let l:options .= !empty(l:options) ? ' -x c++' : '-x c++'
+        endif
     endif
 
     " Get the options to pass directly to clang-tidy

--- a/test/command_callback/test_clang_tidy_command_callback.vader
+++ b/test/command_callback/test_clang_tidy_command_callback.vader
@@ -68,7 +68,6 @@ Execute(The build directory should be used for header files):
   \ ale#Escape('clang-tidy')
   \   . ' -checks=' . ale#Escape('*') . ' %s'
   \   . ' -p ' . ale#Escape('/foo/bar')
-  \   . ' -- -x c++'
 
   call ale#test#SetFilename('test.hpp')
 


### PR DESCRIPTION
Simple fix for #3506.