### PR TITLE
add support for prettier-ruby to prettier fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -107,7 +107,7 @@ let s:default_registry = {
 \   },
 \   'prettier': {
 \       'function': 'ale#fixers#prettier#Fix',
-\       'suggested_filetypes': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue', 'html', 'yaml', 'openapi'],
+\       'suggested_filetypes': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'json5', 'graphql', 'markdown', 'vue', 'html', 'yaml', 'openapi', 'ruby'],
 \       'description': 'Apply prettier to a file.',
 \   },
 \   'prettier_eslint': {

--- a/autoload/ale/fixers/prettier.vim
+++ b/autoload/ale/fixers/prettier.vim
@@ -85,6 +85,7 @@ function! ale#fixers#prettier#ApplyFixForVersion(buffer, version) abort
         \    'yaml': 'yaml',
         \    'openapi': 'yaml',
         \    'html': 'html',
+        \    'ruby': 'ruby',
         \}
 
         for l:filetype in l:filetypes

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -41,6 +41,11 @@ g:ale_ruby_debride_options                         *g:ale_ruby_debride_options*
   This variable can be changed to modify flags given to debride.
 
 
+===============================================================================
+prettier                                                    *ale-ruby-prettier*
+
+See |ale-javascript-prettier| for information about the available options.
+
 
 ===============================================================================
 rails_best_practices                            *ale-ruby-rails_best_practices*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -431,6 +431,7 @@ Notes:
 * Ruby
   * `brakeman`
   * `debride`
+  * `prettier`
   * `rails_best_practices`!!
   * `reek`
   * `rubocop`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2931,6 +2931,7 @@ documented in additional help files.
   ruby....................................|ale-ruby-options|
     brakeman..............................|ale-ruby-brakeman|
     debride...............................|ale-ruby-debride|
+    prettier..............................|ale-ruby-prettier|
     rails_best_practices..................|ale-ruby-rails_best_practices|
     reek..................................|ale-ruby-reek|
     rubocop...............................|ale-ruby-rubocop|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -440,6 +440,7 @@ formatting.
 * Ruby
   * [brakeman](http://brakemanscanner.org/) :floppy_disk:
   * [debride](https://github.com/seattlerb/debride) :floppy_disk:
+  * [prettier](https://github.com/prettier/plugin-ruby)
   * [rails_best_practices](https://github.com/flyerhzm/rails_best_practices) :floppy_disk:
   * [reek](https://github.com/troessner/reek)
   * [rubocop](https://github.com/bbatsov/rubocop)

--- a/test/fixers/test_prettier_fixer_callback.vader
+++ b/test/fixers/test_prettier_fixer_callback.vader
@@ -269,6 +269,20 @@ Execute(Should set --parser based on filetype, HTML):
   \     . ' --stdin-filepath %s --stdin',
   \ }
 
+Execute(Should set --parser based on filetype, Ruby):
+  call ale#test#SetFilename('../prettier-test-files/testfile')
+
+  set filetype=ruby
+
+  GivenCommandOutput ['1.6.0']
+  AssertFixer
+  \ {
+  \   'command': ale#path#CdString(expand('%:p:h'))
+  \     . ale#Escape(g:ale_javascript_prettier_executable)
+  \     . ' --parser ruby'
+  \     . ' --stdin-filepath %s --stdin',
+  \ }
+
 Execute(Should set --parser based on first filetype of multiple filetypes):
   call ale#test#SetFilename('../prettier-test-files/testfile')
 


### PR DESCRIPTION
it _does_ need an additional plugin before it'll run ([prettier/plugin-ruby](https://github.com/prettier/plugin-ruby)), but when it has the plugin, it works as expected.
