### PR TITLE
julia: respect $JULIA_PROJECT env var, set project_root explicitly

### DIFF
--- a/ale_linters/julia/languageserver.vim
+++ b/ale_linters/julia/languageserver.vim
@@ -5,10 +5,16 @@
 call ale#Set('julia_executable', 'julia')
 
 function! ale_linters#julia#languageserver#GetCommand(buffer) abort
+    let l:project_root = ale#julia#FindProjectRoot(a:buffer)
+
+    if l:project_root is# ''
+        let l:project_root = '@.'
+    endif
+
     let l:julia_executable = ale#Var(a:buffer, 'julia_executable')
     let l:cmd_string = 'using LanguageServer; using Pkg; import StaticLint; import SymbolServer; server = LanguageServer.LanguageServerInstance(isdefined(Base, :stdin) ? stdin : STDIN, isdefined(Base, :stdout) ? stdout : STDOUT, dirname(Pkg.Types.Context().env.project_file)); server.runlinter = true; run(server);'
 
-    return ale#Escape(l:julia_executable) . ' --project=@. --startup-file=no --history-file=no -e ' . ale#Escape(l:cmd_string)
+    return ale#Escape(l:julia_executable) . ' ' . ale#Escape('--project=' . l:project_root) . ' --startup-file=no --history-file=no -e ' . ale#Escape(l:cmd_string)
 endfunction
 
 call ale#linter#Define('julia', {

--- a/autoload/ale/julia.vim
+++ b/autoload/ale/julia.vim
@@ -5,6 +5,10 @@
 let s:__ale_julia_project_filenames = ['REQUIRE', 'Manifest.toml', 'Project.toml']
 
 function! ale#julia#FindProjectRoot(buffer) abort
+    if $JULIA_PROJECT isnot# ''
+        return $JULIA_PROJECT
+    endif
+
     for l:project_filename in s:__ale_julia_project_filenames
         let l:full_path = ale#path#FindNearestFile(a:buffer, l:project_filename)
 

--- a/test/command_callback/test_julia_languageserver_callbacks.vader
+++ b/test/command_callback/test_julia_languageserver_callbacks.vader
@@ -11,7 +11,7 @@ After:
 Execute(The default executable path should be correct):
   AssertLinter 'julia',
   \ ale#Escape('julia') .
-  \' --project=@. --startup-file=no --history-file=no -e ' .
+  \' ' . ale#Escape('--project=@.') . ' --startup-file=no --history-file=no -e ' .
   \ ale#Escape('using LanguageServer; using Pkg; import StaticLint; import SymbolServer; server = LanguageServer.LanguageServerInstance(isdefined(Base, :stdin) ? stdin : STDIN, isdefined(Base, :stdout) ? stdout : STDOUT, dirname(Pkg.Types.Context().env.project_file)); server.runlinter = true; run(server);')
 
 Execute(The executable should be configurable):
@@ -19,7 +19,7 @@ Execute(The executable should be configurable):
 
   AssertLinter 'julia-new',
   \ ale#Escape('julia-new') .
-  \' --project=@. --startup-file=no --history-file=no -e ' .
+  \' ' . ale#Escape('--project=@.') . ' --startup-file=no --history-file=no -e ' .
   \ ale#Escape('using LanguageServer; using Pkg; import StaticLint; import SymbolServer; server = LanguageServer.LanguageServerInstance(isdefined(Base, :stdin) ? stdin : STDIN, isdefined(Base, :stdout) ? stdout : STDOUT, dirname(Pkg.Types.Context().env.project_file)); server.runlinter = true; run(server);')
 
 Execute(The project root should be detected correctly):


### PR DESCRIPTION
First we modify `ale#Julia#FindProjectRoot` to respect `$JULIA_PROJECT` environment variable. This is what julia [does][1].

Second, instead of using `--project=@.` when launching languageserver process we set `--project` to the value obtained from `ale#Julia#FindProjectRoot`. This is because using `--project=@.` might pick another directory than the one specified by `$JULIA_PROJECT` environment variable, again [see][1] for docs on `--project=@.`.

[1]: https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_PROJECT