### PR TITLE
Fix breakage w/ plugins that inadvertently trigger ALE in `execute()`

### DIFF
--- a/autoload/ale/debugging.vim
+++ b/autoload/ale/debugging.vim
@@ -259,9 +259,7 @@ function! ale#debugging#InfoToClipboard() abort
         return
     endif
 
-    redir => l:output
-        silent call ale#debugging#Info()
-    redir END
+    let l:output = execute('call ale#debugging#Info()')
 
     let @+ = l:output
     call s:Echo('ALEInfo copied to your clipboard')
@@ -270,9 +268,7 @@ endfunction
 function! ale#debugging#InfoToFile(filename) abort
     let l:expanded_filename = expand(a:filename)
 
-    redir => l:output
-        silent call ale#debugging#Info()
-    redir END
+    let l:output = execute('call ale#debugging#Info()')
 
     call writefile(split(l:output, "\n"), l:expanded_filename)
     call s:Echo('ALEInfo written to ' . l:expanded_filename)

--- a/autoload/ale/filetypes.vim
+++ b/autoload/ale/filetypes.vim
@@ -4,9 +4,7 @@
 function! ale#filetypes#LoadExtensionMap() abort
     " Output includes:
     "    '*.erl setf erlang'
-    redir => l:output
-        silent exec 'autocmd'
-    redir end
+    let l:output = execute('exec "autocmd"')
 
     let l:map = {}
 

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -170,8 +170,8 @@ endfunction
 " Read sign data for a buffer to a list of lines.
 function! ale#sign#ReadSigns(buffer) abort
     let l:output = execute(
-        \ 'sign place ' . s:GroupCmd() . s:PriorityCmd()
-        \ . ' buffer=' . a:buffer
+    \   'sign place ' . s:GroupCmd() . s:PriorityCmd()
+    \   . ' buffer=' . a:buffer
     \ )
 
     return split(l:output, "\n")

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -52,9 +52,7 @@ endif
 function! ale#sign#SetUpDefaultColumnWithoutErrorsHighlight() abort
     let l:verbose = &verbose
     set verbose=0
-    redir => l:output
-        0verbose silent highlight SignColumn
-    redir end
+    let l:output = execute('highlight SignColumn', 'silent')
     let &verbose = l:verbose
 
     let l:highlight_syntax = join(split(l:output)[2:])
@@ -171,10 +169,10 @@ endfunction
 
 " Read sign data for a buffer to a list of lines.
 function! ale#sign#ReadSigns(buffer) abort
-    redir => l:output
-        silent execute 'sign place ' . s:GroupCmd() . s:PriorityCmd()
+    let l:output = execute(
+        \ 'sign place ' . s:GroupCmd() . s:PriorityCmd()
         \ . ' buffer=' . a:buffer
-    redir end
+    \ )
 
     return split(l:output, "\n")
 endfunction


### PR DESCRIPTION
Vim does not allow the use of `:redir` from within `execute()` calls, no matter how deeply within the call chain it occurs. There are sadly plugins that call `execute()` for whatever reasons, and inadvertently trigger ALE functions that use `:redir`, thereby raising an `E930`:

>E930: Cannot use :redir inside execute()

We replace all uses of `:redir => var` with `let var = execute(…)` to resolve this.

---

I've been trying to narrow down a minimal test case, and it's turned into a bit of a rabbit hole, as LanguageClient-neovim seems to suppress errors being displayed to the user when they use Solargraph (a Ruby language server), but not when they use Haskell Language Server. See autozimu/LanguageClient-neovim#1223 for the issue describing this.

That said, you can try this with an empty Haskell file using this `vimrc`:

```viml
" vimrc

let g:LanguageClient_showCompletionDocs = 1

call plug#begin('~/.vim/plugged')
Plug 'dense-analysis/ale'
Plug 'autozimu/LanguageClient-neovim', {
  \ 'branch': 'next',
  \ 'do': './install.sh'
\ }
let g:LanguageClient_serverCommands = {}
if executable('haskell-language-server-wrapper')
  let g:LanguageClient_serverCommands['haskell'] =
    \ ['haskell-language-server-wrapper', '--lsp']
endif
call plug#end()
```

Just type `Prelude.`, then press `C-x C-o`. Make sure to run all this in an empty folder for best reproducibility. Also, wait a few seconds after opening the Haskell file before attempting completion to let the language server launch. It seems if you try to complete before the language server has launched, even after it's launched, a second completion attempt won't work (possibly a bug in itself).

