### PR TITLE
feat(golangci-lint): add ale_go_golangci_lint_show_current_only option

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -4,6 +4,7 @@
 call ale#Set('go_golangci_lint_options', '--enable-all')
 call ale#Set('go_golangci_lint_executable', 'golangci-lint')
 call ale#Set('go_golangci_lint_package', 0)
+call ale#Set('go_golangci_lint_show_current_only', 0)
 
 function! ale_linters#go#golangci_lint#GetCommand(buffer) abort
     let l:filename = expand('#' . a:buffer . ':t')
@@ -30,10 +31,17 @@ function! ale_linters#go#golangci_lint#GetMatches(lines) abort
 endfunction
 
 function! ale_linters#go#golangci_lint#Handler(buffer, lines) abort
+    let l:filename = expand('#' . a:buffer . ':t')
     let l:dir = expand('#' . a:buffer . ':p:h')
     let l:output = []
+    let l:current_only = ale#Var(a:buffer, 'go_golangci_lint_show_current_only')
 
     for l:match in ale_linters#go#golangci_lint#GetMatches(a:lines)
+        " skip lint message of other files
+        if l:current_only && l:match[1] != l:filename
+            continue
+        endif
+
         " l:match[1] will already be an absolute path, output from
         " golangci_lint
         call add(l:output, {

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -112,6 +112,12 @@ g:ale_go_golangci_lint_package                 *g:ale_go_golangci_lint_package*
   When set to `1`, the whole Go package will be checked instead of only the
   current file.
 
+g:ale_go_golangci_lint_show_current_only       *g:ale_go_golangci_lint_show_current_only*
+                                               *b:ale_go_golangci_lint_show_current_only*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, only show lint result of the current file
 
 ===============================================================================
 golangserver                                              *ale-go-golangserver*


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

related issue: https://github.com/dense-analysis/ale/issues/2339

`golangci-lint` can not lint single file (ale default option is lint single file) if `a.go` depends on `b.go`, it will result in `golangci-lint` exited with non zero error code and no lint message got output.

so the solution is `let g:ale_go_golangci_lint_package = 1`, but in this condition, 

ale will show all lint messages including messages not related to the current file, this is in most case, not what we want.

so I'm here, add an `ale_go_golangci_lint_show_current_only` option to allow filter out lint messages of other files, and left the right messages of the current file.

since golangci-lint does not support actually `exclude` other files from lint:

>  Golangci-lint exclude mechanism differs from the gometalinter's one: we don't handle file path excluding by --exclude: this option excludes only by a message text. But golangci-lint can exclude by file path by skip-files.

>    As I understand the goal is to analyze an only one file. If we run golangci-lint on one file we can get compilation errors. I think a more convenient way is to fix this behavior: if a user requested an analysis of one fil
e we need to load a full package but report errors only from this file. The simplest way to implement it is:

>    replace single files by their packages
>    make a Include processor and filter messages for such packages

Refs: https://github.com/golangci/golangci-lint/issues/420

current situation:

with `let g:ale_go_golangci_lint_package = 1` :

![2021-03-30_11-39](https://user-images.githubusercontent.com/41882455/112931157-2d64f600-914e-11eb-841a-6922d9626974.png)

after `let g:ale_go_golangci_lint_show_current_only = 1` (this PR)

![2021-03-30_11-41](https://user-images.githubusercontent.com/41882455/112931184-381f8b00-914e-11eb-9113-455455ae1093.png)
