### PR TITLE
Fix URLs of clippy, rustfmt and rls

### DIFF
--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -155,7 +155,7 @@ g:ale_rust_cargo_use_clippy
   `cargo build` as linter.
   For details of `cargo clippy`, please visit the following link:
 
-  https://github.com/rust-lang-nursery/rust-clippy
+  https://github.com/rust-lang/rust-clippy
 
   Since `cargo clippy` is optional toolchain, it's safer to check whether
   `cargo-clippy` is executable as follows:

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -464,10 +464,10 @@ formatting.
   * [standardrb](https://github.com/testdouble/standard)
 * Rust
   * [cargo](https://github.com/rust-lang/cargo) :floppy_disk: (see `:help ale-integration-rust` for configuration instructions)
-  * [rls](https://github.com/rust-lang-nursery/rls) :warning:
+  * [rls](https://github.com/rust-lang/rls) :warning:
   * [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer) :warning:
   * [rustc](https://www.rust-lang.org/) :warning:
-  * [rustfmt](https://github.com/rust-lang-nursery/rustfmt)
+  * [rustfmt](https://github.com/rust-lang/rustfmt)
 * Salt
   * [salt-lint](https://github.com/warpnet/salt-lint)
 * Sass


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

- https://github.com/rust-lang/rust-clippy
- https://github.com/rust-lang/rustfmt
- https://github.com/rust-lang/rls

These tools graduated rust-lang-nursery organization and now managed by official rust-lang organization. This PR fixes the links.
