### PR TITLE
hadolint: multiple fixes and adapt expected format

### DIFF
--- a/ale_linters/dockerfile/hadolint.vim
+++ b/ale_linters/dockerfile/hadolint.vim
@@ -7,7 +7,7 @@ call ale#Set('dockerfile_hadolint_docker_image', 'hadolint/hadolint')
 function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
     " Matches patterns line the following:
     "
-    " /dev/stdin:19 DL3001 Pipe chain should start with a raw value.
+    " -:19 DL3001 warning: Pipe chain should start with a raw value.
     " /dev/stdin:19:3 unexpected thing
     let l:pattern = '\v^%(/dev/stdin|-):(\d+):?(\d+)? ((DL|SC)(\d+) )?((.+)?: )?(.+)$'
     let l:output = []
@@ -38,6 +38,8 @@ function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
         let l:text = l:match[8]
         let l:detail = l:match[8]
         let l:domain = 'https://github.com/hadolint/hadolint/wiki/'
+        let l:code = ''
+        let l:link = ''
 
         if l:match[4] is# 'SC'
             let l:domain = 'https://github.com/koalaman/shellcheck/wiki/'
@@ -46,9 +48,11 @@ function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
         if l:match[5] isnot# ''
             let l:code = l:match[4] . l:match[5]
             let l:link = ' ( ' . l:domain . l:code . ' )'
+            let l:text = l:code . ': ' . l:detail
             let l:detail = l:code . l:link . "\n\n" . l:detail
         else
             let l:type = 'E'
+            let l:detail = 'hadolint could not parse the file because of a syntax error.'
         endif
 
         call add(l:output, {

--- a/test/handler/test_hadolint.vader
+++ b/test/handler/test_hadolint.vader
@@ -16,34 +16,41 @@ Execute(The hadolint handler should handle a normal example):
   \     'lnum': 1,
   \     'col': 0,
   \     'type': 'W',
-  \     'text': "Always tag the version of an image explicitly",
+  \     'text': "DL3006: Always tag the version of an image explicitly",
   \     'detail': "DL3006 ( https://github.com/hadolint/hadolint/wiki/DL3006 )\n\nAlways tag the version of an image explicitly",
   \   },
-#  \   {
-#  \     'lnum': 2,
-#  \     'col': 0,
-#  \     'type': 'E',
-#  \     'text': "MAINTAINER is deprecated",
-#  \     'detail': "DL4000 ( https://github.com/hadolint/hadolint/wiki/DL4000 )\n\nMAINTAINER is deprecated",
-#  \   },
-#  \   {
-#  \     'lnum': 4,
-#  \     'col': 0,
-#  \     'type': 'W',
-#  \     'text': "Specify version with `yum install -y <package>-<version>`.",
-#  \     'detail': "DL3033 ( https://github.com/hadolint/hadolint/wiki/DL3033 )\n\nSpecify version with `yum install -y <package>-<version>`.",
-#  \   },
-#  \   {
-#  \     'lnum': 12,
-#  \     'col': 0,
-#  \     'type': 'W',
-#  \     'text': "In POSIX sh, brace expansion is undefined.",
-#  \     'detail': "SC2039 ( https://github.com/koalaman/shellcheck/wiki/SC2039 )\n\nIn POSIX sh, brace expansion is undefined.",
-#  \   },
+  \   {
+  \     'lnum': 4,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': "DL3033: Specify version with `yum install -y <package>-<version>`.",
+  \     'detail': "DL3033 ( https://github.com/hadolint/hadolint/wiki/DL3033 )\n\nSpecify version with `yum install -y <package>-<version>`.",
+  \   },
+  \   {
+  \     'lnum': 12,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': "SC2039: In POSIX sh, brace expansion is undefined.",
+  \     'detail': "SC2039 ( https://github.com/koalaman/shellcheck/wiki/SC2039 )\n\nIn POSIX sh, brace expansion is undefined.",
+  \   },
   \ ],
   \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
