### PR TITLE
Replace new-line characters in incomming linting messages

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -285,9 +285,12 @@ function! ale#engine#FixLocList(buffer, linter_name, from_other_source, loclist)
         "
         " The linter_name will be set on the errors so it can be used in
         " output, filtering, etc..
+        if !exists('g:ale_other_source_text_line_separator')
+            let g:ale_other_source_text_line_separator = ': '
+        endif
         let l:item = {
         \   'bufnr': a:buffer,
-        \   'text': l:old_item.text,
+        \   'text': substitute(l:old_item.text, '\n', g:ale_other_source_text_line_separator, 'g'),
         \   'lnum': str2nr(l:old_item.lnum),
         \   'col': str2nr(get(l:old_item, 'col', 0)),
         \   'vcol': 0,

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -310,6 +310,8 @@ A plugin might integrate its own checks with ALE like so: >
     call ale#other_source#ShowResults(a:buffer, 'some-name', a:results)
   endfunction
 <
+The |g:ale_other_source_text_line_separator| is used as the replacement for
+the new-line characters in the incomming linting messages.
 
 ===============================================================================
 4. Fixing Problems                                                    *ale-fix*
@@ -1810,6 +1812,16 @@ g:ale_open_list                                               *g:ale_open_list*
     autocmd QuitPre * if empty(&buftype) | lclose | endif
   augroup END
 <
+
+g:ale_other_source_text_line_separator     *g:other_source_text_line_separator*
+
+  Type: |String|
+  Default: `': '`
+
+  Substitution string used to replace the new-line character in linting
+  messages incomming from |ale-lint-other-sources|. The format of the string
+  corresponds to that of {sub} parameteer used by |substitute()| function.
+
 
 g:ale_pattern_options                                   *g:ale_pattern_options*
 


### PR DESCRIPTION
This is to fix diagnostic messages from CoC, which do contain new-line
characters and these are displayed as `^@` by ALE. This commit adds code
that substitutes those new-line characters by string set by the user
 (or `": "` by default).

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
