### PR TITLE
Add support for `dart format` fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -371,6 +371,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['dart'],
 \       'description': 'Fix Dart files with dartfmt.',
 \   },
+\   'dart-format': {
+\       'function': 'ale#fixers#dart_format#Fix',
+\       'suggested_filetypes': ['dart'],
+\       'description': 'Fix Dart files with dart format.',
+\   },
 \   'xmllint': {
 \       'function': 'ale#fixers#xmllint#Fix',
 \       'suggested_filetypes': ['xml'],

--- a/autoload/ale/fixers/dart_format.vim
+++ b/autoload/ale/fixers/dart_format.vim
@@ -1,0 +1,18 @@
+" Author: ghsang <gwonhyuksang@gmail.com>
+" Description: Integration of dart format with ALE.
+
+call ale#Set('dart_format_executable', 'dart')
+call ale#Set('dart_format_options', '')
+
+function! ale#fixers#dart_format#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'dart_format_executable')
+    let l:options = ale#Var(a:buffer, 'dart_format_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' format'
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-dart.txt
+++ b/doc/ale-dart.txt
@@ -58,6 +58,37 @@ g:ale_dart_dartanalyzer_executable         *g:ale_dart_dartanalyzer_executable*
 
   This variable can be set to change the path to dartanalyzer.
 
+===============================================================================
+dart-format                                                   *ale-dart-format*
+
+Installation
+-------------------------------------------------------------------------------
+
+Installing Dart should probably ensure that `dart` is in your `$PATH`.
+
+In case it is not, try to set the executable option to its absolute path. : >
+  " Set the executable path for dart to the absolute path to it.
+  let g:ale_dart_format_executable = '/usr/lib/dart/bin/dart'
+ >
+
+Options
+-------------------------------------------------------------------------------
+
+g:ale_dart_format_executable                     *g:ale_dart_format_executable*
+                                                 *b:ale_dart_format_executable*
+  Type: |String|
+  Default: `'dart'`
+
+  This variable can be set to specify an absolute path to the
+  format executable (or to specify an alternate executable).
+
+
+g:ale_dart_format_options                           *g:ale_dart_format_options*
+                                                    *b:ale_dart_format_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the dart format fixer.
 
 ===============================================================================
 dartfmt                                                      *ale-dart-dartfmt*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -124,6 +124,7 @@ Notes:
   * `dafny`!!
 * Dart
   * `analysis_server`
+  * `dart-format`!!
   * `dartanalyzer`!!
   * `dartfmt`!!
   * `language_server`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2700,6 +2700,7 @@ documented in additional help files.
   dart....................................|ale-dart-options|
     analysis_server.......................|ale-dart-analysis_server|
     dartanalyzer..........................|ale-dart-dartanalyzer|
+    dart-format...........................|ale-dart-format|
     dartfmt...............................|ale-dart-dartfmt|
   desktop.................................|ale-desktop-options|
     desktop-file-validate.................|ale-desktop-desktop-file-validate|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -133,6 +133,7 @@ formatting.
   * [dafny](https://rise4fun.com/Dafny) :floppy_disk:
 * Dart
   * [analysis_server](https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server)
+  * [dart-format](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)
   * [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli) :floppy_disk:
   * [dartfmt](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)
   * [language_server](https://github.com/natebosch/dart_language_server)

--- a/test/fixers/test_dart_format_fixer_callback.vader
+++ b/test/fixers/test_dart_format_fixer_callback.vader
@@ -1,0 +1,40 @@
+Before:
+  Save g:ale_dart_format_executable
+  Save g:ale_dart_format_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_dart_format_executable = 'xxxinvalid'
+  let g:ale_dart_format_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The dart format callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/dart/testfile.dart')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format'
+  \     . ' %t',
+  \ },
+  \ ale#fixers#dart_format#Fix(bufnr(''))
+
+Execute(The dart format callback should include custom dart format options):
+  let g:ale_dart_format_options = "-l 80"
+  call ale#test#SetFilename('../test-files/dart/testfile.dart')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format'
+  \     . ' ' . g:ale_dart_format_options
+  \     . ' %t',
+  \ },
+  \ ale#fixers#dart_format#Fix(bufnr(''))


### PR DESCRIPTION
`dartfmt` is being deprecated in favor of `dart format`. (https://github.com/dart-lang/dart_style/issues/986)

Code was adapted from `dartfmt` fixer (https://github.com/dense-analysis/ale/pull/1683)