### PR TITLE
racket/raco: add filename to loc list

### DIFF
--- a/ale_linters/racket/raco.vim
+++ b/ale_linters/racket/raco.vim
@@ -14,6 +14,7 @@ function! ale_linters#racket#raco#Handle(buffer, lines) abort
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
+        \   'filename': l:match[2],
         \   'lnum': l:match[3] + 0,
         \   'col': l:match[4] + 0,
         \   'type': 'E',

--- a/test/handler/test_raco_handler.vader
+++ b/test/handler/test_raco_handler.vader
@@ -8,6 +8,7 @@ Execute(The raco handler should handle errors for the current file correctly):
   AssertEqual
   \ [
   \   {
+  \     'filename': 'foo.rkt',
   \     'lnum': 4,
   \     'col': 1,
   \     'type': 'E',


### PR DESCRIPTION
This allows the location list from one buffer to point to an issue in
another; previously, the error message would be shown but with no way to
jump to it.
