### PR TITLE
3560 add vim 8.2 and nvim 0.4 to ci tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build docker run image
+        shell: bash
+        env:
+          DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
+          DOCKER_HUB_PASS: ${{ secrets.DOCKER_HUB_PASS }}
         run: ./run-tests --build-image
   test_ale:
     needs: build_image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,8 @@ jobs:
       matrix:
         vim-version:
           - '--vim-80-only'
-          - '--vim-81-only'
           - '--vim-82-only'
           - '--neovim-02-only'
-          - '--neovim-03-only'
           - '--neovim-04-only'
           - '--linters-only'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,14 @@ on:
     branches: [ master ]
 
 jobs:
+  build_image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build docker run image
+        run: ./run-tests --build-image
   test_ale:
+    needs: build_image
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,10 @@ jobs:
         vim-version:
           - '--vim-80-only'
           - '--vim-81-only'
-          - '--neovim-only'
+          - '--vim-82-only'
+          - '--neovim-02-only'
+          - '--neovim-03-only'
+          - '--neovim-04-only'
           - '--linters-only'
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apk --update add $PACKAGES && \
 
 RUN pip install vim-vint==0.3.15
 
-RUN git clone https://github.com/junegunn/vader.vim vader
+RUN git clone https://github.com/junegunn/vader.vim vader && \
+    cd vader && git checkout c6243dd81c98350df4dec608fa972df98fa2a3af
 
 ARG GIT_VERSION
 LABEL Version=${GIT_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM tweekmonster/vim-testbed:latest
 
 RUN install_vim -tag v8.0.0027 -build \
-                -tag v8.1.0519 -build \
                 -tag v8.2.2401 -build \
                 -tag neovim:v0.2.0 -build \
-                -tag neovim:v0.3.5 -build \
                 -tag neovim:v0.4.4 -build
 
 ENV PACKAGES="\

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,7 @@ RUN apk --update add $PACKAGES && \
 RUN pip install vim-vint==0.3.15
 
 RUN git clone https://github.com/junegunn/vader.vim vader
+
+ARG GIT_VERSION
+LABEL Version=${GIT_VERSION}
+LABEL Name=w0rp/ale

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM tweekmonster/vim-testbed:latest
 
 RUN install_vim -tag v8.0.0027 -build \
                 -tag v8.1.0519 -build \
+                -tag v8.2.2401 -build \
                 -tag neovim:v0.2.0 -build \
-                -tag neovim:v0.3.5 -build
+                -tag neovim:v0.3.5 -build \
+                -tag neovim:v0.4.4 -build
 
 ENV PACKAGES="\
     bash \
@@ -18,5 +20,4 @@ RUN apk --update add $PACKAGES && \
 
 RUN pip install vim-vint==0.3.15
 
-RUN git clone https://github.com/junegunn/vader.vim vader && \
-    cd vader && git checkout c6243dd81c98350df4dec608fa972df98fa2a3af
+RUN git clone https://github.com/junegunn/vader.vim vader

--- a/ale_linters/perl6/perl6.vim
+++ b/ale_linters/perl6/perl6.vim
@@ -88,7 +88,7 @@ function! ale_linters#perl6#perl6#Handle(buffer, lines) abort
 
     try
         let l:json = json_decode(join(a:lines, ''))
-    catch /E474/
+    catch /E474\|E491/
         call add(l:output, {
         \   'lnum': '1',
         \   'text': 'Received output in the default Perl6 error format. See :ALEDetail for details',

--- a/autoload/ale/handlers/hdl_checker.vim
+++ b/autoload/ale/handlers/hdl_checker.vim
@@ -32,6 +32,8 @@ function! ale#handlers#hdl_checker#GetProjectRoot(buffer) abort
     if ale#handlers#hdl_checker#IsDotGit(l:project_root)
         return fnamemodify(l:project_root, ':h:h')
     endif
+
+    return ''
 endfunction
 
 function! ale#handlers#hdl_checker#GetExecutable(buffer) abort

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -20,17 +20,16 @@ endif
 
 " Return 1 if there is a buffer with buftype == 'quickfix' in bufffer list
 function! ale#list#IsQuickfixOpen() abort
-
     let l:res = getqflist({ 'winid' : winnr() })
 
     if has_key(l:res, 'winid') && l:res.winid > 0
-      return 1
+        return 1
     endif
 
     let l:res = getloclist(0, { 'winid' : winnr() })
 
     if has_key(l:res, 'winid') && l:res.winid > 0
-      return 1
+        return 1
     endif
 
     return 0

--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -20,11 +20,18 @@ endif
 
 " Return 1 if there is a buffer with buftype == 'quickfix' in bufffer list
 function! ale#list#IsQuickfixOpen() abort
-    for l:buf in range(1, bufnr('$'))
-        if getbufvar(l:buf, '&buftype') is# 'quickfix'
-            return 1
-        endif
-    endfor
+
+    let l:res = getqflist({ 'winid' : winnr() })
+
+    if has_key(l:res, 'winid') && l:res.winid > 0
+      return 1
+    endif
+
+    let l:res = getloclist(0, { 'winid' : winnr() })
+
+    if has_key(l:res, 'winid') && l:res.winid > 0
+      return 1
+    endif
 
     return 0
 endfunction

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -50,9 +50,12 @@ if !hlexists('ALESignColumnWithErrors')
 endif
 
 function! ale#sign#SetUpDefaultColumnWithoutErrorsHighlight() abort
+    let l:verbose = &verbose
+    set verbose=0
     redir => l:output
         0verbose silent highlight SignColumn
     redir end
+    let &verbose = l:verbose
 
     let l:highlight_syntax = join(split(l:output)[2:])
     let l:match = matchlist(l:highlight_syntax, '\vlinks to (.+)$')

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -409,7 +409,7 @@ function! ale#util#FuzzyJSONDecode(data, default) abort
         endif
 
         return l:result
-    catch /E474/
+    catch /E474\|E491/
         return a:default
     endtry
 endfunction

--- a/run-tests
+++ b/run-tests
@@ -10,7 +10,7 @@ set -u
 #
 
 image=w0rp/ale
-current_image_id=1c04720f5d17
+current_image_id=b2c5422958d4
 
 # Used in all test scripts for running the selected Docker image.
 DOCKER_RUN_IMAGE="$image"
@@ -22,8 +22,10 @@ verbose_flag=''
 quiet_flag=''
 run_neovim_02_tests=1
 run_neovim_03_tests=1
+run_neovim_04_tests=1
 run_vim_80_tests=1
 run_vim_81_tests=1
+run_vim_82_tests=1
 run_linters=1
 
 while [ $# -ne 0 ]; do
@@ -39,55 +41,87 @@ while [ $# -ne 0 ]; do
     --neovim-only)
         run_vim_80_tests=0
         run_vim_81_tests=0
+        run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --neovim-02-only)
         run_neovim_03_tests=0
+        run_neovim_04_tests=0
         run_vim_80_tests=0
         run_vim_81_tests=0
+        run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --neovim-03-only)
         run_neovim_02_tests=0
+        run_neovim_04_tests=0
         run_vim_80_tests=0
         run_vim_81_tests=0
+        run_vim_82_tests=0
+        run_linters=0
+        shift
+    ;;
+    --neovim-04-only)
+        run_neovim_02_tests=0
+        run_neovim_03_tests=0
+        run_vim_80_tests=0
+        run_vim_81_tests=0
+        run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --vim-only)
         run_neovim_02_tests=0
         run_neovim_03_tests=0
