### PR TITLE
Switch to using buildifier's -path option

### DIFF
--- a/autoload/ale/fixers/buildifier.vim
+++ b/autoload/ale/fixers/buildifier.vim
@@ -14,20 +14,9 @@ endfunction
 function! ale#fixers#buildifier#Fix(buffer) abort
     let l:executable = ale#Escape(ale#fixers#buildifier#GetExecutable(a:buffer))
     let l:options = ale#Var(a:buffer, 'bazel_buildifier_options')
-    let l:filename = fnamemodify(bufname(a:buffer), ':t')
+    let l:filename = ale#Escape(bufname(a:buffer))
 
-    let l:command = l:executable . ' -mode fix -lint fix'
-
-    " Attempt to guess the file type based on the filename. buildifier itself
-    " usually does this based on the filenames provided on the command line,
-    " but because we're piping our buffer via stdin, we do this manually.
-    if l:filename =~? 'WORKSPACE'
-        let l:command .= ' -type workspace'
-    elseif l:filename =~? 'BUILD'
-        let l:command .= ' -type build'
-    elseif l:filename =~? '.bzl$'
-        let l:command .= ' -type bzl'
-    endif
+    let l:command = l:executable . ' -mode fix -lint fix -path ' . l:filename
 
     if l:options isnot# ''
         let l:command .= ' ' . l:options

--- a/test/fixers/test_buildifier_fixer_callback.vader
+++ b/test/fixers/test_buildifier_fixer_callback.vader
@@ -11,7 +11,9 @@ Execute(The buildifier callback should return the correct default values):
   AssertFixer
   \ {
   \   'command': ale#Escape(g:ale_bazel_buildifier_executable)
-  \     . ' -mode fix -lint fix -type workspace -'
+  \     . ' -mode fix -lint fix -path '
+  \     . ale#Escape(ale#test#GetFilename('../test-files/bazel/WORKSPACE'))
+  \     . ' -'
   \ }
 
 Execute(The buildifier callback should include any additional options):
@@ -21,23 +23,7 @@ Execute(The buildifier callback should include any additional options):
   AssertFixer
   \ {
   \   'command': ale#Escape(g:ale_bazel_buildifier_executable)
-  \     . ' -mode fix -lint fix -type workspace --some-option -',
-  \ }
-
-Execute(The buildifier callback should recognize BUILD files):
-  call ale#test#SetFilename('../test-files/bazel/BUILD')
-
-  AssertFixer
-  \ {
-  \   'command': ale#Escape(g:ale_bazel_buildifier_executable)
-  \     . ' -mode fix -lint fix -type build -'
-  \ }
-
-Execute(The buildifier callback should recognize .bzl files):
-  call ale#test#SetFilename('../test-files/bazel/defs.bzl')
-
-  AssertFixer
-  \ {
-  \   'command': ale#Escape(g:ale_bazel_buildifier_executable)
-  \     . ' -mode fix -lint fix -type bzl -'
+  \     . ' -mode fix -lint fix -path '
+  \     . ale#Escape(ale#test#GetFilename('../test-files/bazel/WORKSPACE'))
+  \     . ' --some-option -'
   \ }


### PR DESCRIPTION
Buildifier offers a -path command line option:

> Buildifier's reformatting depends in part on the path to the file
> relative to the workspace directory. Normally buildifier deduces
> that path from the file names given, but the path can be given
> explicitly with the -path argument. This is especially useful when
> reformatting standard input, or in scripts that reformat a temporary
> copy of a file.

This lets us drop our `-type`-guessing logic.

For the moment, we rely on the buffer filename being "relative to the
workspace directory", which it generally is, but in a future change, we
should introduce logic that will locate the `WORKSPACE` file and adjusts
the filename relative to that directory. This could be complicated based
on the working directory in which `buildifier` is executed, so a little
more research is necessary to implement that logic correctly.