### PR TITLE
Fix 3605 - set fallback for error detail

### DIFF
--- a/ale_linters/terraform/terraform.vim
+++ b/ale_linters/terraform/terraform.vim
@@ -20,6 +20,10 @@ function! ale_linters#terraform#terraform#GetType(severity) abort
     return 'E'
 endfunction
 
+function! ale_linters#terraform#terraform#GetDetail(error) abort
+    return get(a:error, 'detail', get(a:error, 'summary', ''))
+endfunction
+
 function! ale_linters#terraform#terraform#Handle(buffer, lines) abort
     let l:output = []
 
@@ -33,7 +37,7 @@ function! ale_linters#terraform#terraform#Handle(buffer, lines) abort
             \   'filename': ale#path#GetAbsPath(l:dir, l:error['range']['filename']),
             \   'lnum': l:error['range']['start']['line'],
             \   'col': l:error['range']['start']['column'],
-            \   'text': l:error['detail'],
+            \   'text': ale_linters#terraform#terraform#GetDetail(l:error),
             \   'type': ale_linters#terraform#terraform#GetType(l:error['severity']),
             \})
         else
@@ -41,7 +45,7 @@ function! ale_linters#terraform#terraform#Handle(buffer, lines) abort
             \   'filename': l:file,
             \   'lnum': 0,
             \   'col': 0,
-            \   'text': l:error['detail'],
+            \   'text': ale_linters#terraform#terraform#GetDetail(l:error),
             \   'type': ale_linters#terraform#terraform#GetType(l:error['severity']),
             \})
         endif

--- a/test/handler/test_terraform_handler.vader
+++ b/test/handler/test_terraform_handler.vader
@@ -59,3 +59,41 @@ Execute(The output should be correct):
   \ '  ]',
   \ '}',
   \ ])
+
+Execute(Should use summary if detail not available):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 91,
+  \     'col': 41,
+  \     'filename': ale#path#Simplify(g:dir . '/main.tf'),
+  \     'type': 'E',
+  \     'text': 'storage_os_disk: required field is not set',
+  \   }
+  \ ],
+  \ ale_linters#terraform#terraform#Handle(bufnr(''), [
+  \ '{',
+  \ '  "valid": false,',
+  \ '  "error_count": 1,',
+  \ '  "warning_count": 0,',
+  \ '  "diagnostics": [',
+  \ '    {',
+  \ '      "severity": "error",',
+  \ '      "summary": "storage_os_disk: required field is not set",',
+  \ '      "range": {',
+  \ '        "filename": "main.tf",',
+  \ '        "start": {',
+  \ '          "line": 91,',
+  \ '          "column": 41,',
+  \ '          "byte": 2381',
+  \ '        },',
+  \ '        "end": {',
+  \ '          "line": 91,',
+  \ '          "column": 41,',
+  \ '          "byte": 2381',
+  \ '        }',
+  \ '      }',
+  \ '    }',
+  \ '  ]',
+  \ '}'
+  \ ])


### PR DESCRIPTION
Fixes #3605 by adding a fallback when detail key not found in terraform output.