### PR TITLE
Add support for `erlfmt` fixer

### DIFF
--- a/autoload/ale/fixers/erlfmt.vim
+++ b/autoload/ale/fixers/erlfmt.vim
@@ -14,6 +14,7 @@ function! ale#fixers#erlfmt#Fix(buffer) abort
     let l:executable = ale#fixers#erlfmt#GetExecutable(a:buffer)
 
     let l:command = ale#Escape(l:executable) . (empty(l:options) ? '' : ' ' . l:options) . ' %s'
+
     return {
     \   'command': l:command
     \}

--- a/autoload/ale/fixers/erlfmt.vim
+++ b/autoload/ale/fixers/erlfmt.vim
@@ -1,0 +1,20 @@
+" Author: AntoineGagne - https://github.com/AntoineGagne
+" Description: Integration of erlfmt with ALE.
+
+call ale#Set('erlang_erlfmt_executable', 'erlfmt')
+call ale#Set('erlang_erlfmt_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('erlang_erlfmt_options', '')
+
+function! ale#fixers#erlfmt#GetExecutable(buffer) abort
+    return ale#node#FindExecutable(a:buffer, 'erlang_erlfmt', ['erlfmt'])
+endfunction
+
+function! ale#fixers#erlfmt#Fix(buffer) abort
+    let l:options = ale#Var(a:buffer, 'erlang_erlfmt_options')
+    let l:executable = ale#fixers#erlfmt#GetExecutable(a:buffer)
+
+    let l:command = ale#Escape(l:executable) . (empty(l:options) ? '' : ' ' . l:options) . ' %s'
+    return {
+    \   'command': l:command
+    \}
+endfunction

--- a/doc/ale-erlang.txt
+++ b/doc/ale-erlang.txt
@@ -72,6 +72,26 @@ g:ale_erlang_erlc_options                           *g:ale_erlang_erlc_options*
 
 
 -------------------------------------------------------------------------------
+erlfmt                                                      *ale-erlang-erlfmt*
+
+g:ale_erlang_erlfmt_executable                 *g:ale_erlang_erlfmt_executable*
+                                               *b:ale_erlang_erlfmt_executable*
+  Type: |String|
+  Default: `'erlfmt'`
+
+  This variable can be changed to specify the erlfmt executable.
+
+
+g:ale_erlang_erlfmt_options                       *g:ale_erlang_erlfmt_options*
+                                                  *b:ale_erlang_erlfmt_options*
+  Type: |String|
+  Default: `''`
+
+  This variable controls additional parameters passed to `erlfmt`, such as
+  `--insert-pragma` or `--print-width`.
+
+
+-------------------------------------------------------------------------------
 syntaxerl                                                *ale-erlang-syntaxerl*
 
 g:ale_erlang_syntaxerl_executable           *g:ale_erlang_syntaxerl_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -150,6 +150,8 @@ Notes:
   * `SyntaxErl`
   * `elvis`!!
   * `erlc`
+  * `erlfmt`
+  * `dialyzer`
 * Fish
   * `fish` (-n flag)
   * `fish_indent`

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -148,10 +148,10 @@ Notes:
   * `ruumba`
 * Erlang
   * `SyntaxErl`
+  * `dialyzer`
   * `elvis`!!
   * `erlc`
   * `erlfmt`
-  * `dialyzer`
 * Fish
   * `fish` (-n flag)
   * `fish_indent`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2695,6 +2695,7 @@ documented in additional help files.
     dialyzer..............................|ale-erlang-dialyzer|
     elvis.................................|ale-erlang-elvis|
     erlc..................................|ale-erlang-erlc|
+    erlfmt................................|ale-erlang-erlfmt|
     syntaxerl.............................|ale-erlang-syntaxerl|
   eruby...................................|ale-eruby-options|
     ruumba................................|ale-eruby-ruumba|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -157,8 +157,10 @@ formatting.
   * [ruumba](https://github.com/ericqweinstein/ruumba)
 * Erlang
   * [SyntaxErl](https://github.com/ten0s/syntaxerl)
+  * [dialyzer](http://erlang.org/doc/man/dialyzer.html)
   * [elvis](https://github.com/inaka/elvis) :floppy_disk:
   * [erlc](http://erlang.org/doc/man/erlc.html)
+  * [erlfmt](https://github.com/WhatsApp/erlfmt)
 * Fish
   * fish [-n flag](https://linux.die.net/man/1/fish)
   * [fish_indent](https://fishshell.com/docs/current/cmds/fish_indent.html)

--- a/test/fixers/test_erlfmt_fixer_callback.vader
+++ b/test/fixers/test_erlfmt_fixer_callback.vader
@@ -1,0 +1,25 @@
+Before:
+  Save b:ale_elm_format_executable
+  Save b:ale_elm_format_options
+
+  let b:ale_elm_format_executable = 'erlfmt'
+  let b:ale_elm_format_options = ''
+
+After:
+  Restore
+
+Execute(The erlfmt command should handle empty options):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('erlfmt') . ' %s'
+  \ },
+  \ ale#fixers#erlfmt#Fix(bufnr(''))
+
+Execute(The erlfmt command should handle custom options):
+  let b:ale_erlang_erlfmt_options = '--insert-pragma'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('erlfmt') . ' --insert-pragma %s'
+  \ },
+  \ ale#fixers#erlfmt#Fix(bufnr(''))


### PR DESCRIPTION
As the title says, this PR adds support for [`erlfmt`](https://github.com/WhatsApp/erlfmt).

**Note:** The supported tools list seemed to be missing `dialyzer` for Erlang so I added it to the list at the same time as `erlfmt`.