### PR TITLE
Don't use a temporary file for tflint

### DIFF
--- a/ale_linters/terraform/tflint.vim
+++ b/ale_linters/terraform/tflint.vim
@@ -99,6 +99,7 @@ endfunction
 call ale#linter#Define('terraform', {
 \   'name': 'tflint',
 \   'executable': {b -> ale#Var(b, 'terraform_tflint_executable')},
+\   'cwd': '%s:h',
 \   'command': function('ale_linters#terraform#tflint#GetCommand'),
 \   'callback': 'ale_linters#terraform#tflint#Handle',
 \})

--- a/ale_linters/terraform/tflint.vim
+++ b/ale_linters/terraform/tflint.vim
@@ -91,7 +91,7 @@ function! ale_linters#terraform#tflint#GetCommand(buffer) abort
         let l:cmd .= ' ' . l:opts
     endif
 
-    let l:cmd .= ' -f json %t'
+    let l:cmd .= ' -f json'
 
     return l:cmd
 endfunction

--- a/test/linter/test_terraform_tflint.vader
+++ b/test/linter/test_terraform_tflint.vader
@@ -5,18 +5,18 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'tflint', ale#Escape('tflint') . ' -f json %t'
+  AssertLinter 'tflint', ale#Escape('tflint') . ' -f json'
 
 Execute(The default executable should be configurable):
   let b:ale_terraform_tflint_executable = 'asdf'
 
-  AssertLinter 'asdf', ale#Escape('asdf') . ' -f json %t'
+  AssertLinter 'asdf', ale#Escape('asdf') . ' -f json'
 
 Execute(Overriding options should work):
   let g:ale_terraform_tflint_executable = 'fnord'
   let g:ale_terraform_tflint_options = '--whatever'
 
-  AssertLinter 'fnord', ale#Escape('fnord') . ' --whatever -f json %t'
+  AssertLinter 'fnord', ale#Escape('fnord') . ' --whatever -f json'
 
 Execute(Configuration files should be found):
   call ale#test#SetFilename('../test-files/tflint/foo/bar.tf')
@@ -25,4 +25,4 @@ Execute(Configuration files should be found):
   \ ale#Escape('tflint')
   \   . ' --config '
   \   . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/tflint/foo/.tflint.hcl'))
-  \   . ' -f json %t'
+  \   . ' -f json'


### PR DESCRIPTION
Standard terraform module structure is to split files into `main.tf`, `variables.tf`, `output.tf`.

Current `tflint` linting creates a temporary file.  But taking eg the `main.tf` in isolation prevents `tflint` from doing its job, `ALEInfo` shows output like this:
```
{"issues":[],"errors":[{"message":"Failed to check `azurerm_public_ip_invalid_sku` rule: Failed to eval an expression i
n /tmp/nvimcFkTcA/2/main.tf:49; Reference to undeclared input variable: An input variable with the name \"vm\" has not
been declared. This variable can be declared with a variable \"vm\" {} block."}]}
```
... where the `vm` was indeed declared, in the `variables.tf` file, where it should be.

Simply not using a temporary file resolves this.
