### PR TITLE
Prevent ALEWantResults race condition

### DIFF
--- a/autoload/ale.vim
+++ b/autoload/ale.vim
@@ -102,13 +102,13 @@ function! s:Lint(buffer, should_lint_file, timer_id) abort
     let l:linters = ale#linter#Get(l:filetype)
     let l:linters = ale#linter#RemoveIgnored(a:buffer, l:filetype, l:linters)
 
-    " Tell other sources that they can start checking the buffer now.
-    let g:ale_want_results_buffer = a:buffer
-    silent doautocmd <nomodeline> User ALEWantResults
-    unlet! g:ale_want_results_buffer
-
     " Don't set up buffer data and so on if there are no linters to run.
     if !has_key(g:ale_buffer_info, a:buffer) && empty(l:linters)
+        " Tell other sources that they can start checking the buffer now.
+        let g:ale_want_results_buffer = a:buffer
+        silent doautocmd <nomodeline> User ALEWantResults
+        unlet! g:ale_want_results_buffer
+
         return
     endif
 

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -648,6 +648,11 @@ function! s:RunLinters(
     " We can only clear the results if we aren't checking the buffer.
     let l:can_clear_results = !ale#engine#IsCheckingBuffer(a:buffer)
 
+    " Tell other sources that they can start checking the buffer now.
+    let g:ale_want_results_buffer = a:buffer
+    silent doautocmd <nomodeline> User ALEWantResults
+    unlet! g:ale_want_results_buffer
+
     silent doautocmd <nomodeline> User ALELintPre
 
     for [l:lint_file, l:linter] in a:slots


### PR DESCRIPTION
s:Lint was calling ALEWantResults and, if other linters were available,
would call s:RunLinters, which clears all running jobs.  This causes
ALEWantResults to only fire consistently when no other linters are
running.

Moved the code to ALEWantResults:
 - in s:Lint for the gaurd of no linters to run
 - in s:RunLinters immediately before ALELintPre

Closes #3636