+        run_neovim_04_tests=0
         run_linters=0
         shift
     ;;
     --vim-80-only)
         run_neovim_02_tests=0
         run_neovim_03_tests=0
+        run_neovim_04_tests=0
         run_vim_81_tests=0
+        run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --vim-81-only)
         run_neovim_02_tests=0
         run_neovim_03_tests=0
+        run_neovim_04_tests=0
         run_vim_80_tests=0
+        run_vim_82_tests=0
+        run_linters=0
+        shift
+    ;;
+    --vim-82-only)
+        run_neovim_02_tests=0
+        run_neovim_03_tests=0
+        run_neovim_04_tests=0
+        run_vim_80_tests=0
+        run_vim_81_tests=0
         run_linters=0
         shift
     ;;
     --linters-only)
         run_vim_80_tests=0
         run_vim_81_tests=0
+        run_vim_82_tests=0
         run_neovim_02_tests=0
         run_neovim_03_tests=0
+        run_neovim_04_tests=0
         shift
     ;;
     --fast)
         run_vim_80_tests=0
         run_vim_81_tests=0
+        run_vim_82_tests=0
         run_neovim_02_tests=0
-        run_neovim_03_tests=1
+        run_neovim_03_tests=0
+        run_neovim_04_tests=1
         shift
     ;;
     --help)
