### PR TITLE
Add fixer to remove whitespace at end of lines, except for double whitespace

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -141,6 +141,11 @@ let s:default_registry = {
 \       'suggested_filetypes': [],
 \       'description': 'Remove all trailing whitespace characters at the end of every line.',
 \   },
+\   'trim_whitespace_except_double': {
+\       'function': 'ale#fixers#generic#TrimWhitespaceExceptDoubleWhitespace',
+\       'suggested_filetypes': [],
+\       'description': 'Remove all trailing whitespace characters at the end of every line except for a double whitespace.',
+\   },
 \   'yamlfix': {
 \       'function': 'ale#fixers#yamlfix#Fix',
 \       'suggested_filetypes': ['yaml'],

--- a/autoload/ale/fixers/generic.vim
+++ b/autoload/ale/fixers/generic.vim
@@ -23,3 +23,16 @@ function! ale#fixers#generic#TrimWhitespace(buffer, lines) abort
 
     return l:lines_new
 endfunction
+
+" Remove all whitespaces at the end of lines except double space
+function! ale#fixers#generic#TrimWhitespaceExceptDoubleWhitespace(buffer, lines) abort
+    let l:index = 0
+    let l:lines_new = range(len(a:lines))
+
+    for l:line in a:lines
+        let l:lines_new[l:index] = substitute(l:line, '\v(\s)@<!\s(\s{2,})?$', '', 'g')
+        let l:index = l:index + 1
+    endfor
+
+    return l:lines_new
+endfunction

--- a/test/fixers/test_trim_whitespace_except_double.vader
+++ b/test/fixers/test_trim_whitespace_except_double.vader
@@ -9,14 +9,12 @@ Execute(Should delete all whitespace at the end of different lines except a doub
   \ [
   \   'def foo():',
   \   '    some_variable = this_is_a_longer_function(',
-  \   'first_argument,',
+  \   'first_argument,',  
   \   ' second_argument,',
   \   ' third_with_function_call(',
   \   'foo,',
   \   ' bar,',
   \   '))',
-  \   'fourth_argument_with_double_trailing_whitespace,',
-  \   'fifth_argument_with_three_trailing_whitespace,',
   \ ],
   \ ale#fixers#generic#TrimWhitespace(bufnr(''), [
   \   'def foo():',     
@@ -27,6 +25,4 @@ Execute(Should delete all whitespace at the end of different lines except a doub
   \   'foo,', 
   \   ' bar,',   
   \   '))',              
-  \   'fourth_argument_with_double_trailing_whitespace,',  
-  \   'fifth_argument_with_three_trailing_whitespace,',
   \ ])

--- a/test/fixers/test_trim_whitespace_except_double.vader
+++ b/test/fixers/test_trim_whitespace_except_double.vader
@@ -1,0 +1,32 @@
+Before:
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  call ale#test#RestoreDirectory()
+
+Execute(Should delete all whitespace at the end of different lines except a double whitespace):
+  AssertEqual
+  \ [
+  \   'def foo():',
+  \   '    some_variable = this_is_a_longer_function(',
+  \   'first_argument,',
+  \   ' second_argument,',
+  \   ' third_with_function_call(',
+  \   'foo,',
+  \   ' bar,',
+  \   '))',
+  \   'fourth_argument_with_double_trailing_whitespace,',
+  \   'fifth_argument_with_three_trailing_whitespace,',
+  \ ],
+  \ ale#fixers#generic#TrimWhitespace(bufnr(''), [
+  \   'def foo():',     
+  \   '    some_variable = this_is_a_longer_function(', 
+  \   'first_argument,',  
+  \   ' second_argument,',   
+  \   ' third_with_function_call(',      
+  \   'foo,', 
+  \   ' bar,',   
+  \   '))',              
+  \   'fourth_argument_with_double_trailing_whitespace,',  
+  \   'fifth_argument_with_three_trailing_whitespace,',
+  \ ])


### PR DESCRIPTION
Add a generic fixture called `trim_whitespace_except_double` which calls `ale#fixers#generic#TrimWhitespaceExceptDoubleWhitespace`

This fixer removes whitespace at the end of a line but leaves a double whitespace. (It will remove a single whitespace, it will remove 3 or more whitespaces. It will not remove 2 whitespaces).

This is useful in markdown, where a double whitespace is used to create a line break.

I wrote a test `test_trim_whitespace_except_double.vader` and ran `./run-tests` and the tests seemed  to run without problems. The test is based on `test_trim_whitespace.vader`, I simply changed the first argument of the result so that it was unchanged compared to the code being fixed (to not remove the double whitespace after `first_argument`).

Any comments are appreciated, I'm still learning how to make pull requests. 