### PR TITLE
Add stdin ("-") to the command-line arguments of ansible-lint >=5.0.0

### DIFF
--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -73,7 +73,7 @@ endfunction
 
 function! ale_linters#ansible#ansible_lint#GetCommand(buffer, version) abort
     let l:commands = {
-    \   '>=5.0.0': '%e --parseable-severity -x yaml',
+    \   '>=5.0.0': '%e --parseable-severity -x yaml -',
     \   '<5.0.0': '%e -p %t'
     \}
     let l:command = ale#semver#GTE(a:version, [5, 0]) ? l:commands['>=5.0.0'] : l:commands['<5.0.0']

--- a/test/linter/test_ansible_lint.vader
+++ b/test/linter/test_ansible_lint.vader
@@ -13,7 +13,7 @@ Execute(The ansible_lint version <5.0.0 command callback should return default s
 
 Execute(The ansible_lint version >=5.0.0 command callback should return default string):
   GivenCommandOutput ['v5.1.2']
-  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --parseable-severity -x yaml'
+  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --parseable-severity -x yaml -'
 
 Execute(The ansible_lint executable should be configurable):
   let g:ale_ansible_ansible_lint_executable = '~/.local/bin/ansible-lint'


### PR DESCRIPTION
Ansible-lint version >=5.0.0 ignores the standard input when "-" or "/dev/stdin" is not explicitly specified in the arguments:
```
:ALEInfo
(finished - exit code 0) ['/bin/bash', '-c', ''ansible-lint'' --parseable-severity -x yaml < ''/tmp/vVyvn4B/7/test2.yml'']
<<<NO OUTPUT RETURNED>>>'
```

This commit adds "-" to the arguments of  ansible-lint version >=5.0.0 (file: ale_linters/ansible/ansible_lint.vim).

**Steps to reproduce the bug:**

Tested with: ansible-lint 5.0.12 using ansible 2.11.2

Create the file "test.yml":
```
- hosts: localhost
  gather_facts: no
  tasks:
    - name: "Shell test"
      shell: "ls /"
```

Execute "ansible-lint" without "-" (result: no output):
```shell
$ ansible-lint --parseable-severity -x yaml < test.yml
```

Execute "ansible-lint" with "-" (result: the errors are displayed):
```shell
$ ansible-lint --parseable-severity -x yaml - < test.yml
WARNING  Listing 1 violation(s) that are fatal
stdin:1: [internal-error] [VERY_HIGH] Unexpected error code 1 from execution of: ansible-playbook --syntax-check /tmp/tmp939mrvbkplaybook.yml
You can skip specific rules or tags by adding them to your configuration file:
# .ansible-lint
warn_list:  # or 'skip_list' to silence them completely
  - internal-error  # Unexpected internal error

Finished with 1 failure(s), 0 warning(s) on 1 files.
```