### PR TITLE
Add borders for floating windows in Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,8 +910,8 @@ ALE to support this.
 
 ### 5.xxi. How can I change the borders for floating preview windows?
 
-The borders for floating preview is enabled by default. You could use the
-`g:ale_floating_window_border` to control.
+Borders for floating preview windows are enabled by default. You can use the
+`g:ale_floating_window_border` setting to configure them.
 
 You could disable the border with an empty list.
 

--- a/README.md
+++ b/README.md
@@ -907,3 +907,21 @@ tools are well-integrated with ALE, and ALE is properly configured to run the
 correct commands and map filename paths between different file systems. See
 `:help ale-lint-other-machines` for the full documentation on how to configure
 ALE to support this.
+
+### 5.xxi. How can I change the borders for floating preview windows?
+
+The borders for floating preview is enabled by default. You could use the
+`g:ale_floating_window_border` to control.
+
+You could disable the border with an empty list.
+
+```vim
+let g:ale_floating_window_border = []
+```
+
+If the terminal supports unicode, you may use the setting to beauty the
+floating window.
+
+```vim
+let g:ale_floating_window_border = ['│', '─', '╭', '╮', '╯', '╰']
+```

--- a/README.md
+++ b/README.md
@@ -919,8 +919,7 @@ You could disable the border with an empty list.
 let g:ale_floating_window_border = []
 ```
 
-If the terminal supports unicode, you may use the setting to beauty the
-floating window.
+If the terminal supports Unicode, you might try setting the value like below, to make it look nicer.
 
 ```vim
 let g:ale_floating_window_border = ['│', '─', '╭', '╮', '╯', '╰']

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -62,7 +62,7 @@ function! s:PrepareWindowContent(lines) abort
     let l:width = max(map(copy(a:lines), 'strdisplaywidth(v:val)'))
     let l:height = min([len(a:lines), l:max_height])
 
-    if empty(g:ale_floating_window_border) == 1
+    if empty(g:ale_floating_window_border)
         return [a:lines, l:width, l:height]
     endif
 

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -79,9 +79,9 @@ function! s:PrepareWindowContent(lines) abort
 
     let l:lines = [l:top_left . repeat(l:top, l:width - 2) . l:top_right]
 
-    for s:line in a:lines
-        let l:line_width = strchars(s:line)
-        let l:lines = add(l:lines, l:hor . s:line . repeat(' ', l:width - l:line_width - 2). l:hor)
+    for l:line in a:lines
+        let l:line_width = strchars(l:line)
+        let l:lines = add(l:lines, l:hor . l:line . repeat(' ', l:width - l:line_width - 2). l:hor)
     endfor
 
     " Truncate the lines

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -77,7 +77,7 @@ function! s:PrepareWindowContent(lines) abort
     let l:bottom_right = g:ale_floating_window_border[4]
     let l:bottom_left  = g:ale_floating_window_border[5]
 
-    let l:lines = add([], l:top_left . repeat(l:top, l:width - 2) . l:top_right)
+    let l:lines = [l:top_left . repeat(l:top, l:width - 2) . l:top_right]
 
     for s:line in a:lines
         let l:line_width = strchars(s:line)

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -47,14 +47,51 @@ function! ale#floating_preview#Show(lines, ...) abort
         endif
     augroup END
 
-    let l:width = max(map(copy(a:lines), 'strdisplaywidth(v:val)'))
-    let l:height = min([len(a:lines), 10])
+    let [l:lines, l:width, l:height] = s:PrepareWindowContent(a:lines)
+
     call nvim_win_set_width(w:preview['id'], l:width)
     call nvim_win_set_height(w:preview['id'], l:height)
-
-    call nvim_buf_set_lines(w:preview['buffer'], 0, -1, v:false, a:lines)
+    call nvim_buf_set_lines(w:preview['buffer'], 0, -1, v:false, l:lines)
     call nvim_buf_set_option(w:preview['buffer'], 'modified', v:false)
     call nvim_buf_set_option(w:preview['buffer'], 'modifiable', v:false)
