### PR TITLE
Fix texlab#GetProjectRoot

### DIFF
--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -7,7 +7,7 @@ call ale#Set('tex_texlab_options', '')
 function! ale_linters#tex#texlab#GetProjectRoot(buffer) abort
     let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
 
-    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : fnamemodify(a:buffer, ':h')
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
 endfunction
 
 function! ale_linters#tex#texlab#GetCommand(buffer) abort

--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -1,13 +1,14 @@
 " Author: Ricardo Liang <ricardoliang@gmail.com>
+" Author: ourigen <ourigen [at] pm.me>
 " Description: Texlab language server (Rust rewrite)
 
 call ale#Set('tex_texlab_executable', 'texlab')
 call ale#Set('tex_texlab_options', '')
 
 function! ale_linters#tex#texlab#GetProjectRoot(buffer) abort
-    let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
 
-    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : ''
+    return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
 endfunction
 
 function! ale_linters#tex#texlab#GetCommand(buffer) abort

--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -5,7 +5,9 @@ call ale#Set('tex_texlab_executable', 'texlab')
 call ale#Set('tex_texlab_options', '')
 
 function! ale_linters#tex#texlab#GetProjectRoot(buffer) abort
-    return ''
+  let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+  return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : fnamemodify(a:buffer, ':h')
 endfunction
 
 function! ale_linters#tex#texlab#GetCommand(buffer) abort

--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -5,9 +5,9 @@ call ale#Set('tex_texlab_executable', 'texlab')
 call ale#Set('tex_texlab_options', '')
 
 function! ale_linters#tex#texlab#GetProjectRoot(buffer) abort
-  let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
+    let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
 
-  return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : fnamemodify(a:buffer, ':h')
+    return !empty(l:project_root) ? fnamemodify(l:project_root, ':h') : fnamemodify(a:buffer, ':h')
 endfunction
 
 function! ale_linters#tex#texlab#GetCommand(buffer) abort

--- a/test/command_callback/test_texlab_command_callbacks.vader
+++ b/test/command_callback/test_texlab_command_callbacks.vader
@@ -14,7 +14,10 @@ Execute(The default executable path should be correct):
   AssertLinter 'texlab', ale#Escape('texlab')
 
 Execute(The project root should be detected correctly):
-  AssertLSPProject ''
+  call ale#test#SetFilename('tex_paths/sample1.tex')
+  silent! call mkdir('tex_paths/.git')
+  
+  AssertLSPProject ale#path#Simplify(g:dir . '/tex_paths')
 
 Execute(The executable should be configurable):
   let b:ale_tex_texlab_executable = 'foobar'


### PR DESCRIPTION
This fixes the texlab#GetProjectRoot function based on the discussion in #2501 of using a .git folder as an indicator of a TeX project root. This should address the issue of the texlab LSP server not starting at all, as raised by #2790 and #2699
