### PR TITLE
black fixer: --pyi option was appended without a space

### DIFF
--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -18,20 +18,25 @@ endfunction
 
 function! ale#fixers#black#Fix(buffer) abort
     let l:executable = ale#fixers#black#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv$'
-    \   ? ' run black'
-    \   : ''
-    let l:options = ale#Var(a:buffer, 'python_black_options')
+    let l:cmd = [ale#Escape(l:executable)]
 
-    if expand('#' . a:buffer . ':e') is? 'pyi'
-        let l:options .= '--pyi'
+    if l:executable =~? 'pipenv$'
+        call extend(l:cmd, ['run', 'black'])
     endif
 
-    let l:result = {
-    \   'command': ale#Escape(l:executable) . l:exec_args
-    \       . (!empty(l:options) ? ' ' . l:options : '')
-    \       . ' -',
-    \}
+    let l:options = ale#Var(a:buffer, 'python_black_options')
+
+    if !empty(l:options)
+        call add(l:cmd, l:options)
+    endif
+
+    if expand('#' . a:buffer . ':e') is? 'pyi'
+        call add(l:cmd, '--pyi')
+    endif
+
+    call add(l:cmd, '-')
+
+    let l:result = {'command': join(l:cmd, ' ')}
 
     if ale#Var(a:buffer, 'python_black_change_directory')
         let l:result.cwd = '%s:h'

--- a/test/fixers/test_black_fixer_callback.vader
+++ b/test/fixers/test_black_fixer_callback.vader
@@ -36,6 +36,16 @@ Execute(The black callback should include --pyi for .pyi files):
   \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/black')) . ' --pyi -' },
   \ ale#fixers#black#Fix(bufnr(''))
 
+Execute(The black callback should not concatenate options):
+  let g:ale_python_black_options = '--some-option'
+  let g:ale_python_black_change_directory = 0
+
+  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.pyi')
+
+  AssertEqual
+  \ {'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/black')) . ' --some-option --pyi -' },
+  \ ale#fixers#black#Fix(bufnr(''))
+
 Execute(Pipenv is detected when python_black_auto_pipenv is set):
   let g:ale_python_black_auto_pipenv = 1
   let g:ale_python_black_change_directory = 0


### PR DESCRIPTION
Also a new test: The black callback should not concatenate options