### PR TITLE
Add support for V: "v" (compiler) and "vfmt" fixer.

### DIFF
--- a/ale_linters/v/v.vim
+++ b/ale_linters/v/v.vim
@@ -1,0 +1,79 @@
+" Author: fiatjaf <fiatjaf@alhur.es>
+" Description: v build for V files
+
+call ale#Set('v_v_executable', 'v')
+call ale#Set('v_v_options', '')
+
+function! ale_linters#v#v#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'v_v_options')
+
+    " Run v in local directory with relative path
+    let l:command = ale#Var(a:buffer, 'v_v_executable')
+    \   . ' .'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' -o /tmp/vim-ale-v'
+    return l:command
+endfunction
+
+function! ale_linters#v#v#Handler(buffer, lines) abort
+    let l:dir = expand('#' . a:buffer . ':p:h')
+    let l:output = []
+
+    " Matches patterns like the following:
+    "
+    " ./const.v:4:3: warning: const names cannot contain uppercase letters, use snake_case instead
+    "     2 |
+    "     3 | const (
+    "     4 |   BUTTON_TEXT = 'OK'
+    "       |   ~~~~~~~~~~~
+    "     5 | )
+    " ./main.v:4:8: warning: module 'os' is imported but never used
+    "     2 |
+    "     3 | import ui
+    "     4 | import os
+    "       |        ~~
+    "     5 |
+    "     6 | const (
+    " ./main.v:20:10: error: undefined ident: `win_widt`
+    "    18 |     mut app := &App{}
+    "    19 |     app.window = ui.window({
+    "    20 |         width: win_widt
+    "       |                ~~~~~~~~
+    "    21 |         height: win_height
+    "    22 |         title: 'Counter'
+    let l:current = {}
+    for l:line in a:lines
+        " matches basic error description
+        let l:match = matchlist(l:line,
+            \ '\([^:]\+\):\([^:]\+\):\([^:]\+\): \([^:]\+\): \(.*\)')
+        if !empty(l:match)
+            let l:current = {
+            \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
+            \   'lnum': l:match[2] + 0,
+            \   'col': l:match[3] + 0,
+            \   'text': l:match[5],
+            \   'type': l:match[4] is 'error' ? 'E' : 'W',
+            \}
+            call add(l:output, l:current)
+            continue
+        endif
+
+        " try to get information about the ending column
+        let l:tildematch = matchstr(l:line, '\~\+')
+        if !empty(l:tildematch)
+            let l:current['end_col'] = l:current['col'] + len(l:tildematch)
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('v', {
+\   'name': 'v',
+\   'aliases': [],
+\   'executable': {b -> ale#Var(b, 'v_v_executable')},
+\   'command': function('ale_linters#v#v#GetCommand'),
+\   'output_stream': 'stderr',
+\   'callback': 'ale_linters#v#v#Handler',
+\   'lint_file': 1,
+\})

--- a/ale_linters/v/v.vim
+++ b/ale_linters/v/v.vim
@@ -12,6 +12,7 @@ function! ale_linters#v#v#GetCommand(buffer) abort
     \   . ' .'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' -o /tmp/vim-ale-v'
+
     return l:command
 endfunction
 
@@ -42,17 +43,19 @@ function! ale_linters#v#v#Handler(buffer, lines) abort
     "    21 |         height: win_height
     "    22 |         title: 'Counter'
     let l:current = {}
+
     for l:line in a:lines
         " matches basic error description
         let l:match = matchlist(l:line,
-            \ '\([^:]\+\):\([^:]\+\):\([^:]\+\): \([^:]\+\): \(.*\)')
+        \ '\([^:]\+\):\([^:]\+\):\([^:]\+\): \([^:]\+\): \(.*\)')
+
         if !empty(l:match)
             let l:current = {
             \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
             \   'lnum': l:match[2] + 0,
             \   'col': l:match[3] + 0,
             \   'text': l:match[5],
-            \   'type': l:match[4] is 'error' ? 'E' : 'W',
+            \   'type': l:match[4] is# 'error' ? 'E' : 'W',
             \}
             call add(l:output, l:current)
             continue
@@ -60,6 +63,7 @@ function! ale_linters#v#v#Handler(buffer, lines) abort
 
         " try to get information about the ending column
         let l:tildematch = matchstr(l:line, '\~\+')
+
         if !empty(l:tildematch)
             let l:current['end_col'] = l:current['col'] + len(l:tildematch)
         endif

--- a/ale_linters/v/v.vim
+++ b/ale_linters/v/v.vim
@@ -9,9 +9,8 @@ function! ale_linters#v#v#GetCommand(buffer) abort
 
     " Run v in local directory with relative path
     let l:command = ale#Var(a:buffer, 'v_v_executable')
-    \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' .'
-    \   . ' -o /tmp/vim-ale-v'
+    \   . ale#Pad(l:options)
+    \   . ' .' . ' -o /tmp/vim-ale-v'
 
     return l:command
 endfunction