@@ -99,12 +133,14 @@ while [ $# -ne 0 ]; do
         echo 'Options:'
         echo '  -v                Enable verbose output'
         echo '  -q                Hide output for successful tests'
-        echo '  --neovim-only     Run tests only for NeoVim 0.2 and 0.3'
+        echo '  --neovim-only     Run tests only for NeoVim'
         echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
         echo '  --neovim-03-only  Run tests only for NeoVim 0.3'
-        echo '  --vim-only        Run tests only for Vim 8.0 and 8.1'
+        echo '  --neovim-04-only  Run tests only for NeoVim 0.4'
+        echo '  --vim-only        Run tests only for Vim'
         echo '  --vim-80-only     Run tests only for Vim 8.0'
         echo '  --vim-81-only     Run tests only for Vim 8.1'
+        echo '  --vim-82-only     Run tests only for Vim 8.2'
         echo '  --linters-only    Run only Vint and custom checks'
         echo '  --fast            Run only the fastest Vim and custom checks'
         echo '  --help            Show this help text'
@@ -175,8 +211,10 @@ trap cancel_tests INT TERM
 for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neovim\|^vim' ); do
     if ( [[ $vim =~ ^vim-v8.0 ]] && ((run_vim_80_tests)) ) \
     || ( [[ $vim =~ ^vim-v8.1 ]] && ((run_vim_81_tests)) ) \
+    || ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
-    || ( [[ $vim =~ ^neovim-v0.3 ]] && ((run_neovim_03_tests)) ); then
+    || ( [[ $vim =~ ^neovim-v0.3 ]] && ((run_neovim_03_tests)) ) \
+    || ( [[ $vim =~ ^neovim-v0.4 ]] && ((run_neovim_04_tests)) ); then
         echo "Starting Vim: $vim..."
         file_number=$((file_number+1))
         test/script/run-vader-tests $quiet_flag $verbose_flag "$vim" "$tests" \

--- a/run-tests
+++ b/run-tests
@@ -10,7 +10,9 @@ set -u
 #
 
 image=w0rp/ale
-current_image_id=b2c5422958d4
+
+# Create docker image tag based on Dockerfile contents
+image_tag=$(md5sum Dockerfile | cut -d' ' -f1)
 
 # Used in all test scripts for running the selected Docker image.
 DOCKER_RUN_IMAGE="$image"
@@ -36,6 +38,16 @@ while [ $# -ne 0 ]; do
     ;;
     -q)
         quiet_flag='-q'
+        shift
+    ;;
+    --build-image)
+        run_vim_80_tests=0
+        run_vim_81_tests=0
+        run_vim_82_tests=0
+        run_neovim_02_tests=0
+        run_neovim_03_tests=0
+        run_neovim_04_tests=0
+        run_linters=0
         shift
     ;;
     --neovim-only)