If you want to reproduce this without another plugin, you can use `vim -Nu <(echo "set rtp+=path/to/ale")`

and just run these commands in order:

```viml
let pop_win_id = popup_create(['# Title', '', 'Body'], { 'line': 0, 'col': 0, 'padding': [2, 2, 2, 2], 'moved': 'any' })
call setbufvar(winbufnr(pop_win_id), '&filetype', 'markdown')
call win_execute(pop_win_id, 'doautocmd InsertLeave')
```

You should see the first time:

```
Error detected while processing InsertLeave Autocommands for "*"..function ale#Queue[33]..<SNR>16_Lint[20]..ale#engine#RunLinters[4]..<SNR>32_GetLintFileValues[27]..<lambda>4[1]..<SNR>32_RunLinters[18]..<SNR>32_RunLinter[6]..<SNR>32_RunIfExecutable[43]..<SNR>32_RunJob[27]..ale#command#Run[17]..ale#command#FormatCommand[40]..<SNR>33_TemporaryFilename[6]..ale#filetypes#GuessExtension[1]..<SNR>35_GetCachedExtensionMap[2]..ale#filetypes#LoadExtensionMap:
line    3:
E930: Cannot use :redir inside execute()
Error detected while processing InsertLeave Autocommands for "*"..function ale#Queue[33]..<SNR>16_Lint[20]..ale#engine#RunLinters[4]..<SNR>32_GetLintFileValues[27]..<lambda>4[1]..<SNR>32_RunLinters[18]..<SNR>32_RunLinter[6]..<SNR>32_RunIfExecutable[43]..<SNR>32_RunJob[27]..ale#command#Run:
line   17:
E714: List required
```

Every subsequent time before restarting Vim (which I believe is because the extension map is no longer a blank hash, so it's using the now cached corrupt value (another bug)):

```
Error detected while processing InsertLeave Autocommands for "*"..function ale#Queue[33]..<SNR>16_Lint[20]..ale#engine#RunLinters[4]..<SNR>32_GetLintFileValues[27]..<lambda>6[1]..<SNR>32_RunLinters[18]..<SNR>32_RunLinter[6]..<SNR>32_RunIfExecutable[43]..<SNR>32_RunJob[27]..ale#command#Run[17]..ale#command#FormatCommand[40]..<SNR>33_TemporaryFilename[6]..ale#filetypes#GuessExtension:
line    2:
E896: Argument of get() must be a List, Dictionary or Blob
Error detected while processing InsertLeave Autocommands for "*"..function ale#Queue[33]..<SNR>16_Lint[20]..ale#engine#RunLinters[4]..<SNR>32_GetLintFileValues[27]..<lambda>6[1]..<SNR>32_RunLinters[18]..<SNR>32_RunLinter[6]..<SNR>32_RunIfExecutable[43]..<SNR>32_RunJob[27]..ale#command#Run:
line   17:
E714: List required
Press ENTER or type command to continue
```

I've tried creating a Vader test of the second method of reproduction (both with Do and Execute), but I can't seem to reproduce it in a Vader test. I thought I did a few days ago, but now I'm not so sure. I had to use `Do`, because for some reason, it seemed as if I had to be in insert mode to do the third line to prevent the popup window disappearing after I pressed colon, and it also seemed as if the second line wasn't necessary.

Now, I've been no longer able to reproduce without the second line, and being in insert mode doesn't seem to matter, both with the minimal `vimrc`s and my usual `vimrc`. This has been an exhausting bunch of bugs to track down and deal with (see [linked issue](/autozimu/LanguageClient-neovim/issues/1223) for full details), so I'm not down for any more, but if a Vader test is really necessary for this PR, I'll keep trying, but I can't promise anything.

```

---

According to @hsanson, the use of `:redir`, in at least the case of the linked PR, may not be an arbitrary decision:

>@w0rp I do not think the use of redir in this part of the code was an arbitrary decision. Would prefer that you review this MR and #3648 before merging them.
— https://github.com/dense-analysis/ale/pull/3691#issuecomment-818671627

How much stock should be put in that statement is not clear, as Vim's documentation says of `execute()`:

>execute({command} [, {silent}])					*execute()*
>
>		[…]
>
>		This is equivalent to: >
>			redir => var
>			{command}
>			redir END

Related PR: #3691