+endfunction
+
+function! s:PrepareWindowContent(lines) abort
+    let l:max_height = 10
+
+    let l:width = max(map(copy(a:lines), 'strdisplaywidth(v:val)'))
+    let l:height = min([len(a:lines), l:max_height])
+
+    if empty(g:ale_floating_window_border) == 1
+        return [a:lines, l:width, l:height]
+    endif
+
+    " Add the size of borders
+    let l:width += 2
+    let l:height += 2
+
+    let l:hor          = g:ale_floating_window_border[0]
+    let l:top          = g:ale_floating_window_border[1]
+    let l:top_left     = g:ale_floating_window_border[2]
+    let l:top_right    = g:ale_floating_window_border[3]
+    let l:bottom_right = g:ale_floating_window_border[4]
+    let l:bottom_left  = g:ale_floating_window_border[5]
+
+    let l:lines = add([], l:top_left . repeat(l:top, l:width - 2) . l:top_right)
+
+    for s:line in a:lines
+        let l:line_width = strchars(s:line)
+        let l:lines = add(l:lines, l:hor . s:line . repeat(' ', l:width - l:line_width - 2). l:hor)
+    endfor
+
+    " Truncate the lines
+    if len(l:lines) > l:max_height + 1
+        let l:lines = l:lines[0:l:max_height]
+    endif
+
+    let l:lines = add(l:lines, l:bottom_left . repeat(l:top, l:width - 2) . l:bottom_right)
+
+    return [l:lines, l:width, l:height]
 endfunction
 
 function! s:Create(options) abort
@@ -88,4 +125,3 @@ function! s:Close() abort
 
     unlet w:preview
 endfunction
-

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -647,7 +647,8 @@ Hover information can be displayed in the preview window instead by setting
 |g:ale_hover_to_preview| to `1`.
 
 When using Neovim, if |g:ale_hover_to_floating_preview| or |g:ale_floating_preview|
-is set to 1, the hover information will show in a floating window.
+is set to 1, the hover information will show in a floating window. And 
+|g:ale_floating_window_border| for the border setting.
 
 For Vim 8.1+ terminals, mouse hovering is disabled by default. Enabling
 |balloonexpr| commands in terminals can cause scrolling issues in terminals,
@@ -1197,6 +1198,19 @@ g:ale_floating_preview                                       *g:ale_floating_pre
   When set to `1`, Neovim will use a floating window for ale's preview window.
   This is equivalent to setting |g:ale_hover_to_floating_preview| and
   |g:ale_detail_to_floating_preview| to `1`.
+
+
+g:ale_floating_window_border                       *g:ale_floating_window_border*
+
+  Type: |List|
+  Default: `['|', '-', '+', '+', '+', '+']`
+
+  When set to `[]`, the border rendering is disabled. The elements in the list
+  present the values for horizontal, top, top-left, top-right, bottom-right 
+  and bottom-left.
+
+  If the terminal suuports unicode, you may set the value with
+  ` ['│', '─', '╭', '╮', '╯', '╰']` for a beautiful looking.
 
 
 g:ale_history_enabled                                   *g:ale_history_enabled*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1209,8 +1209,8 @@ g:ale_floating_window_border                       *g:ale_floating_window_border
   set the horizontal, top, top-left, top-right, bottom-right 
   and bottom-left border characters, respectively.
 
-  If the terminal suuports unicode, you may set the value with
-  ` ['│', '─', '╭', '╮', '╯', '╰']` for a beautiful looking.
+  If the terminal supports Unicode, you might try setting the value to
+  ` ['│', '─', '╭', '╮', '╯', '╰']`, to make it look nicer.
 
 
 g:ale_history_enabled                                   *g:ale_history_enabled*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1205,9 +1205,9 @@ g:ale_floating_window_border                       *g:ale_floating_window_border
   Type: |List|
   Default: `['|', '-', '+', '+', '+', '+']`
 
-  When set to `[]`, the border rendering is disabled. The elements in the list
-  present the values for horizontal, top, top-left, top-right, bottom-right 
-  and bottom-left.
+  When set to `[]`, window borders are disabled. The elements in the list
+  set the horizontal, top, top-left, top-right, bottom-right 
+  and bottom-left border characters, respectively.
 
   If the terminal suuports unicode, you may set the value with
   ` ['│', '─', '╭', '╮', '╯', '╰']` for a beautiful looking.

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -150,6 +150,11 @@ let g:ale_hover_to_floating_preview = get(g:, 'ale_hover_to_floating_preview', 0
 " Detail uses floating windows in Neovim
 let g:ale_detail_to_floating_preview = get(g:, 'ale_detail_to_floating_preview', 0)
 
+" Border setting for floating preview windows in Neovim
+" The element in the list presents - horizontal, top, top-left, top-right,
+" bottom-right and bottom-left
+let g:ale_floating_window_border = get(g:, 'ale_floating_window_border', ['|', '-', '+', '+', '+', '+'])
+
 " This flag can be set to 0 to disable warnings for trailing whitespace
 let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)
 " This flag can be set to 0 to disable warnings for trailing blank lines


### PR DESCRIPTION
Render borders for floating windows in Neovim. The patch introduces a new variable `g:ale_floating_window_border` to enable/disable the function. Thanks for @w0rp 's help.

The patch is original from https://github.com/dense-analysis/ale/issues/3589