### PR TITLE
Change checkstyle's output sub_type to style

### DIFF
--- a/ale_linters/java/checkstyle.vim
+++ b/ale_linters/java/checkstyle.vim
@@ -14,6 +14,7 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'type': l:match[1] is? 'WARN' ? 'W' : 'E',
+        \   'sub_type': 'style',
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
         \   'text': l:match[4],
@@ -31,6 +32,7 @@ function! ale_linters#java#checkstyle#Handle(buffer, lines) abort
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'type': l:match[3] is? 'warning' ? 'W' : 'E',
+        \   'sub_type': 'style',
         \   'lnum': l:match[2] + 0,
         \   'text': l:match[4],
         \})

--- a/test/handler/test_checkstyle_handler.vader
+++ b/test/handler/test_checkstyle_handler.vader
@@ -13,6 +13,7 @@ Execute(The checkstyle handler should parse lines correctly):
   \     'text': '''method def rcurly'' has incorrect indentation level 4, expected level should be 2.',
   \     'code': 'Indentation',
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \   {
   \     'lnum': 63,
@@ -20,6 +21,7 @@ Execute(The checkstyle handler should parse lines correctly):
   \     'text': 'Missing a Javadoc comment.',
   \     'code': 'JavadocMethod',
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \   {
   \     'lnum': 11,
@@ -27,6 +29,7 @@ Execute(The checkstyle handler should parse lines correctly):
   \     'text': 'WhitespaceAround: ''if'' is not followed by whitespace.',
   \     'code': 'WhitespaceAround',
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \ ],
   \ ale_linters#java#checkstyle#Handle(666, [
@@ -42,6 +45,7 @@ Execute(The checkstyle handler should parse lines from older checkstyle versions
   \     'lnum': 289,
   \     'text': '''method def modifier'' have incorrect indentation level 4, expected level should be 2.',
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \ ],
   \ ale_linters#java#checkstyle#Handle(666, [


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Checkstyle's output should have `style` as `sub_type`, otherwise it causes
issues such as wrong sign column icons.

`./run-tests` all passed.
