### PR TITLE
Let R_languageserver consider .Renviron

### DIFF
--- a/ale_linters/r/languageserver.vim
+++ b/ale_linters/r/languageserver.vim
@@ -7,7 +7,7 @@ call ale#Set('r_languageserver_config', {})
 function! ale_linters#r#languageserver#GetCommand(buffer) abort
     let l:cmd_string = ale#Var(a:buffer, 'r_languageserver_cmd')
 
-    return 'Rscript --vanilla -e ' . ale#Escape(l:cmd_string)
+    return 'Rscript --no-save --no-restore --no-site-file --no-init-file -e ' . ale#Escape(l:cmd_string)
 endfunction
 
 function! ale_linters#r#languageserver#GetProjectRoot(buffer) abort

--- a/ale_linters/r/languageserver.vim
+++ b/ale_linters/r/languageserver.vim
@@ -1,4 +1,5 @@
 " Author: Eric Zhao <21zhaoe@protonmail.com>
+" Author: ourigen <https://github.com/ourigen>
 " Description: Implementation of the Language Server Protocol for R.
 
 call ale#Set('r_languageserver_cmd', 'languageserver::run()')

--- a/test/linter/test_r_languageserver.vader
+++ b/test/linter/test_r_languageserver.vader
@@ -5,7 +5,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
-  AssertLinter 'Rscript', 'Rscript --vanilla -e ' . ale#Escape('languageserver::run()')
+  AssertLinter 'Rscript', 'Rscript --no-save --no-restore --no-site-file --no-init-file -e ' . ale#Escape('languageserver::run()')
 
 Execute(The project root should be detected correctly):
   AssertLSPProject '.'


### PR DESCRIPTION
Addresses a similar problem to #3727 but for the R language server. 

Using `--vanilla` switch prevents R from reading `.Renviron` settings, which for users who define their R libraries in locations different from the default prevents `library(languageserver)` from being called