### PR TITLE
Bugfix: ParseCFlagsFromMakeOutput was never being called

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -491,7 +491,7 @@ function! ale#c#GetCFlags(buffer, output) abort
         endif
     endif
 
-    if s:CanParseMakefile(a:buffer) && !empty(a:output) && !empty(l:cflags)
+    if empty(l:cflags) && s:CanParseMakefile(a:buffer) && !empty(a:output)
         let l:cflags = ale#c#ParseCFlagsFromMakeOutput(a:buffer, a:output)
     endif
 


### PR DESCRIPTION
Previously, the make output was never being parsed, even when the
`c_parse_makefile` option was set. I think this is because of a bug in GetCFlags, which would only try parsing the makefile if the compile_commands.json was ALSO present.

I'm not sure if I need to add tests for this, because it's a small change. If it is then I can come back later to add those.