### PR TITLE
Add ALEPopulateQuickfix and ALEPopulateLocList

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -204,6 +204,23 @@ function! ale#list#SetLists(buffer, loclist) abort
     endif
 endfunction
 
+function! ale#list#ForcePopulateErrorList(populate_quickfix) abort
+    let l:quickfix_bak = g:ale_set_quickfix
+    let g:ale_set_quickfix = a:populate_quickfix
+    let l:loclist_bak = g:ale_set_loclist
+    let g:ale_set_loclist = !a:populate_quickfix
+    let l:open_list_bak = g:ale_open_list
+    let g:ale_open_list = 1
+
+    let l:buffer = bufnr('')
+    let l:loclist = get(g:ale_buffer_info, l:buffer, {'loclist': []}).loclist
+    call s:SetListsImpl(-1, l:buffer, l:loclist)
+
+    let g:ale_open_list = l:open_list_bak
+    let g:ale_set_loclist = l:loclist_bak
+    let g:ale_set_quickfix = l:quickfix_bak
+endfunction
+
 function! s:CloseWindowIfNeeded(buffer) abort
     if ale#Var(a:buffer, 'keep_list_window_open') || !s:ShouldOpen(a:buffer)
         return

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3102,7 +3102,7 @@ ALEComplete                                                       *ALEComplete*
   Manually trigger LSP autocomplete and show the menu. Works only when called
   from insert mode. >
 
-    inoremap <silent> <C-Space> <C-\><C-O>:AleComplete<CR>
+    inoremap <silent> <C-Space> <C-\><C-O>:ALEComplete<CR>
 <
   A plug mapping `<Plug>(ale_complete)` is defined for this command. >
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2007,7 +2007,7 @@ g:ale_set_quickfix                                         *g:ale_set_quickfix*
   This feature should not be used in combination with tools for searching for
   matches and commands like |:cfdo|, as ALE will replace the quickfix list
   pretty frequently. If you wish to use such tools, you should populate the
-  loclist instead.
+  loclist or use |ALEPopulateQuickfix| instead.
 
 
 g:ale_set_signs                                               *g:ale_set_signs*
@@ -3318,6 +3318,20 @@ ALELintStop                                                       *ALELintStop*
 
   Any problems from previous linter results will continue to be shown.
 
+
+ALEPopulateQuickfix                                       *ALEPopulateQuickfix*
+ALEPopulateLocList                                         *ALEPopulateLocList*
+
+  Manually populate the |quickfix| or |location-list| and show the
+  corresponding list. Useful when you have other uses for both the |quickfix|
+  and |location-list| and don't want them automatically populated. Be sure to
+  disable auto populating: >
+
+    let g:ale_set_quickfix = 0
+    let g:ale_set_loclist = 0
+<
+  With these settings, ALE will still run checking and display it with signs,
+  highlighting, and other output described in |ale-lint-file-linters|.
 
 ALEPrevious                                                       *ALEPrevious*
 ALEPreviousWrap                                               *ALEPreviousWrap*

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -222,6 +222,10 @@ command! -bar ALELint :call ale#Queue(0, 'lint_file')
 " Stop current jobs when linting.
 command! -bar ALELintStop :call ale#engine#Stop(bufnr(''))
 
+" Commands to manually populate the quickfixes.
+command! -bar ALEPopulateQuickfix :call ale#list#ForcePopulateErrorList(1)
+command! -bar ALEPopulateLocList  :call ale#list#ForcePopulateErrorList(0)
+
 " Define a command to get information about current filetype.
 command! -bar ALEInfo :call ale#debugging#Info()
 " The same, but copy output to your clipboard.

--- a/test/test_ale_populate_command.vader
+++ b/test/test_ale_populate_command.vader
@@ -1,0 +1,96 @@
+Before:
+  Save g:ale_buffer_info
+  Save g:ale_enabled
+  Save g:ale_set_quickfix
+  Save g:ale_set_loclist
+  Save g:ale_open_list
+
+  let g:ale_buffer_info = {}
+  let g:ale_enabled = 1
+  let g:ale_set_quickfix = 0
+  let g:ale_set_loclist = 0
+  let g:ale_open_list = 1
+
+  let g:expected_loclist = [{
+  \ 'bufnr': bufnr('%'),
+  \ 'lnum': 2,
+  \ 'vcol': 0,
+  \ 'col': 3,
+  \ 'text': 'foo bar',
+  \ 'type': 'E',
+  \ 'nr': -1,
+  \ 'pattern': '',
+  \ 'valid': 1,
+  \}]
+
+  function! ToggleTestCallback(buffer, output)
+    return [{
+    \ 'bufnr': a:buffer,
+    \ 'lnum': 2,
+    \ 'vcol': 0,
+    \ 'col': 3,
+    \ 'text': join(split(a:output[0])),
+    \ 'type': 'E',
+    \ 'nr': -1,
+    \}]
+  endfunction
+
+  call ale#linter#Define('foobar', {
+  \ 'name': 'testlinter',
+  \ 'callback': 'ToggleTestCallback',
+  \ 'executable': has('win32') ? 'cmd' : 'echo',
+  \ 'command': 'echo foo bar',
+  \})
+
+After:
+  Restore
+
+  unlet! g:expected_loclist
+  unlet! b:i
+
+  call ale#engine#Cleanup(bufnr(''))
+  call ale#linter#Reset()
+
+  " Not sure this is necessary since it was Save/Restore-d
+  let g:ale_buffer_info = {}
+
+  delfunction ToggleTestCallback
+
+Given foobar (Some imaginary filetype):
+  foo
+  bar
+  baz
+
+Execute(ALEPopulateQuickfix should have results):
+  AssertEqual 'foobar', &filetype
+
+  " Clear so we can check that they're unmodified.
+  call setqflist([])
+  call setloclist(winnr(), [])
+
+  " Try to run the linter a few times, as it fails randomly in NeoVim.
+  for b:i in range(5)
+    ALELint
+    call ale#test#WaitForJobs(2000)
+
+    if !has('nvim')
+      " Sleep so the delayed list function can run.
+      " This breaks the tests in NeoVim for some reason.
+      sleep 1ms
+    endif
+
+    if ale#test#GetLoclistWithoutModule() == g:expected_loclist
+      break
+    endif
+  endfor
+
+
+  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetQflistWithoutModule()
+
+  ALEPopulateLocList
+  AssertNotEqual 0, get(getloclist(0, {'winid':0}), 'winid', 0)
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+
+  ALEPopulateQuickfix
+  AssertEqual g:expected_loclist, ale#test#GetQflistWithoutModule()


### PR DESCRIPTION
Resolve #1810.

Add ALEPopulateQuickfix and ALEPopulateLocList. They're not very useful
with ale's default autopopulate behaviour, so their useful configuration
is described in help.

Also fixed an unrelated typo.

Open to changing the command names. I'd suggested ALEShowErrors, but since there's two lists I went with populate. Not sure if it should optionally obey `g:ale_open_list`. That setting seems mostly for "don't make windows popup automatically", so I don't have a bang variant.

I didn't implement the fancy list target preservation [described on the issue](https://github.com/dense-analysis/ale/issues/1810#issuecomment-448644686). Doing that would improve this feature to keep the list updated while it's displayed, but it seems much more complicated.

