### PR TITLE
Add support for rpmlint 2.0.0

### DIFF
--- a/ale_linters/spec/rpmlint.vim
+++ b/ale_linters/spec/rpmlint.vim
@@ -29,11 +29,18 @@
 call ale#Set('spec_rpmlint_executable', 'rpmlint')
 call ale#Set('spec_rpmlint_options', '')
 
-function! ale_linters#spec#rpmlint#GetCommand(buffer) abort
+function! ale_linters#spec#rpmlint#GetCommand(buffer, version) abort
+    if ale#semver#GTE(a:version, [2, 0, 0])
+        " The -o/--option flag was removed in version 2.0.0
+        let l:version_dependent_args = ''
+    else
+        let l:version_dependent_args = ' -o "NetworkEnabled False"'
+    endif
+
     return '%e'
     \   . ale#Pad(ale#Var(a:buffer, 'spec_rpmlint_options'))
-    \   . ' -o "NetworkEnabled False"'
     \   . ' -v'
+    \   . l:version_dependent_args
     \   . ' %t'
 endfunction
 
@@ -73,6 +80,11 @@ endfunction
 call ale#linter#Define('spec', {
 \   'name': 'rpmlint',
 \   'executable': {b -> ale#Var(b, 'spec_rpmlint_executable')},
-\   'command': function('ale_linters#spec#rpmlint#GetCommand'),
+\   'command': {buffer -> ale#semver#RunWithVersionCheck(
+\       buffer,
+\       ale#Var(buffer, 'spec_rpmlint_executable'),
+\       '%e --version',
+\       function('ale_linters#spec#rpmlint#GetCommand'),
+\   )},
 \   'callback': 'ale_linters#spec#rpmlint#Handle',
 \})


### PR DESCRIPTION
The -o/--option flag was removed in version 2.0.0 of rpmlint. Providing
this causes rpmlint to fail and provide no output. Only provide this
flag to rpmlint if the version is less than 2.0.0.