### PR TITLE
ALERename: Fix an issue with unlisted buffers

### DIFF
--- a/test/test_code_action.vader
+++ b/test/test_code_action.vader
@@ -36,10 +36,10 @@ Before:
 
 After:
   " Close the extra buffers if we opened it.
-  if bufnr(g:file1) != -1
+  if bufnr(g:file1) != -1 && buflisted(bufnr(g:file1))
     execute ':bp! | :bd! ' . bufnr(g:file1)
   endif
-  if bufnr(g:file2) != -1
+  if bufnr(g:file2) != -1 && buflisted(bufnr(g:file2))
     execute ':bp! | :bd! ' . bufnr(g:file2)
   endif
 
@@ -251,6 +251,45 @@ Execute(Current buffer contents will be reloaded):
   \  'type B: number',
   \] + g:test.text, getbufline(g:test.buffer, 1, '$')
 
+
+Execute(Unlisted buffer contents will be modified correctly):
+  let g:test.text = [
+  \ 'class Name {',
+  \ '  value: string',
+  \ '}',
+  \]
+  call writefile(g:test.text, g:file1, 'S')
+
+  execute 'edit ' . g:file1
+  let g:test.buffer = bufnr(g:file1)
+
+  execute 'bd'
+  AssertEqual bufnr(g:file1), g:test.buffer
+
+  call ale#code_action#HandleCodeAction(
+  \ {
+  \   'changes': [{
+  \      'fileName': g:file1,
+  \      'textChanges': [{
+  \        'start': {
+  \          'line': 1,
+  \          'offset': 1,
+  \        },
+  \        'end': {
+  \          'line': 1,
+  \          'offset': 1,
+  \        },
+  \        'newText': "type A: string\ntype B: number\n",
+  \      }],
+  \   }]
+  \ },
+  \ {'should_save': 1},
+  \)
+
+  AssertEqual [
+  \  'type A: string',
+  \  'type B: number',
+  \] + g:test.text + [''], readfile(g:file1, 'b')
 
 # Tests for cursor repositioning. In comments `=` designates change range, and
 # `C` cursor position


### PR DESCRIPTION
After calling ALERename on certain symbols, some files would be incorrectly replaced. The whole file would be truncated, and the only contents would be the new variable name.

I was able to consistently reproduce it using the following configuration:

    let g:ale_linters = {
    \  'go': ['gopls', 'golangci-lint'],
    \}

Whenever I rename a symbol in `myfile.go` which is also referenced from an unopened file `myfile_test.go`, the whole `myfile_test.go` is truncated.

I tracked it down to `bufnr('/path/to/myfile_test.go')` returning number for a buffer that I never opened.

I later noticed that this buffer was unlisted (visible only via `:ls!`). So there must be something in the golangci-lint linter that opens this file in the background.

This fix adds a check for hidden buffers before applying code actions.

Closes #3781