### PR TITLE
Fixes an index error with Java files.

### DIFF
--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -132,7 +132,7 @@ function! ale_linters#java#javac#Handle(buffer, lines) abort
 
     for l:match in ale#util#GetMatches(a:lines, [l:pattern, l:col_pattern, l:symbol_pattern])
         if empty(l:match[2]) && empty(l:match[3])
-            if !empty(l:match[1]) && !empty(l.output)
+            if !empty(l:match[1]) && !empty(l:output)
                 let l:output[-1].col = len(l:match[1])
             endif
         elseif empty(l:match[3])

--- a/ale_linters/java/javac.vim
+++ b/ale_linters/java/javac.vim
@@ -132,7 +132,9 @@ function! ale_linters#java#javac#Handle(buffer, lines) abort
 
     for l:match in ale#util#GetMatches(a:lines, [l:pattern, l:col_pattern, l:symbol_pattern])
         if empty(l:match[2]) && empty(l:match[3])
-            let l:output[-1].col = len(l:match[1])
+            if !empty(l:match[1]) && !empty(l.output)
+                let l:output[-1].col = len(l:match[1])
+            endif
         elseif empty(l:match[3])
             " Add symbols to 'cannot find symbol' errors.
             if l:output[-1].text is# 'error: cannot find symbol'


### PR DESCRIPTION
When loading a Java file into Vim an index error occurred in ale_linters#java#javac#Handle. I added empty checks and this resolved the issue for me. 
Please be aware that these were the first lines of Vim code I ever wrote. Hopefully I didn't mess it up.