### PR TITLE
Robot framework rflint support

### DIFF
--- a/ale_linters/robot/rflint.vim
+++ b/ale_linters/robot/rflint.vim
@@ -1,0 +1,57 @@
+" Author: Samuel Branisa <branisa.samuel@icloud.com>
+" Description: rflint linting for robot framework files
+
+call ale#Set('robot_rflint_executable', 'rflint')
+call ale#Set('robot_rflint_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('robot_rflint_auto_pipenv', 0)
+
+function! ale_linters#robot#rflint#GetExecutable(buffer) abort
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'robot_rflint_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
+    return ale#python#FindExecutable(a:buffer, 'robot_rflint', ['rflint'])
+endfunction
+
+function! ale_linters#robot#rflint#GetCommand(buffer) abort
+    let l:executable = ale_linters#robot#rflint#GetExecutable(a:buffer)
+    let l:flags = '--no-filenames --format'
+    \ . ' "{filename}:{severity}:{linenumber}:{char}:{rulename}:{message}"'
+
+    let l:exec_args = l:executable =~? 'pipenv$'
+    \   ? 'run rflint '
+    \   : ''
+
+    return l:executable
+    \   . ' '
+    \   . l:exec_args
+    \   . l:flags
+    \   . ' %s'
+endfunction
+
+function! ale_linters#robot#rflint#Handle(buffer, lines) abort
+    let l:pattern = '\v^([[:alnum:][:punct:]]+):(W|E):([[:digit:]]+):([[:digit:]]+):([[:alnum:]]+):(.*)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'bufnr': a:buffer,
+        \   'filename': l:match[1],
+        \   'type': l:match[2],
+        \   'lnum': str2nr(l:match[3]),
+        \   'col': str2nr(l:match[4]),
+        \   'text': l:match[5],
+        \   'detail': l:match[6],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('robot', {
+\   'name': 'rflint',
+\   'executable': function('ale_linters#robot#rflint#GetExecutable'),
+\   'command': function('ale_linters#robot#rflint#GetCommand'),
+\   'callback': 'ale_linters#robot#rflint#Handle',
+\})

--- a/ale_linters/robot/rflint.vim
+++ b/ale_linters/robot/rflint.vim
@@ -2,30 +2,18 @@
 " Description: rflint linting for robot framework files
 
 call ale#Set('robot_rflint_executable', 'rflint')
-call ale#Set('robot_rflint_use_global', get(g:, 'ale_use_global_executables', 0))
-call ale#Set('robot_rflint_auto_pipenv', 0)
 
 function! ale_linters#robot#rflint#GetExecutable(buffer) abort
-    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'robot_rflint_auto_pipenv'))
-    \ && ale#python#PipenvPresent(a:buffer)
-        return 'pipenv'
-    endif
-
-    return ale#python#FindExecutable(a:buffer, 'robot_rflint', ['rflint'])
+    return ale#Var(a:buffer, 'robot_rflint_executable')
 endfunction
 
 function! ale_linters#robot#rflint#GetCommand(buffer) abort
     let l:executable = ale_linters#robot#rflint#GetExecutable(a:buffer)
-    let l:flags = '--no-filenames --format'
+    let l:flags = '--format'
     \ . ' "{filename}:{severity}:{linenumber}:{char}:{rulename}:{message}"'
-
-    let l:exec_args = l:executable =~? 'pipenv$'
-    \   ? 'run rflint '
-    \   : ''
 
     return l:executable
     \   . ' '
-    \   . l:exec_args
     \   . l:flags
     \   . ' %s'
 endfunction
@@ -55,3 +43,4 @@ call ale#linter#Define('robot', {
 \   'command': function('ale_linters#robot#rflint#GetCommand'),
 \   'callback': 'ale_linters#robot#rflint#Handle',
 \})
+

--- a/doc/ale-robot.txt
+++ b/doc/ale-robot.txt
@@ -1,0 +1,16 @@
+===============================================================================
+ALE Robot Integration                                       *ale-robot-options*
+
+
+===============================================================================
+rflint                                                       *ale-robot-rflint*
+
+g:ale_robot_rflint_executable                   *g:ale_robot_rflint_executable*
+                                                *b:ale_robot_rflint_executable*
+  Type: |String|
+  Default: `'rflint'`
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:
+

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -439,6 +439,8 @@ Notes:
   * `textlint`
   * `vale`
   * `write-good`
+* Robot
+  * `rflint`
 * RPM spec
   * `rpmlint`
 * Ruby

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2964,6 +2964,8 @@ documented in additional help files.
   restructuredtext........................|ale-restructuredtext-options|
     textlint..............................|ale-restructuredtext-textlint|
     write-good............................|ale-restructuredtext-write-good|
+  robot...................................|ale-robot-options|
+    rflint................................|ale-robot-rflint|
   ruby....................................|ale-ruby-options|
     brakeman..............................|ale-ruby-brakeman|
     debride...............................|ale-ruby-debride|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -448,6 +448,8 @@ formatting.
   * [textlint](https://textlint.github.io/)
   * [vale](https://github.com/ValeLint/vale)
   * [write-good](https://github.com/btford/write-good)
+* Robot
+  * [rflint](https://github.com/boakley/robotframework-lint)
 * RPM spec
   * [rpmlint](https://github.com/rpm-software-management/rpmlint) :warning: (see `:help ale-integration-spec`)
 * Ruby

--- a/test/handler/test_rflint_handler.vader
+++ b/test/handler/test_rflint_handler.vader
@@ -1,0 +1,33 @@
+Before:
+  runtime ale_linters/robot/rflint.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(Warning and error messages should be handled correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'bufnr': 1,
+  \     'filename': 'test.robot',
+  \     'type': 'W',
+  \     'lnum': 1,
+  \     'col': 2,
+  \     'text': 'RequireSuiteDocumentation',
+  \     'detail': 'No suite documentation',
+  \   },
+  \   {
+  \     'bufnr': 1,
+  \     'filename': 'test.robot',
+  \     'type': 'E',
+  \     'lnum': 3,
+  \     'col': 4,
+  \     'text': 'RequireTestDocumentation',
+  \     'detail': 'No testcase documentation',
+  \   },
+  \ ],
+  \ ale_linters#robot#rflint#Handle(1, [
+  \   'test.robot:W:1:2:RequireSuiteDocumentation:No suite documentation',
+  \   'test.robot:E:3:4:RequireTestDocumentation:No testcase documentation'
+  \])
+

--- a/test/linter/test_rflint.vader
+++ b/test/linter/test_rflint.vader
@@ -1,0 +1,20 @@
+Before:
+  call ale#assert#SetUpLinterTest('robot', 'rflint')
+  let b:rflint_format = ' --format'
+  \ . ' "{filename}:{severity}:{linenumber}:{char}:{rulename}:{message}" %s'
+
+After:
+  call ale#assert#TearDownLinterTest()
+  unlet! b:rflint_format
+
+Execute(The rflint command callback should return default string):
+  AssertLinter 'rflint',
+  \ 'rflint'
+  \ . b:rflint_format
+
+Execute(The rflint executable should be configurable):
+  let g:ale_robot_rflint_executable = '~/.local/bin/rflint'
+
+  AssertLinter '~/.local/bin/rflint',
+  \ '~/.local/bin/rflint'
+  \ . b:rflint_format


### PR DESCRIPTION
Added support for [rflint](https://github.com/boakley/robotframework-lint), which is static syntax checker for Robot Framework syntax. Also wrote tests + documentation.