### PR TITLE
Don't exit visual mode on floating preview close

### DIFF
--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -113,6 +113,9 @@ function! s:Create(options) abort
 endfunction
 
 function! s:Close() abort
+    let l:mode = mode()
+    let l:restore_visual = l:mode is# 'v' || l:mode is# 'V' || l:mode is# "\<C-V>"
+
     if !exists('w:preview')
         return
     endif
@@ -124,4 +127,8 @@ function! s:Close() abort
     endif
 
     unlet w:preview
+
+    if l:restore_visual
+        normal! gv
+    endif
 endfunction


### PR DESCRIPTION
As reported in #3584, the floating preview doesn't interact properly with visual modes. Because the window creation is a new command, it exits visual mode in the process. This PR checks to see if visual mode was in use before and then restores it after the fact if so.

Unfortunately I wasn't able to add tests for this fix. Support for visual mode handling doesn't *appear* to exist in vader. Since there's no change in buffer input, that doesn't seem to be a viable strategy either. Existing preview tests do pass (though they're stubbing out a lot of the actual functionality).

I've been living on this branch for a couple of weeks with success and another respondent on the issue verifies the fix as well.