### PR TITLE
Use execute instead of redir because redir cannot be used inside execute

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -171,10 +171,8 @@ endfunction
 
 " Read sign data for a buffer to a list of lines.
 function! ale#sign#ReadSigns(buffer) abort
-    redir => l:output
-        silent execute 'sign place ' . s:GroupCmd() . s:PriorityCmd()
-        \ . ' buffer=' . a:buffer
-    redir end
+    let l:output = execute('sign place ' . s:GroupCmd() . s:PriorityCmd()
+    \ . ' buffer=' . a:buffer, 'silent')
 
     return split(l:output, "\n")
 endfunction


### PR DESCRIPTION
Use execute instead of redir because redir cannot be used inside execute.


```
Error detected while processing function plum#Plum[9]..<lambda>6654[1]..plum#fso#Act[18]..plum#layout#Open[4]..<lambda>6690[1]..BufWinEnter Autocommands for "*"..function ale#events#LintOnEnter[5]..ale#Queue[33]..<SNR>51_Lint[20]..ale#engine#RunLinters[4]..<SNR>67_GetLintFileValues[27]..<lambda>6692[1]..<SNR>67_RunLi
nters[32]..ale#engine#SetResults[6]..ale#sign#SetSigns[8]..ale#sign#FindCurrentSigns[1]..ale#sign#ReadSigns:
line    1:
E930: Cannot use :redir inside execute()
Error detected while processing function plum#Plum[9]..<lambda>6654[1]..plum#fso#Act[18]..plum#layout#Open[4]..<lambda>6690[1]..BufWinEnter Autocommands for "*"..function ale#events#LintOnEnter[5]..ale#Queue[33]..<SNR>51_Lint[20]..ale#engine#RunLinters[4]..<SNR>67_GetLintFileValues[27]..<lambda>6692[1]..<SNR>67_RunLi
nters[32]..ale#engine#SetResults[6]..ale#sign#SetSigns:
line    8:
E714: List required
```


