### PR TITLE
PHPStan: Add support for multiline messages

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -31,8 +31,8 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     \   : ''
 
     let l:error_format = ale#semver#GTE(a:version, [0, 10, 3])
-    \   ? ' --error-format raw'
-    \   : ' --errorFormat raw'
+    \   ? ' --error-format json'
+    \   : ' --errorFormat json'
 
     return '%e analyze --no-progress'
     \   . l:error_format
@@ -43,17 +43,17 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
 endfunction
 
 function! ale_linters#php#phpstan#Handle(buffer, lines) abort
-    " Matches against lines like the following:
-    "
-    " filename.php:15:message
-    " C:\folder\filename.php:15:message
-    let l:pattern = '^\([a-zA-Z]:\)\?[^:]\+:\(\d\+\):\(.*\)$'
+    let l:res = ale#util#FuzzyJSONDecode(a:lines, {'files': []})
     let l:output = []
 
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+    if type(l:res.files) is v:t_list
+        return l:output
+    endif
+
+    for l:err in l:res.files[expand('#' . a:buffer .':p')].messages
         call add(l:output, {
-        \   'lnum': l:match[2] + 0,
-        \   'text': l:match[3],
+        \   'lnum': l:err.line,
+        \   'text': l:err.message,
         \   'type': 'E',
         \})
     endfor

--- a/test/handler/test_phpstan_handler.vader
+++ b/test/handler/test_phpstan_handler.vader
@@ -14,7 +14,9 @@ Execute(Output without errors should be parsed correctly):
 
   AssertEqual
   \ [],
-  \ ale_linters#php#phpstan#Handle(bufnr(''), [])
+  \ ale_linters#php#phpstan#Handle(bufnr(''), [
+  \ '{"totals":{"errors":0,"file_errors":0},"files":[],"errors":[]}',
+  \ ])
 
 Execute(Output with some errors should be parsed correctly):
   call ale#test#SetFilename('phpstan-test-files/foo/test.php')
@@ -37,38 +39,13 @@ Execute(Output with some errors should be parsed correctly):
   \     'type': 'E'
   \   }
   \ ],
-  \ ale_linters#php#phpstan#Handle(bufnr(''), [
-  \   'phpstan-test-files/foo/test.php:9:Call to method format() on an unknown class DateTimeImutable.',
-  \   'phpstan-test-files/foo/test.php:16:Sample message.',
-  \   'phpstan-test-files/foo/test.php:192:Invalid command testCommand.',
-  \])
-
-Execute(Output should be parsed correctly with Windows paths):
-  call ale#test#SetFilename('phpstan-test-files/foo/test.php')
-
-  AssertEqual
-  \ [
-  \   {
-  \     'lnum': 9,
-  \     'text': 'Access to an undefined property Test::$var.',
-  \     'type': 'E'
-  \   }
-  \ ],
-  \ ale_linters#php#phpstan#Handle(bufnr(''), [
-  \   'D:\phpstan-test-files\foo\test.php:9:Access to an undefined property Test::$var.',
-  \])
-
-Execute(Output for .inc files should be parsed correctly):
-  call ale#test#SetFilename('phpstan-test-files/test.inc')
-
-  AssertEqual
-  \ [
-  \   {
-  \     'lnum': 9,
-  \     'text': 'Access to an undefined property Test::$var.',
-  \     'type': 'E'
-  \   }
-  \ ],
-  \ ale_linters#php#phpstan#Handle(bufnr(''), [
-  \   '/phpstan-test-files/foo/test.inc:9:Access to an undefined property Test::$var.',
-  \])
+  \ ale_linters#php#phpstan#Handle(bufnr(''), [json_encode(
+  \ {
+  \     "totals":{"errors": 0, "file_errors": 11},
+  \     "files":{expand('%:p'): {"errors": 3, "messages": [
+  \         {"message": "Call to method format() on an unknown class DateTimeImutable.", "line":9},
+  \         {"message": "Sample message.", "line":16},
+  \         {"message": "Invalid command testCommand.", "line": 192}
+  \     ]}}
+  \ },
+  \)])

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -25,27 +25,27 @@ Execute(Custom executables should be used for the executable and command):
   let g:ale_php_phpstan_executable = 'phpstan_test'
 
   AssertLinter 'phpstan_test',
