### PR TITLE
Add support for `ptop` fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -430,6 +430,11 @@ let s:default_registry = {
 \       'function': 'ale#fixers#ormolu#Fix',
 \       'suggested_filetypes': ['haskell'],
 \       'description': 'A formatter for Haskell source code.',
+\   },
+\   'ptop': {
+\       'function': 'ale#fixers#ptop#Fix',
+\       'suggested_filetypes': ['pascal'],
+\       'description': 'Fix Pascal files with ptop.',
 \   }
 \}
 

--- a/autoload/ale/fixers/ptop.vim
+++ b/autoload/ale/fixers/ptop.vim
@@ -11,7 +11,7 @@ function! ale#fixers#ptop#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' %t %t',
+    \       . ' %s %t',
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/autoload/ale/fixers/ptop.vim
+++ b/autoload/ale/fixers/ptop.vim
@@ -1,0 +1,17 @@
+" Author: BarrOff https://github.com/BarrOff
+" Description: Integration of ptop with ALE.
+
+call ale#Set('pascal_ptop_executable', 'ptop')
+call ale#Set('pascal_ptop_options', '')
+
+function! ale#fixers#ptop#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'pascal_ptop_executable')
+    let l:options = ale#Var(a:buffer, 'pascal_ptop_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' %t %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-pascal.txt
+++ b/doc/ale-pascal.txt
@@ -1,0 +1,24 @@
+===============================================================================
+ALE Pascal Integration                                     *ale-pascal-options*
+
+===============================================================================
+ptop                                                          *ale-pascal-ptop*
+
+g:ale_pascal_ptop_executable                     *g:ale_pascal_ptop_executable*
+                                                 *b:ale_pascal_ptop_executable*
+  Type: |String|
+  Default: `'ptop'`
+
+  This variable can be changed to specify the ptop executable.
+
+
+g:ale_pascal_ptop_options                           *g:ale_pascal_ptop_options*
+                                                    *b:ale_pascal_ptop_options*
+  Type: |String|
+  Default: `''`
+
+This variable can be set to pass additional options to the ptop fixer.
+
+
+===============================================================================
+vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -344,6 +344,8 @@ Notes:
   * `ibm_validator`
   * `prettier`
   * `yamllint`
+* Pascal
+  * `ptop`
 * Pawn
   * `uncrustify`
 * Perl

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2881,6 +2881,8 @@ documented in additional help files.
     ibm_validator.........................|ale-openapi-ibm-validator|
     prettier..............................|ale-openapi-prettier|
     yamllint..............................|ale-openapi-yamllint|
+  pascal..................................|ale-pascal-options|
+    ptop..................................|ale-pascal-ptop|
   pawn....................................|ale-pawn-options|
     uncrustify............................|ale-pawn-uncrustify|
   perl....................................|ale-perl-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -353,6 +353,8 @@ formatting.
   * [ibm_validator](https://github.com/IBM/openapi-validator)
   * [prettier](https://github.com/prettier/prettier)
   * [yamllint](https://yamllint.readthedocs.io/)
+* Pascal
+  * [ptop](https://www.freepascal.org/tools/ptop.var)
 * Pawn
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * Perl

--- a/test/fixers/test_ptop_fixer_callback.vader
+++ b/test/fixers/test_ptop_fixer_callback.vader
@@ -20,7 +20,7 @@ Execute(The ptop callback should return the correct default values):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' %t %t',
+  \     . ' %s %t',
   \ },
   \ ale#fixers#ptop#Fix(bufnr(''))
 
@@ -33,6 +33,6 @@ Execute(The ptop callback should include custom ptop options):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
   \     . ' ' . g:ale_pascal_ptop_options
-  \     . ' %t %t',
+  \     . ' %s %t',
   \ },
   \ ale#fixers#ptop#Fix(bufnr(''))

--- a/test/fixers/test_ptop_fixer_callback.vader
+++ b/test/fixers/test_ptop_fixer_callback.vader
@@ -1,0 +1,38 @@
+Before:
+  Save g:ale_pascal_ptop_executable
+  Save g:ale_pascal_ptop_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_pascal_ptop_executable = 'xxxinvalid'
+  let g:ale_pascal_ptop_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The ptop callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/pascal/test.pas')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' %t %t',
+  \ },
+  \ ale#fixers#dfmt#Fix(bufnr(''))
+
+Execute(The ptop callback should include custom ptop options):
+  let g:ale_pascal_ptop_options = "-i 2"
+  call ale#test#SetFilename('../test-files/pascal/test.pas')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' ' . g:ale_pascal_ptop_options
+  \     . ' %t %t',
+  \ },
+  \ ale#fixers#dfmt#Fix(bufnr(''))

--- a/test/fixers/test_ptop_fixer_callback.vader
+++ b/test/fixers/test_ptop_fixer_callback.vader
@@ -22,7 +22,7 @@ Execute(The ptop callback should return the correct default values):
   \   'command': ale#Escape('xxxinvalid')
   \     . ' %t %t',
   \ },
-  \ ale#fixers#dfmt#Fix(bufnr(''))
+  \ ale#fixers#ptop#Fix(bufnr(''))
 
 Execute(The ptop callback should include custom ptop options):
   let g:ale_pascal_ptop_options = "-i 2"
@@ -35,4 +35,4 @@ Execute(The ptop callback should include custom ptop options):
   \     . ' ' . g:ale_pascal_ptop_options
   \     . ' %t %t',
   \ },
-  \ ale#fixers#dfmt#Fix(bufnr(''))
+  \ ale#fixers#ptop#Fix(bufnr(''))


### PR DESCRIPTION
As the title says, this PR adds support for [ptop](https://www.freepascal.org/tools/ptop.var), a Pascal fixer and part of the [freepascal](https://www.freepascal.org/) project.