### PR TITLE
Use stdin/out for cmake-format

### DIFF
--- a/autoload/ale/fixers/cmakeformat.vim
+++ b/autoload/ale/fixers/cmakeformat.vim
@@ -10,9 +10,7 @@ function! ale#fixers#cmakeformat#Fix(buffer) abort
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' -i '
     \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' %t',
-    \   'read_temporary_file': 1,
+    \       . ' -'
     \}
 endfunction

--- a/test/fixers/test_cmakeformat_fixer_callback.vader
+++ b/test/fixers/test_cmakeformat_fixer_callback.vader
@@ -18,10 +18,8 @@ Execute(The cmakeformat callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' -i '
-  \     . ' %t',
+  \     . ' -'
   \ },
   \ ale#fixers#cmakeformat#Fix(bufnr(''))
 
@@ -31,10 +29,8 @@ Execute(The cmakeformat callback should include custom cmakeformat options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' -i '
   \     . ' ' . g:ale_cmake_cmakeformat_options
-  \     . ' %t',
+  \     . ' -',
   \ },
   \ ale#fixers#cmakeformat#Fix(bufnr(''))


### PR DESCRIPTION
cmake-format added support for reading from/outputting to stdin/out as
of v0.3.6, released 2018-04-10 (commit 2e2aff2) [0].

Reading from stdin is preferable over reading from a temporary file
because when given a concrete file cmake-format will look for its config
file (.cmake-format.py or similar) in the parent directories of the
provided file. If the temporary file is off in a tmpdir somewhere (e.g.,
/tmp on *nix), cmake-format will almost certainly not come across the
user's intended format configuration file, making it appear that
cmake-format is ignoring the config file.

If cmake-format reads from stdin, though, it'll look for its config file
in its current working directory and its parent directories, in a
similar manner to clang-format. This has a much higher chance of running
across the intended config file.

[0]: https://github.com/cheshirekow/cmake_format/releases/tag/v0.3.6