--- a/ale_linters/v/v.vim
+++ b/ale_linters/v/v.vim
@@ -9,8 +9,8 @@ function! ale_linters#v#v#GetCommand(buffer) abort
 
     " Run v in local directory with relative path
     let l:command = ale#Var(a:buffer, 'v_v_executable')
-    \   . ' .'
     \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' .'
     \   . ' -o /tmp/vim-ale-v'
 
     return l:command

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -440,6 +440,11 @@ let s:default_registry = {
 \       'function': 'ale#fixers#ptop#Fix',
 \       'suggested_filetypes': ['pascal'],
 \       'description': 'Fix Pascal files with ptop.',
+\   },
+\   'vfmt': {
+\       'function': 'ale#fixers#vfmt#Fix',
+\       'suggested_filetypes': ['v'],
+\       'description': 'A formatter for V source code.',
 \   }
 \}
 

--- a/autoload/ale/fixers/vfmt.vim
+++ b/autoload/ale/fixers/vfmt.vim
@@ -1,15 +1,14 @@
 " Author: fiatjaf <fiatjaf@alhur.es>
 " Description: Integration of `v fmt` with ALE.
 
-call ale#Set('v_vfmt_executable', 'v')
 call ale#Set('v_vfmt_options', '')
 
 function! ale#fixers#vfmt#Fix(buffer) abort
-    let l:executable = ale#Var(a:buffer, 'v_vfmt_executable')
+    let l:executable = ale#Var(a:buffer, 'v_v_executable')
     let l:options = ale#Var(a:buffer, 'v_vfmt_options')
 
     return {
-    \   'command': ale#Escape(l:executable) . " fmt"
+    \   'command': ale#Escape(l:executable) . ' fmt'
     \       . (empty(l:options) ? '' : ' ' . l:options)
     \}
 endfunction

--- a/autoload/ale/fixers/vfmt.vim
+++ b/autoload/ale/fixers/vfmt.vim
@@ -1,0 +1,15 @@
+" Author: fiatjaf <fiatjaf@alhur.es>
+" Description: Integration of `v fmt` with ALE.
+
+call ale#Set('v_vfmt_executable', 'v')
+call ale#Set('v_vfmt_options', '')
+
+function! ale#fixers#vfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'v_vfmt_executable')
+    let l:options = ale#Var(a:buffer, 'v_vfmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable) . " fmt"
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \}
+endfunction

--- a/autoload/ale/fixers/vfmt.vim
+++ b/autoload/ale/fixers/vfmt.vim
@@ -8,7 +8,6 @@ function! ale#fixers#vfmt#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'v_vfmt_options')
 
     return {
-    \   'command': ale#Escape(l:executable) . ' fmt'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \   'command': ale#Escape(l:executable) . ' fmt' . ale#Pad(l:options)
     \}
 endfunction

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -53,6 +53,7 @@ let s:default_ale_linters = {
 \   'text': [],
 \   'vue': ['eslint', 'vls'],
 \   'zsh': ['shell'],
+\   'v': ['v'],
 \}
 
 " Testing/debugging helper to unload all linters.

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -534,6 +534,9 @@ Notes:
   * `tslint`
   * `tsserver`
   * `typecheck`
+* V
+  * `v`
+  * `vfmt`
 * VALA
   * `uncrustify`
   * `vala_lint`!!

--- a/doc/ale-v.txt
+++ b/doc/ale-v.txt
@@ -1,0 +1,45 @@
+===============================================================================
+ALE V Integration                                               *ale-v-options*
+
+
+===============================================================================
+Integration Information
+
+`v` is V's build tool. `vfmt` (called as `v fmt` from the same
+executable that does the builds) is the autoformatter/fixer.
+
+g:ale_v_v_executable                                     *g:ale_v_v_executable*
+                                                         *b:ale_v_v_executable*
+
+  Type: |String|
+  Default: `'v'`
+
+  The executable that will be run for the `v` linter and the `vfmt` fixer.
+
+
+===============================================================================
+v                                                                     *ale-v-v*
+
+g:ale_v_v_options                                           *g:ale_v_v_options*
+                                                            *b:ale_v_v_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the v linter.
+  They are injected directly after "v .".
+
+
+===============================================================================
+vfmt                                                               *ale-v-vfmt*
+
+g:ale_v_vfmt_options                                     *g:ale_v_vfmt_options*
+                                                         *b:ale_v_vfmt_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the vfmt fixer.
+  They are injected directly after "v fmt".
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1593,6 +1593,7 @@ g:ale_linters                                                   *g:ale_linters*
   \   'text': [],
   \   'vue': ['eslint', 'vls'],
   \   'zsh': ['shell'],
+  \   'v': ['v'],
   \}
 <
   This option can be used to enable only a particular set of linters for a
@@ -3051,6 +3052,9 @@ documented in additional help files.
     tslint................................|ale-typescript-tslint|
     tsserver..............................|ale-typescript-tsserver|
     xo....................................|ale-typescript-xo|