@@ -133,6 +145,7 @@ while [ $# -ne 0 ]; do
         echo 'Options:'
         echo '  -v                Enable verbose output'
         echo '  -q                Hide output for successful tests'
+        echo '  --build-image     Run docker image build only.'
         echo '  --neovim-only     Run tests only for NeoVim'
         echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
         echo '  --neovim-03-only  Run tests only for NeoVim 0.3'
@@ -174,8 +187,25 @@ fi
 # Delete .swp files in the test directory, which cause Vim 8 to hang.
 find test -name '*.swp' -delete
 
-docker images -q w0rp/ale | grep "^$current_image_id" > /dev/null \
-    || docker pull "$image"
+# Check if docker un image is available locally
+has_image=$(docker images ls --filter reference="w0rp/ale:${image_tag}" --quiet | wc -l)
+
+if [ "$has_image" -eq 0 ]
+then
+  # Check if image exists on Docker hub
+  if docker manifest inspect "w0rp/ale:${image_tag}" &> /dev/null
+  then
+    echo "Downloading run image w0rp/ale:${image_tag}"
+    docker pull "w0rp/ale:${image_tag}"
+    docker tag "w0rp/ale:${image_tag}" "w0rp/ale:latest"
+  else
+    echo "Building run image w0rp/ale:${image_tag}"
+    docker build -t "w0rp/ale:${image_tag}" .
+    docker tag "w0rp/ale:${image_tag}" "w0rp/ale:latest"
+  fi
+else
+  echo "Docker run image w0rp/ale:${image_tag} ready"
+fi
 
 output_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 

--- a/run-tests
+++ b/run-tests
@@ -24,10 +24,8 @@ tests='test/*.vader test/*/*.vader test/*/*/*.vader test/*/*/*.vader'
 verbose_flag=''
 quiet_flag=''
 run_neovim_02_tests=1
-run_neovim_03_tests=1
 run_neovim_04_tests=1
 run_vim_80_tests=1
-run_vim_81_tests=1
 run_vim_82_tests=1
 run_linters=1
 
@@ -43,97 +41,63 @@ while [ $# -ne 0 ]; do
     ;;
     --build-image)
         run_vim_80_tests=0
-        run_vim_81_tests=0
         run_vim_82_tests=0
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_neovim_04_tests=0
         run_linters=0
         shift
     ;;
     --neovim-only)
         run_vim_80_tests=0
-        run_vim_81_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --neovim-02-only)
-        run_neovim_03_tests=0
         run_neovim_04_tests=0
         run_vim_80_tests=0
-        run_vim_81_tests=0
-        run_vim_82_tests=0
-        run_linters=0
-        shift
-    ;;
-    --neovim-03-only)
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
-        run_vim_80_tests=0
-        run_vim_81_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --neovim-04-only)
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_vim_80_tests=0
-        run_vim_81_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --vim-only)
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_neovim_04_tests=0
         run_linters=0
         shift
     ;;
     --vim-80-only)
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_neovim_04_tests=0
-        run_vim_81_tests=0
-        run_vim_82_tests=0
-        run_linters=0
-        shift
-    ;;
-    --vim-81-only)
-        run_neovim_02_tests=0
-        run_neovim_03_tests=0
-        run_neovim_04_tests=0
-        run_vim_80_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --vim-82-only)
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_neovim_04_tests=0
         run_vim_80_tests=0
-        run_vim_81_tests=0
         run_linters=0
         shift
     ;;
     --linters-only)
         run_vim_80_tests=0
-        run_vim_81_tests=0
         run_vim_82_tests=0
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_neovim_04_tests=0
         shift
     ;;
     --fast)
         run_vim_80_tests=0
-        run_vim_81_tests=0
         run_vim_82_tests=0
         run_neovim_02_tests=0
-        run_neovim_03_tests=0
         run_neovim_04_tests=1
         shift
     ;;
