### PR TITLE
Use filter pattern instead of regex for tags filter in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,8 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches: [ master ]  # yamllint disable-line rule:brackets
     tags:
-      - /^v\d+\.\d+\.(x|\d+)$/
+      - v[0-9]+.[0-9]+.x
+      - v[0-9]+.[0-9]+.[0-9]+
   pull_request:
     branches: [ master ]  # yamllint disable-line rule:brackets
 


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

This is a fix for GitHub Actions CI workflow. `main.yml` now uses regular expression to filtering tags. However, regular expression is not supported by tag, path, branch filters.

- Filter document: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
- Answer by GitHub staff: https://github.community/t/using-regex-for-filtering/16427/2

I also confirmed that the CI for `v3.1.0` tag at Feb. 7 did not run by checking history of workflow runs.

This PR fixes the tags filter using [pattern syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) which is equivalent to the current regular expression.
