### PR TITLE
Add pandoc as a markdown fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -311,6 +311,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['reason'],
 \       'description': 'Fix ReasonML files with refmt.',
 \   },
+\   'pandoc': {
+\       'function': 'ale#fixers#pandoc#Fix',
+\       'suggested_filetypes': ['markdown'],
+\       'description': 'Fix markdown files with pandoc.',
+\   },
 \   'shfmt': {
 \       'function': 'ale#fixers#shfmt#Fix',
 \       'suggested_filetypes': ['sh'],

--- a/autoload/ale/fixers/pandoc.vim
+++ b/autoload/ale/fixers/pandoc.vim
@@ -1,0 +1,16 @@
+scriptencoding utf-8
+" Author: Jesse Hathaway <jesse@mbuki-mvuki.org>
+" Description: Fix markdown files with pandoc.
+
+call ale#Set('markdown_pandoc_executable', 'pandoc')
+call ale#Set('markdown_pandoc_options', '-f gfm -t gfm -s -')
+
+function! ale#fixers#pandoc#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'markdown_pandoc_executable')
+    let l:options = ale#Var(a:buffer, 'markdown_pandoc_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' ' . l:options,
+    \}
+endfunction

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -34,6 +34,25 @@ g:ale_markdown_mdl_options                         *g:ale_markdown_mdl_options*
 
 
 ===============================================================================
+pandoc                                                    *ale-markdown-pandoc*
+
+g:ale_markdown_pandoc_executable             *g:ale_markdown_pandoc_executable*
+                                             *b:ale_markdown_pandoc_executable*
+  Type: |String|
+  Default: `'pandoc'`
+
+  This variable can be set to specify where to find the pandoc executable
+
+
+g:ale_markdown_pandoc_options                   *g:ale_markdown_pandoc_options*
+                                                *b:ale_markdown_pandoc_options*
+  Type: |String|
+  Default: `'-f gfm -t gfm -s -'`
+
+  This variable can be set to change the default options passed to pandoc
+
+
+===============================================================================
 prettier                                                *ale-markdown-prettier*
 
 See |ale-javascript-prettier| for information about the available options.

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -297,6 +297,7 @@ Notes:
   * `languagetool`!!
   * `markdownlint`!!
   * `mdl`
+  * `pandoc`
   * `prettier`
   * `proselint`
   * `redpen`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2841,6 +2841,7 @@ documented in additional help files.
   markdown................................|ale-markdown-options|
     markdownlint..........................|ale-markdown-markdownlint|
     mdl...................................|ale-markdown-mdl|
+    pandoc................................|ale-markdown-pandoc|
     prettier..............................|ale-markdown-prettier|
     remark-lint...........................|ale-markdown-remark-lint|
     textlint..............................|ale-markdown-textlint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -306,6 +306,7 @@ formatting.
   * [languagetool](https://languagetool.org/) :floppy_disk:
   * [markdownlint](https://github.com/DavidAnson/markdownlint) :floppy_disk:
   * [mdl](https://github.com/mivok/markdownlint)
+  * [pandoc](https://pandoc.org)
   * [prettier](https://github.com/prettier/prettier)
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)

--- a/test/fixers/test_pandoc_fixer_callback.vader
+++ b/test/fixers/test_pandoc_fixer_callback.vader
@@ -1,0 +1,23 @@
+Before:
+  Save g:ale_markdown_pandoc_executable
+  Save g:ale_markdown_pandoc_options
+
+After:
+  Restore
+
+Execute(The pandoc callback should return 'pandoc' as default command):
+  setlocal noexpandtab
+  Assert
+  \ ale#fixers#pandoc#Fix(bufnr('')).command =~# '^' . ale#Escape('pandoc'),
+  \ "Default command name is expected to be 'pandoc'"
+
+Execute(The pandoc executable and options should be configurable):
+  let g:ale_markdown_pandoc_executable = 'foobar'
+  let g:ale_markdown_pandoc_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('foobar')
+  \     . ' --some-option',
+  \ },
+  \ ale#fixers#pandoc#Fix(bufnr(''))


### PR DESCRIPTION
Utilize pandoc to fix markdown files, currently set to Github-Flavored
Markdown, but that can be changed by setting,
ale_markdown_pandoc_options.
