### PR TITLE
fix: cflags parser: no absolute path for '-include'

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -151,8 +151,6 @@ function! ale#c#ParseCFlags(path_prefix, should_quote, raw_arguments) abort
         \ || stridx(l:option, '-isystem') == 0
         \ || stridx(l:option, '-idirafter') == 0
         \ || stridx(l:option, '-iframework') == 0
-        \ || stridx(l:option, '-include') == 0
-        \ || stridx(l:option, '-imacros') == 0
             if stridx(l:option, '-I') == 0 && l:option isnot# '-I'
                 let l:arg = join(split(l:option, '\zs')[2:], '')
                 let l:option = '-I'
@@ -182,6 +180,7 @@ function! ale#c#ParseCFlags(path_prefix, should_quote, raw_arguments) abort
         " Options that have an argument (always separate)
         elseif l:option is# '-iprefix' || stridx(l:option, '-iwithprefix') == 0
         \ || l:option is# '-isysroot' || l:option is# '-imultilib'
+        \ || l:option is# '-include' || l:option is# '-imacros'
             call add(l:items, [0, l:option])
             call add(l:items, [0, l:arguments[l:option_index]])
             let l:option_index = l:option_index + 1

--- a/test/test_c_flag_parsing.vader
+++ b/test/test_c_flag_parsing.vader
@@ -495,8 +495,8 @@ Execute(We should include several important flags):
   \ . ' -isystem ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/incsystem'))
   \ . ' -idirafter ' . ale#Escape(ale#path#Simplify(g:dir. '/test-files/c/makefile_project/incafter'))
   \ . ' -iframework ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/incframework'))
-  \ . ' -include ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/foo bar'))
-  \ . ' -imacros ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/incmacros'))
+  \ . ' -include file.h'
+  \ . ' -imacros macros.h'
   \ . ' -Dmacro="value"'
   \ . ' -DGoal=9'
   \ . ' -D macro2'
@@ -525,9 +525,9 @@ Execute(We should include several important flags):
   \     '-iframework',
   \     'incframework',
   \     '-include',
-  \     '''foo bar''',
+  \     'file.h',
   \     '-imacros',
-  \     'incmacros',
+  \     'macros.h',
   \     '-Dmacro="value"',
   \     '-DGoal=9',
   \     '-D',
@@ -575,8 +575,8 @@ Execute(We should quote the flags we need to quote):
   \ . ' -isystem ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/incsystem'))
   \ . ' -idirafter ' . ale#Escape(ale#path#Simplify(g:dir. '/test-files/c/makefile_project/incafter'))
   \ . ' -iframework ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/incframework'))
-  \ . ' -include ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/foo bar'))
-  \ . ' -imacros ' . ale#Escape(ale#path#Simplify(g:dir . '/test-files/c/makefile_project/incmacros'))
+  \ . ' -include file.h'
+  \ . ' -imacros macros.h'
   \ . ' ' . ale#Escape('-Dmacro="value"')
   \ . ' -DGoal=9'
   \ . ' -D macro2'
@@ -608,9 +608,9 @@ Execute(We should quote the flags we need to quote):
   \     '-iframework',
   \     'incframework',
   \     '-include',
-  \     '''foo bar''',
+  \     'file.h',
   \     '-imacros',
-  \     'incmacros',
+  \     'macros.h',
   \     '-Dmacro="value"',
   \     '-DGoal=9',
   \     '-D',


### PR DESCRIPTION
Both '-include' and '-imacros' take a file as an argument that will then
be searched in the include path like a regular '#include "..."'
statement in a source file. As such, they should not have their path
converted to an absolute path.