@@ -149,11 +113,9 @@ while [ $# -ne 0 ]; do
         echo '  --build-image     Run docker image build only.'
         echo '  --neovim-only     Run tests only for NeoVim'
         echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
-        echo '  --neovim-03-only  Run tests only for NeoVim 0.3'
         echo '  --neovim-04-only  Run tests only for NeoVim 0.4'
         echo '  --vim-only        Run tests only for Vim'
         echo '  --vim-80-only     Run tests only for Vim 8.0'
-        echo '  --vim-81-only     Run tests only for Vim 8.1'
         echo '  --vim-82-only     Run tests only for Vim 8.2'
         echo '  --linters-only    Run only Vint and custom checks'
         echo '  --fast            Run only the fastest Vim and custom checks'
@@ -241,10 +203,8 @@ trap cancel_tests INT TERM
 
 for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neovim\|^vim' ); do
     if ( [[ $vim =~ ^vim-v8.0 ]] && ((run_vim_80_tests)) ) \
-    || ( [[ $vim =~ ^vim-v8.1 ]] && ((run_vim_81_tests)) ) \
     || ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
-    || ( [[ $vim =~ ^neovim-v0.3 ]] && ((run_neovim_03_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.4 ]] && ((run_neovim_04_tests)) ); then
         echo "Starting Vim: $vim..."
         file_number=$((file_number+1))

--- a/run-tests
+++ b/run-tests
@@ -13,6 +13,7 @@ image=w0rp/ale
 
 # Create docker image tag based on Dockerfile contents
 image_tag=$(md5sum Dockerfile | cut -d' ' -f1)
+git_version=$(git describe --always --tags)
 
 # Used in all test scripts for running the selected Docker image.
 DOCKER_RUN_IMAGE="$image"
@@ -200,7 +201,7 @@ then
     docker tag "w0rp/ale:${image_tag}" "w0rp/ale:latest"
   else
     echo "Building run image w0rp/ale:${image_tag}"
-    docker build -t "w0rp/ale:${image_tag}" .
+    docker build --build-arg GIT_VERSION="$git_version" -t "w0rp/ale:${image_tag}" .
     docker tag "w0rp/ale:${image_tag}" "w0rp/ale:latest"
   fi
 else

--- a/run-tests
+++ b/run-tests
@@ -9,7 +9,7 @@ set -u
 # options, or read the output below.
 #
 
-image=w0rp/ale
+image=denseanalysis/ale
 
 # Create docker image tag based on Dockerfile contents
 image_tag=$(md5sum Dockerfile | cut -d' ' -f1)
@@ -151,24 +151,35 @@ fi
 find test -name '*.swp' -delete
 
 # Check if docker un image is available locally
-has_image=$(docker images ls --filter reference="w0rp/ale:${image_tag}" --quiet | wc -l)
+has_image=$(docker images ls --filter reference="${image}:${image_tag}" --quiet | wc -l)
 
 if [ "$has_image" -eq 0 ]
 then
-  # Check if image exists on Docker hub
-  if docker manifest inspect "w0rp/ale:${image_tag}" &> /dev/null
+
+  echo "Downloading run image ${image}:${image_tag}"
+  docker pull "${image}:${image_tag}" &> /dev/null
+
+  if [ $? -eq 1 ]
   then
-    echo "Downloading run image w0rp/ale:${image_tag}"
-    docker pull "w0rp/ale:${image_tag}"
-    docker tag "w0rp/ale:${image_tag}" "w0rp/ale:latest"
-  else
-    echo "Building run image w0rp/ale:${image_tag}"
-    docker build --build-arg GIT_VERSION="$git_version" -t "w0rp/ale:${image_tag}" .
-    docker tag "w0rp/ale:${image_tag}" "w0rp/ale:latest"
+    echo "Could not pull image ${image}:${image_tag}"
+    echo "Building run image ${image}:${image_tag}"
+    docker build --build-arg GIT_VERSION="$git_version" -t "${image}:${image_tag}" .
+    docker tag "${image}:${image_tag}" "${image}:latest"
+
+    if [[ -z "${DOCKER_HUB_USER:-}" || -z "${DOCKER_HUB_PASS:-}" ]]
+    then
+      echo "Docker Hub credentials not set, skip push"
+    else
+      echo "Push ${image}:${image_tag} to Docker Hub"
+      echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
+      docker push "${image}:${image_tag}"
+    fi
   fi
 else
-  echo "Docker run image w0rp/ale:${image_tag} ready"
+  echo "Docker run image ${image}:${image_tag} ready"
 fi
+
+docker tag "${image}:${image_tag}" "${image}:latest"
 
 output_dir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 

--- a/test/completion/test_omnifunc_completion.vader
+++ b/test/completion/test_omnifunc_completion.vader
@@ -45,15 +45,15 @@ Execute(The start position should be returned when results can be requested):
   AssertEqual 11, ale#completion#OmniFunc(1, '')
 
 Execute(The omnifunc function should return async results):
-  " Neovim 0.2.0 struggles at running these tests.
-  if !has('nvim') || has('nvim-0.3.0')
+  " Neovim 0.2.0 and 0.4.4 struggles at running these tests.
+  if !has('nvim')
     call timer_start(0, function('SetCompletionResult'))
 
     AssertEqual ['foo'], ale#completion#OmniFunc(0, '')
   endif
 
 Execute(The omnifunc function should parse and return async responses):
-  if !has('nvim') || has('nvim-0.3.0')
+  if !has('nvim')
     call timer_start(0, function('SetCompletionResponse'))
 
     AssertEqual ['foo'], ale#completion#OmniFunc(0, '')

--- a/test/smoke_test.vader
+++ b/test/smoke_test.vader
@@ -64,9 +64,9 @@ Execute(Linters should run with the default options):
   \   'valid': 1,
   \ }]
 