+  v.......................................|ale-v-options|
+    v.....................................|ale-v-v|
+    vfmt..................................|ale-v-vfmt|
   vala....................................|ale-vala-options|
     uncrustify............................|ale-vala-uncrustify|
   verilog/systemverilog...................|ale-verilog-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -543,6 +543,9 @@ formatting.
   * [tslint](https://github.com/palantir/tslint)
   * [tsserver](https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29)
   * typecheck
+* V
+  * [v](https://github.com/vlang/v/)
+  * [vfmt](https://github.com/vlang/v/)
 * VALA
   * [uncrustify](https://github.com/uncrustify/uncrustify)
   * [vala_lint](https://github.com/vala-lang/vala-lint) :floppy_disk:

--- a/test/fixers/test_vfmt_fixer_callback.vader
+++ b/test/fixers/test_vfmt_fixer_callback.vader
@@ -1,0 +1,44 @@
+Before:
+  Save g:ale_v_v_executable
+  Save g:ale_v_vfmt_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_v_v_executable = 'xxxinvalid'
+  let g:ale_v_vfmt_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The vfmt callback should return the correct default values):
+  call ale#test#SetFilename('../v_files/testfile.v')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid') . ' fmt',
+  \ },
+  \ ale#fixers#vfmt#Fix(bufnr(''))
+
+Execute(The vfmt callback should include custom vfmt options):
+  let g:ale_v_vfmt_options = "-r '(a) -> a'"
+
+  call ale#test#SetFilename('../v_files/testfile.v')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' fmt ' . g:ale_v_vfmt_options,
+  \ },
+  \ ale#fixers#vfmt#Fix(bufnr(''))
+
+Execute(The vfmt callback should support Go environment variables):
+  call ale#test#SetFilename('../v_files/testfile.v')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid') . ' fmt',
+  \ },
+  \ ale#fixers#vfmt#Fix(bufnr(''))

--- a/test/handler/test_v_handler.vader
+++ b/test/handler/test_v_handler.vader
@@ -1,0 +1,54 @@
+Before:
+  runtime ale_linters/v/v.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute (The v handler should correctly parse error messages):
+  AssertEqual
+  \ [{
+  \   'lnum': 4,
+  \   'col': 3,
+  \   'filename': ale#path#GetAbsPath(expand('%:p:h'), 'const ants.v'),
+  \   'type': 'W',
+  \   'end_col': 14,
+  \   'text': 'const names cannot contain uppercase letters, use snake_case instead'
+  \ },
+  \ {
+  \   'lnum': 4,
+  \   'col': 8,
+  \   'filename': ale#path#GetAbsPath(expand('%:p:h'), 'main.v'),
+  \   'type': 'W',
+  \   'end_col': 10,
+  \   'text': 'module "os" is imported but never used'
+  \ },
+  \ {
+  \   'lnum': 20,
+  \   'col': 10,
+  \   'filename': ale#path#GetAbsPath(expand('%:p:h'), 'main.v'),
+  \   'type': 'E',
+  \   'end_col': 18,
+  \   'text': 'undefined ident: `win_widt`'
+  \ }],
+  \ ale_linters#v#v#Handler('', [
+  \   './const ants.v:4:3: warning: const names cannot contain uppercase letters, use snake_case instead',
+  \   '    2 |',
+  \   '    3 | const (',
+  \   '    4 |   BUTTON_TEXT = "OK"',
+  \   '      |   ~~~~~~~~~~~',
+  \   '    5 | )',
+  \   './main.v:4:8: warning: module "os" is imported but never used',
+  \   '    2 |',
+  \   '    3 | import ui',
+  \   '    4 | import os',
+  \   '      |        ~~',
+  \   '    5 |',
+  \   '    6 | const (',
+  \   './main.v:20:10: error: undefined ident: `win_widt`',
+  \   '   18 |     mut app := &App{}',
+  \   '   19 |     app.window = ui.window({',
+  \   '   20 |         width: win_widt',
+  \   '      |                ~~~~~~~~',
+  \   '   21 |         height: win_height',
+  \   '   22 |         title: "Counter"',
+  \ ])

--- a/test/linter/test_v_command_callback.vader
+++ b/test/linter/test_v_command_callback.vader
@@ -1,0 +1,25 @@
+Before:
+  Save g:ale_v_v_executable
+
+  call ale#assert#SetUpLinterTest('v', 'v')
+
+  GivenCommandOutput ['/foo/bar', '/foo/baz']
+
+After:
+  Restore
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'v', 'v . -o /tmp/vim-ale-v'
+
+Execute(Extra options should be supported):
+  let g:ale_v_v_options = '--foo-bar'
+
+  AssertLinter 'v', 'v --foo-bar . -o /tmp/vim-ale-v'
+
+  let g:ale_v_vbuild_options = ''
+
+Execute(The executable should be configurable):
+  let g:ale_v_v_executable = 'foobar'
+
+  AssertLinter 'foobar', 'foobar . -o /tmp/vim-ale-v'


### PR DESCRIPTION
https://vlang.io/

Based my changes mostly on the `gobuild` and `gofmt` code.

I'm not sure how to proceed regarding filetype, but I think it's something to be handled externally to this plugin, right? My Vim by default recognizes the `v` extension as `verilog`, but I told it to set it to `v`, then ale works fine with this PR.