### PR TITLE
Fix `ale_sign_column_always` for Neovim 0.5

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -354,10 +354,17 @@ function! ale#sign#GetSignCommands(buffer, was_sign_set, sign_map) abort
     let l:command_list = []
     let l:is_dummy_sign_set = a:was_sign_set
 
+    " Neovim 0.5 changed the way the sign column behaves.
+    " See this commit for more details:
+    " https://github.com/neovim/neovim/commit/88ae03bcdb8992fd91a3efdb61dbd7e2aa395eff
+    if has('nvim-0.5') && g:ale_sign_column_always &&
+    \  ! getbufvar(a:buffer, 'ale_nvim_05_sign_fixed', v:false)
+        setlocal signcolumn=yes:1
+        let b:ale_nvim_05_sign_fixed=v:true
     " Set the dummy sign if we need to.
     " The dummy sign is needed to keep the sign column open while we add
     " and remove signs.
-    if !l:is_dummy_sign_set && (!empty(a:sign_map) || g:ale_sign_column_always)
+    elseif !l:is_dummy_sign_set && (!empty(a:sign_map) || g:ale_sign_column_always)
         call add(l:command_list, 'sign place '
         \   .  g:ale_sign_offset
         \   . s:GroupCmd()

--- a/run-tests
+++ b/run-tests
@@ -12,7 +12,13 @@ set -u
 image=denseanalysis/ale
 
 # Create docker image tag based on Dockerfile contents
-image_tag=$(md5sum Dockerfile | cut -d' ' -f1)
+if command -v md5sum >/dev/null 2>&1
+then
+    image_tag=$(md5sum Dockerfile | cut -d' ' -f1)
+else
+    image_tag=$(md5 -q Dockerfile | cut -d' ' -f1)
+fi
+
 git_version=$(git describe --always --tags)
 
 # Used in all test scripts for running the selected Docker image.


### PR DESCRIPTION
Neovim 0.5 (not yet released) changes the behavior of the sign column such that (quoting from the relevant commit):
> If all signs of the same group have no width, the signcolumn will not be rendered for that group.

See the following for more details: 
1. [The commit that introduced this change](https://github.com/neovim/neovim/commit/88ae03bcdb8992fd91a3efdb61dbd7e2aa395eff)
2. [This GitHub issue](https://github.com/neovim/neovim/issues/13635) where I (unsuccesfully) tried to argue that this was more of a bug than a feature.

What this means for ALE is that unfortunately `ale_sign_column_always` stopped working – the sign column would collapse when there were no warnings/errors, just like the default behavior. This pull request fixes that.

In addition I made a small, unrelated fix to `run-tests`, which wasn't working on my machine because I only have the `md5` tool and not `md5sum`. The fix ensures that `md5` is used if `md5sum` does not exist, to make the script even more portable.