### PR TITLE
Add nixfmt as a Nix fixer.

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -406,6 +406,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['ada'],
 \       'description': 'Format Ada files with gnatpp.',
 \   },
+\   'nixfmt': {
+\       'function': 'ale#fixers#nixfmt#Fix',
+\       'suggested_filetypes': ['nix'],
+\       'description': 'A nix formatter written in Haskell.',
+\   },
 \   'nixpkgs-fmt': {
 \       'function': 'ale#fixers#nixpkgsfmt#Fix',
 \       'suggested_filetypes': ['nix'],

--- a/autoload/ale/fixers/nixfmt.vim
+++ b/autoload/ale/fixers/nixfmt.vim
@@ -1,0 +1,16 @@
+scriptencoding utf-8
+" Author: houstdav000 <houstdav000@gh0st.sh>
+" Description: Fix files with nixfmt
+
+call ale#Set('nix_nixfmt_executable', 'nixfmt')
+call ale#Set('nix_nixfmt_options', '')
+
+function! ale#fixers#nixfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'nix_nixfmt_executable')
+    let l:options = ale#Var(a:buffer, 'nix_nixfmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (empty(l:options) ? '': ' ' . l:options),
+    \}
+endfunction

--- a/autoload/ale/fixers/nixfmt.vim
+++ b/autoload/ale/fixers/nixfmt.vim
@@ -10,7 +10,6 @@ function! ale#fixers#nixfmt#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'nix_nixfmt_options')
 
     return {
-    \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '': ' ' . l:options),
+    \   'command': ale#Escape(l:executable) . ale#Pad(l:options),
     \}
 endfunction

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -3,6 +3,24 @@ ALE Nix Integration                                           *ale-nix-options*
 
 
 ===============================================================================
+nixfmt                                                         *ale-nix-nixfmt*
+
+g:ale_nix_nixfmt_executable                       *g:ale_nix_nixfmt_executable*
+                                                  *b:ale_nix_nixfmt_executable*
+  Type: String
+  Default: 'nixfmt'
+
+  This variable sets the executable used for nixfmt.
+
+g:ale_nix_nixfmt_options                             *g:ale_nix_nixfmt_options*
+                                                     *b:ale_nix_nixfmt_options*
+  Type: String
+  Default: ''
+
+  This variable can be set to pass additional options to the nixfmt fixer.
+
+
+===============================================================================
 nixpkgs-fmt                                                 *ale-nix-nixpkgs-fmt*
 
 g:ale_nix_nixpkgsfmt_executable                *g:ale_nix_nixpkgsfmt_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -319,6 +319,7 @@ Notes:
   * `nimpretty`
 * nix
   * `nix-instantiate`
+  * `nixfmt`
   * `nixpkgs-fmt`
   * `rnix-lsp`
 * nroff

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2859,6 +2859,7 @@ documented in additional help files.
     nimlsp................................|ale-nim-nimlsp|
     nimpretty.............................|ale-nim-nimpretty|
   nix.....................................|ale-nix-options|
+    nixfmt................................|ale-nix-nixfmt|
     nixpkgs-fmt...........................|ale-nix-nixpkgs-fmt|
   nroff...................................|ale-nroff-options|
     write-good............................|ale-nroff-write-good|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -328,6 +328,7 @@ formatting.
   * nimpretty
 * nix
   * [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate)
+  * [nixfmt](https://github.com/serokell/nixfmt)
   * [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)
   * [rnix-lsp](https://github.com/nix-community/rnix-lsp)
 * nroff

--- a/test/fixers/test_nixfmt_fixer_callback.vader
+++ b/test/fixers/test_nixfmt_fixer_callback.vader
@@ -1,0 +1,24 @@
+Before:
+  Save g:ale_nix_nixfmt_executable
+  Save g:ale_nix_nixfmt_options
+
+After:
+  Restore
+
+Execute(The nixfmt callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('nixfmt')
+  \ },
+  \ ale#fixers#nixfmt#Fix(bufnr(''))
+
+Execute(The nixfmt executable and options should be configurable):
+  let g:ale_nix_nixfmt_executable = '/path/to/nixfmt'
+  let g:ale_nix_nixfmt_options = '--help'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/nixfmt')
+  \     . ' --help',
+  \ },
+  \ ale#fixers#nixfmt#Fix(bufnr(''))


### PR DESCRIPTION
Adds `nixfmt` as an available fixer for the Nix language.

Implementation based on that of `nixpkgs-fmt`.

Tested and working on Neovim 0.4.4.

Closes #3650 