### PR TITLE
Update elixir-ls link in supported tools

### DIFF
--- a/supported-tools.md
+++ b/supported-tools.md
@@ -144,7 +144,7 @@ formatting.
   * [credo](https://github.com/rrrene/credo)
   * [dialyxir](https://github.com/jeremyjh/dialyxir) :floppy_disk:
   * [dogma](https://github.com/lpil/dogma) :floppy_disk:
-  * [elixir-ls](https://github.com/JakeBecker/elixir-ls) :warning:
+  * [elixir-ls](https://github.com/elixir-lsp/elixir-ls) :warning:
   * [mix](https://hexdocs.pm/mix/Mix.html) :warning: :floppy_disk:
 * Elm
   * [elm-format](https://github.com/avh4/elm-format)


### PR DESCRIPTION
https://github.com/elixir-lsp/elixir-ls/ is now the canonical repo: 

> It's now being maintained by proactive volunteers from the Elixir community over at elixir-lsp/elixir-ls. Updates will continue to be published from that repo to the original VS Code extension, so no need to switch plugins if you're using VS Code.

from: https://github.com/JakeBecker/elixir-ls#this-project-has-moved