### PR TITLE
Fix #3089 - symlinked tempfiles should still report issues

### DIFF
--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -88,11 +88,16 @@ function! ale#path#IsAbsolute(filename) abort
 endfunction
 
 let s:temp_dir = ale#path#Simplify(fnamemodify(ale#util#Tempname(), ':h:h'))
+let s:resolved_temp_dir = resolve(s:temp_dir)
 
 " Given a filename, return 1 if the file represents some temporary file
-" created by Vim.
+" created by Vim. If the temporary location is symlinked (e.g. macOS), some
+" linters may report the resolved version of the path, so both are checked.
 function! ale#path#IsTempName(filename) abort
-    return ale#path#Simplify(a:filename)[:len(s:temp_dir) - 1] is# s:temp_dir
+    let l:filename = ale#path#Simplify(a:filename)
+
+    return l:filename[:len(s:temp_dir) - 1] is# s:temp_dir
+    \|| l:filename[:len(s:resolved_temp_dir) - 1] is# s:resolved_temp_dir
 endfunction
 
 " Given a base directory, which must not have a trailing slash, and a


### PR DESCRIPTION
### Summary

This PR fixes #3089 (+ jimhester/lintr/issues/480), by ensuring that linters reporting issues against resolved symlink tempfile paths are still considered as reporting against tempfile paths.

### Detail

For example, on macOS calls to `ale#util#Tempname()` produce paths of the form `/var/folders/...`, which are actually symlinks to `/private/var/...`:

```bash
$ pwd -P /var/folders/0r/65637b055vx11s2zwr4f_4k80000gn/T/nvimtH8m0W/15
/private/var/folders/0r/65637b055vx11s2zwr4f_4k80000gn/T
```

It is possible that a linter reports the physical location of ALE's tempfile of the buffer contents (output from `:ALEInfo`):

```
  Command History:
(executable check - success) Rscript
(finished - exit code 0) ['/usr/local/bin/bash', '-c', 'cd ''/Users/josh/code/r_demo'' && Rscript --vanil
la -e ''suppressPackageStartupMessages(library(lintr));lint(cache = FALSE, commandArgs(TRUE), with_defaul
ts())'' ''/var/folders/0r/65637b055vx11s2zwr4f_4k80000gn/T/nvimtH8m0W/2/demo.R''']

<<<OUTPUT STARTS>>>
/private/var/folders/0r/65637b055vx11s2zwr4f_4k80000gn/T/nvimtH8m0W/2/demo.R:1:3: style: Use <-, not =, f
or assignment.
a = c("hello", "world")
  ^
<<<OUTPUT ENDS>>>
```

...which without this PR would not be detected as being a tempfile by `ale#path#IsTempName(filename)` – preventing the issues being reported.