### PR TITLE
Add ocamllsp for reason and esy

### DIFF
--- a/ale_linters/reason/ocamllsp.vim
+++ b/ale_linters/reason/ocamllsp.vim
@@ -1,10 +1,10 @@
 " Author: Risto Stevcev <me@risto.codes>
 " Description: The official language server for OCaml
 
-call ale#Set('ocaml_ocamllsp_use_opam', 1)
-call ale#Set('ocaml_ocamllsp_use_esy', 0)
+call ale#Set('reason_ocamllsp_use_opam', 0)
+call ale#Set('reason_ocamllsp_use_esy', 1)
 
-call ale#linter#Define('ocaml', {
+call ale#linter#Define('reason', {
 \   'name': 'ocamllsp',
 \   'lsp': 'stdio',
 \   'executable': function('ale#handlers#ocamllsp#GetExecutable'),

--- a/autoload/ale/handlers/ocamllsp.vim
+++ b/autoload/ale/handlers/ocamllsp.vim
@@ -1,15 +1,44 @@
 " Author: Risto Stevcev <me@risto.codes>
 " Description: Handlers for the official OCaml language server
 
+let s:ocamllsp = 'ocamllsp'
+
+function! s:OnGetExecutable(buffer, output, meta) abort
+    if a:meta.exit_code == 0
+        return a:output[0]
+    endif
+endfunction
+
 function! ale#handlers#ocamllsp#GetExecutable(buffer) abort
-    return 'ocamllsp'
+    let l:filetype = getbufvar(a:buffer, '&filetype')
+    let l:ocamllsp_use_opam = ale#Var(a:buffer, l:filetype . '_ocamllsp_use_opam')
+    let l:ocamllsp_use_esy = ale#Var(a:buffer, l:filetype . '_ocamllsp_use_esy')
+
+    if l:ocamllsp_use_opam
+        let l:check_cmd = 'opam config exec -- which ' . s:ocamllsp
+
+        return ale#command#Run(a:buffer, l:check_cmd, function('s:OnGetExecutable'))
+    elseif l:ocamllsp_use_esy
+        let l:check_cmd =  'esy exec-command --include-build-env -- which '. s:ocamllsp
+
+        return ale#command#Run(a:buffer, l:check_cmd, function('s:OnGetExecutable'))
+    else
+        return s:ocamllsp
+    endif
 endfunction
 
 function! ale#handlers#ocamllsp#GetCommand(buffer) abort
-    let l:executable = ale#handlers#ocamllsp#GetExecutable(a:buffer)
-    let l:ocaml_ocamllsp_use_opam = ale#Var(a:buffer, 'ocaml_ocamllsp_use_opam')
+    let l:filetype = getbufvar(a:buffer, '&filetype')
+    let l:ocamllsp_use_opam = ale#Var(a:buffer, l:filetype . '_ocamllsp_use_opam')
+    let l:ocamllsp_use_esy = ale#Var(a:buffer, l:filetype . '_ocamllsp_use_esy')
 
-    return l:ocaml_ocamllsp_use_opam ? 'opam config exec -- ' . l:executable : l:executable
+    if l:ocamllsp_use_opam
+        return 'opam config exec -- ' . s:ocamllsp
+    elseif l:ocamllsp_use_esy
+        return 'esy exec-command --include-build-env -- ' . s:ocamllsp
+    else
+        return s:ocamllsp
+    endif
 endfunction
 
 function! ale#handlers#ocamllsp#GetLanguage(buffer) abort


### PR DESCRIPTION
This commit does the following:

- We add support for ocamllsp reason syntax.

  We reuse ocamllsp's ocaml definition here.

- We add support for esy (in addition to opam) for both ocaml and reason.

  The opam workflow stays default for ocaml but for reason I've added esy as the default one.

- We modify executable callback to check for existence of ocamllsp within the opam switch or esy sandbox using "which ocamllsp" invocation.

  This way it doesn't require that the opam switch is active when the vim is started. Same holds for esy projects - there's no need to do "esy vim" and just "vim" will be able to discover "ocamllsp".