-  \ '/dev/stdin:1 DL3006 warning: Always tag the version of an image explicitly',
-#  \ '/dev/stdin:2 DL4000 error: MAINTAINER is deprecated',
-#  \ '/dev/stdin:4 DL3033 warning: Specify version with `yum install -y <package>-<version>`.',
-#  \ '/dev/stdin:12 SC2039 warning: In POSIX sh, brace expansion is undefined.'
+  \ '-:1 DL3006 warning: Always tag the version of an image explicitly',
+  \ '-:4 DL3033 warning: Specify version with `yum install -y <package>-<version>`.',
+  \ '-:12 SC2039 warning: In POSIX sh, brace expansion is undefined.',
+  \ ])
+
+Execute(The hadolint handler should handle parsing errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': "unexpected 'b' expecting '#', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, or end of input",
+  \     'detail': "hadolint could not parse the file because of a syntax error.",
+  \   },
+  \ ],
+  \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
+  \ '/dev/stdin:1:1 unexpected ''b'' expecting ''#'', ADD, ARG, CMD, COPY, ENTRYPOINT, ENV, EXPOSE, FROM, HEALTHCHECK, LABEL, MAINTAINER, ONBUILD, RUN, SHELL, STOPSIGNAL, USER, VOLUME, WORKDIR, or end of input',
   \ ])

--- a/test/test_dockerfile_hadolint_linter.vader
+++ b/test/test_dockerfile_hadolint_linter.vader
@@ -68,21 +68,21 @@ Execute(command is correct when not docker):
 
 Execute(test warnings from hadolint):
   AssertEqual
-  \ [{'lnum': 10, 'col': 0, 'type': 'W', 'text': 'Using latest is prone to errors', 'detail': "DL3007 ( https://github.com/hadolint/hadolint/wiki/DL3007 )\n\nUsing latest is prone to errors"}],
+  \ [{'lnum': 10, 'col': 0, 'type': 'W', 'text': 'DL3007: Using latest is prone to errors', 'detail': "DL3007 ( https://github.com/hadolint/hadolint/wiki/DL3007 )\n\nUsing latest is prone to errors"}],
   \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
-  \ '/dev/stdin:10 DL3007 warning: Using latest is prone to errors',
+  \ '-:10 DL3007 warning: Using latest is prone to errors',
   \ ])
 
 Execute(test warnings from shellcheck):
   AssertEqual
-  \ [{'lnum': 3, 'col': 0, 'type': 'W', 'text': 'bar is referenced but not assigned.', 'detail': "SC2154 ( https://github.com/koalaman/shellcheck/wiki/SC2154 )\n\nbar is referenced but not assigned."}],
+  \ [{'lnum': 3, 'col': 0, 'type': 'W', 'text': 'SC2154: bar is referenced but not assigned.', 'detail': "SC2154 ( https://github.com/koalaman/shellcheck/wiki/SC2154 )\n\nbar is referenced but not assigned."}],
   \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
-  \ '/dev/stdin:3 SC2154 warning: bar is referenced but not assigned.',
+  \ '-:3 SC2154 warning: bar is referenced but not assigned.',
   \ ])
 
 Execute(test errors from dockerfile parser):
   AssertEqual
-  \ [{'lnum': 3, 'col': 4, 'type': 'E', 'text': 'unexpected "A" expecting at least one space after ''RUN''', 'detail': 'unexpected "A" expecting at least one space after ''RUN'''}],
+  \ [{'lnum': 3, 'col': 4, 'type': 'E', 'text': 'unexpected "A" expecting at least one space after ''RUN''', 'detail': 'hadolint could not parse the file because of a syntax error.'}],
   \ ale_linters#dockerfile#hadolint#Handle(bufnr(''), [
   \ "/dev/stdin:3:4 unexpected \"A\" expecting at least one space after 'RUN'",
   \ ])


### PR DESCRIPTION
- Disable color output, so severity detection works again
- Match on the correct filename
- Show hadolint rule number in vim gutter in addition to `ALEDetails`
- Capture and show error in case of syntax errors
- Add tests for error capture
- Adapt existing tests

39d22ad changed the file name, when reading from stdin from `/dev/stdin`
to `-`. This broke integration with ALE.
c00fc5c colorized the output to tty by default and added the flag
`--no-color` to disable it again. This broke detecting issue severity.

fixes: #2333
fixes: #958