-  \ ale#Escape('phpstan_test') . ' analyze --no-progress --errorFormat raw -l ' . ale#Escape('4') . ' %s'
+  \ ale#Escape('phpstan_test') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' %s'
 
 Execute(project with level set to 3):
   call ale#test#SetFilename('phpstan-test-files/foo/test.php')
   let g:ale_php_phpstan_level = 3
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -l ' . ale#Escape('3') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('3') . ' %s'
 
 Execute(Custom phpstan configuration file):
   let g:ale_php_phpstan_configuration = 'phpstan_config'
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -c ' . ale#Escape('phpstan_config') . ' -l ' . ale#Escape('4') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -c ' . ale#Escape('phpstan_config') . ' -l ' . ale#Escape('4') . ' %s'
 
 Execute(Choose the right format for error format param):
   GivenCommandOutput ['0.10.3']
 
   AssertLinter 'phpstan', [
   \ ale#Escape('phpstan') . ' --version',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --error-format raw -l ' . ale#Escape('4') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --error-format json -l ' . ale#Escape('4') . ' %s'
   \ ]
 
 Execute(Configuration file exists in current directory):
@@ -55,7 +55,7 @@ Execute(Configuration file exists in current directory):
 
   AssertLinter 'phpstan', [
   \ ale#Escape('phpstan') . ' --version',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json %s'
   \ ]
 
 Execute(Configuration file exists in current directory, but force phpstan level):
@@ -65,7 +65,7 @@ Execute(Configuration file exists in current directory, but force phpstan level)
 
   AssertLinter 'phpstan', [
   \ ale#Escape('phpstan') . ' --version',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -l ' . ale#Escape('7') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('7') . ' %s'
   \ ]
 
 Execute(Configuration file exists in current directory, but force phpstan configuration):
@@ -75,11 +75,11 @@ Execute(Configuration file exists in current directory, but force phpstan config
 
   AssertLinter 'phpstan', [
   \ ale#Escape('phpstan') . ' --version',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -c ' . ale#Escape('phpstan.custom.neon') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -c ' . ale#Escape('phpstan.custom.neon') . ' %s'
   \ ]
 
 Execute(Autoload parameter is added to the command):
   let g:ale_php_phpstan_autoload = 'autoload.php'
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw -a ' . ale#Escape('autoload.php') . ' -l ' . ale#Escape('4') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -a ' . ale#Escape('autoload.php') . ' -l ' . ale#Escape('4') . ' %s'


### PR DESCRIPTION
When using PHPStan, you might get multiline messages in some cases:

```
/home/greg/dev/doctrine-migrations/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php:83:Fetching class constant class of deprecated class Doctrine\DBAL\Connections\MasterSlaveConnection:
Use PrimaryReadReplicaConnection instead
/home/greg/dev/doctrine-migrations/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php:200:Instantiation of deprecated class Doctrine\DBAL\Driver\PDOSqlite\Driver:
Use {@link PDO\SQLite\Driver} instead.
/home/greg/dev/doctrine-migrations/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php:77:Call to method compare() of deprecated class Doctrine\DBAL\Version:
Refrain from checking the DBAL version at runtime.
```

Without this patch, the messages get truncated and you only get the first line, so just `Instantiation of deprecated class Doctrine\DBAL\Driver\PDOSqlite\Driver:`

With it, you can get the whole message. (`Instantiation of deprecated class Doctrine\DBAL\Driver\PDOSqlite\Driver:
Use {@link PDO\SQLite\Driver} instead.`)

This is achieved by switching to JSON, which makes it much easier to
avoid confusion between an error message and the next one. It also
spares us from having to deal with regular expressions, and eliminates
some edge cases that no longer need to be tested.