-  " Try the test a few times over in NeoVim 0.3 or Windows,
+  " Try the test a few times over in NeoVim 0.3 or Windows or Vim 8.2,
   " where tests fail randomly.
-  for g:i in range(has('nvim-0.3') || has('win32') ? 5 : 1)
+  for g:i in range(has('nvim-0.3') || has('win32') || has('patch-8.2.2401') ? 5 : 1)
     call ale#Queue(0, '')
     call ale#test#WaitForJobs(2000)
 
@@ -165,9 +165,9 @@ Execute(Previous errors should be removed when linters change):
   \ 'valid': 1,
   \}]
 
-  " Try the test a few times over in NeoVim 0.3 or Windows,
+  " Try the test a few times over in NeoVim 0.3 or VIm 8.2 or Windows,
   " where tests fail randomly.
-  for g:i in range(has('nvim-0.3') || has('win32') ? 5 : 1)
+  for g:i in range(has('nvim-0.3') || has('win32') || has('patch-8.2.2401') ? 5 : 1)
     call ale#Queue(0, '')
     call ale#test#WaitForJobs(2000)
 

--- a/test/test_linting_updates_loclist.vader
+++ b/test/test_linting_updates_loclist.vader
@@ -7,10 +7,12 @@ Before:
   Save g:ale_run_synchronously
   Save g:ale_set_lists_synchronously
   Save g:ale_buffer_info
+  Save g:ale_sign_offset
 
   " We want to check that sign IDs are set for this test.
   let g:ale_set_signs = 1
   let g:ale_set_loclist = 1
+  let g:ale_sign_offset = 2000000
   " Disable features we don't need for these tests.
   let g:ale_set_quickfix = 0
   let g:ale_set_highlights = 0
@@ -77,7 +79,7 @@ Execute(The loclist should be updated after linting is done):
   \     'type': 'W',
   \     'col': 10,
   \     'text': 'Infix operators must be spaced. [Warning/space-infix-ops]',
-  \     'sign_id': 1000001,
+  \     'sign_id': 2000001,
   \   },
   \   {
   \     'lnum': 2,
@@ -88,7 +90,7 @@ Execute(The loclist should be updated after linting is done):
   \     'type': 'E',
   \     'col': 10,
   \     'text': 'Missing semicolon. [Error/semi]',
-  \     'sign_id': 1000002,
+  \     'sign_id': 2000002,
   \   }
   \ ],
   \ get(get(g:ale_buffer_info, bufnr('%'), {}), 'loclist', [])


### PR DESCRIPTION
- Add vim 8.2 and nvim 0.4.4 to the CI script.
- Fix tests to work on vim 8.2 that has breaking changes.
- Update Docker image to use latest vim-vader.

Closes: #3560 and #3411 