### PR TITLE
ale-purescript docs update for Spago + purescript v0.14

### DIFF
--- a/doc/ale-purescript.txt
+++ b/doc/ale-purescript.txt
@@ -26,7 +26,7 @@ g:ale_purescript_ls_config                         g:ale_purescript_ls_config
 		\  'purescript': {
 		\    'addSpagoSources': v:true,
 		\    'addNpmPath': v:true,
-		\    'buildCommand': 'spago build -- --json-errors'
+		\    'buildCommand': 'spago --quiet build --purs-args --json-errors'
 		\  }
 		\}
 ===============================================================================


### PR DESCRIPTION
For Spago and purescript 0.14, the example in ale-purescript docs no longer works. This PR updates the example to conform with the new version.