### PR TITLE
Make markdown vale linter command configurable with options

### DIFF
--- a/ale_linters/markdown/vale.vim
+++ b/ale_linters/markdown/vale.vim
@@ -1,9 +1,24 @@
 " Author: chew-z https://github.com/chew-z
 " Description: vale for Markdown files
 
+call ale#Set('markdown_vale_executable', 'vale')
+call ale#Set('markdown_vale_input_file', '%t')
+call ale#Set('markdown_vale_options', '')
+
+function! ale_linters#markdown#vale#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'markdown_vale_executable')
+    let l:input_file = ale#Var(a:buffer, 'markdown_vale_input_file')
+
+    " Defaults to `vale --output=JSON %t`
+    return ale#Escape(l:executable)
+    \   . ' --output=JSON '
+    \   . ale#Var(a:buffer, 'markdown_vale_options')
+    \   . ' ' . l:input_file
+endfunction
+
 call ale#linter#Define('markdown', {
 \   'name': 'vale',
-\   'executable': 'vale',
-\   'command': 'vale --output=JSON %t',
+\   'executable': {b -> ale#Var(b, 'markdown_vale_executable')},
+\   'command': function('ale_linters#markdown#vale#GetCommand'),
 \   'callback': 'ale#handlers#vale#Handle',
 \})

--- a/test/command_callback/test_markdown_vale_command_callback.vader
+++ b/test/command_callback/test_markdown_vale_command_callback.vader
@@ -1,0 +1,32 @@
+Before:
+  call ale#assert#SetUpLinterTest('markdown', 'vale')
+  call ale#test#SetFilename('dummy.md')
+
+  let g:ale_markdown_vale_executable = 'vale'
+  let g:ale_markdown_vale_input_file = '%t'
+  let g:ale_markdown_vale_options = ''
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(Executable should default to rubocop):
+  AssertLinter 'vale', ale#Escape('vale')
+  \   . ' --output=JSON  %t'
+
+Execute(Should be able to set a custom executable):
+  let g:ale_markdown_vale_executable = 'bin/vale'
+
+  AssertLinter 'bin/vale' , ale#Escape('bin/vale')
+  \   . ' --output=JSON  %t'
+
+Execute(Should be able to set custom options):
+  let g:ale_markdown_vale_options = '--foo --bar'
+
+  AssertLinter 'vale', ale#Escape('vale')
+  \   . ' --output=JSON --foo --bar %t'
+
+Execute(Should be able to set a custom input file):
+  let g:ale_markdown_vale_input_file = '%s'
+
+  AssertLinter 'vale', ale#Escape('vale')
+  \   . ' --output=JSON  %s'

--- a/test/command_callback/test_markdown_vale_command_callback.vader
+++ b/test/command_callback/test_markdown_vale_command_callback.vader
@@ -9,7 +9,7 @@ Before:
 After:
   call ale#assert#TearDownLinterTest()
 
-Execute(Executable should default to rubocop):
+Execute(Executable should default to vale):
   AssertLinter 'vale', ale#Escape('vale')
   \   . ' --output=JSON  %t'
 


### PR DESCRIPTION
My work uses a custom Vale setup, and I need to pass in some extra options to get it working with ALE.

I followed the same style as the Rubocop linter:

https://github.com/dbalatero/ale/blob/414d322dc88a52453c1140a41227ad53209228c5/ale_linters/ruby/rubocop.vim#L4-L14

This adds Vimscript config options for executable path, input file, and additional CLI options. It also adds tests as requested in the PR template.