### PR TITLE
Allow lintr to consider .Renviron settings. Fix #3391

### DIFF
--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -1,5 +1,6 @@
 " Author: Michel Lang <michellang@gmail.com>, w0rp <devw0rp@gmail.com>,
-"         Fenner Macrae <fmacrae.dev@gmail.com>
+"         Fenner Macrae <fmacrae.dev@gmail.com>,
+"         ourigen <ourigen [at] pm.me>
 " Description: This file adds support for checking R code with lintr.
 
 let g:ale_r_lintr_options = get(g:, 'ale_r_lintr_options', 'with_defaults()')
@@ -21,7 +22,7 @@ function! ale_linters#r#lintr#GetCommand(buffer) abort
     let l:cmd_string = 'suppressPackageStartupMessages(library(lintr));'
     \   . l:lint_cmd
 
-    return 'Rscript --vanilla -e ' . ale#Escape(l:cmd_string) . ' %t'
+    return 'Rscript --no-save --no-restore --no-site-file --no-init-file -e ' . ale#Escape(l:cmd_string) . ' %t'
 endfunction
 
 call ale#linter#Define('r', {

--- a/ale_linters/r/lintr.vim
+++ b/ale_linters/r/lintr.vim
@@ -1,6 +1,6 @@
 " Author: Michel Lang <michellang@gmail.com>, w0rp <devw0rp@gmail.com>,
 "         Fenner Macrae <fmacrae.dev@gmail.com>,
-"         ourigen <ourigen [at] pm.me>
+"         ourigen <https://github.com/ourigen>
 " Description: This file adds support for checking R code with lintr.
 
 let g:ale_r_lintr_options = get(g:, 'ale_r_lintr_options', 'with_defaults()')

--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -1,5 +1,5 @@
 " Author: Ricardo Liang <ricardoliang@gmail.com>
-" Author: ourigen <ourigen [at] pm.me>
+" Author: ourigen <https://github.com/ourigen>
 " Description: Texlab language server (Rust rewrite)
 
 call ale#Set('tex_texlab_executable', 'texlab')

--- a/test/linter/test_lintr.vader
+++ b/test/linter/test_lintr.vader
@@ -7,7 +7,7 @@ After:
 Execute(The default lintr command should be correct):
   AssertLinterCwd '%s:h'
   AssertLinter 'Rscript',
-  \   'Rscript --vanilla -e '
+  \   'Rscript --no-save --no-restore --no-site-file --no-init-file -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
   \   .            'lint(cache = FALSE, commandArgs(TRUE), '
   \   .            'with_defaults())')
@@ -17,7 +17,7 @@ Execute(The lintr options should be configurable):
   let b:ale_r_lintr_options = 'with_defaults(object_usage_linter = NULL)'
 
   AssertLinter 'Rscript',
-  \   'Rscript --vanilla -e '
+  \   'Rscript --no-save --no-restore --no-site-file --no-init-file -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
   \   .            'lint(cache = FALSE, commandArgs(TRUE), '
   \   .            'with_defaults(object_usage_linter = NULL))')
@@ -27,7 +27,7 @@ Execute(If the lint_package flag is set, lintr::lint_package should be called):
   let b:ale_r_lintr_lint_package = 1
 
   AssertLinter 'Rscript',
-  \   'Rscript --vanilla -e '
+  \   'Rscript --no-save --no-restore --no-site-file --no-init-file -e '
   \   . ale#Escape('suppressPackageStartupMessages(library(lintr));'
   \   .            'lint_package(cache = FALSE, '
   \   .            'linters = with_defaults())')


### PR DESCRIPTION
Using `--vanilla` switch prevents R from reading .Renviron settings, which is problematic for users who define their R libraries in locations separate from the default as it prevents `library(lintr)` from being called. Fixes #3391, which explains the issue more.