### PR TITLE
Perform inverse filename mapping on GoToDefinition

### DIFF
--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -78,6 +78,10 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
                 let l:column = l:item.range.start.character + 1
             endif
 
+            let l:mappings = ale#GetFilenameMappings(bufnr(''), "elixir-ls")
+            let l:mappings = ale#filename_mapping#Invert(l:mappings)
+            let l:filename = ale#filename_mapping#Map(l:filename, l:mappings)
+
             call ale#definition#UpdateTagStack()
             call ale#util#Open(l:filename, l:line, l:column, l:options)
             break

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -34,6 +34,11 @@ endfunction
 function! s:HandleLSPDiagnostics(conn_id, response) abort
     let l:linter_name = s:lsp_linter_map[a:conn_id]
     let l:filename = ale#path#FromURI(a:response.params.uri)
+
+    let l:mappings = ale#GetFilenameMappings(bufnr(''), l:linter_name)
+    let l:mappings = ale#filename_mapping#Invert(l:mappings)
+    let l:filename = ale#filename_mapping#Map(l:filename, l:mappings)
+
     let l:escaped_name = escape(
     \   fnameescape(l:filename),
     \   has('win32') ? '^' : '^,}]'

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -51,10 +51,16 @@ function! ale#references#HandleLSPResponse(conn_id, response) abort
         let l:result = get(a:response, 'result', [])
         let l:item_list = []
 
+        let l:mappings = ale#GetFilenameMappings(bufnr(''), "elixir-ls")
+        let l:mappings = ale#filename_mapping#Invert(l:mappings)
+
         if type(l:result) is v:t_list
             for l:response_item in l:result
+                let l:filename = ale#path#FromURI(l:response_item.uri)
+                let l:filename = ale#filename_mapping#Map(l:filename, l:mappings)
+
                 call add(l:item_list, {
-                \ 'filename': ale#path#FromURI(l:response_item.uri),
+                \ 'filename': l:filename,
                 \ 'line': l:response_item.range.start.line + 1,
                 \ 'column': l:response_item.range.start.character + 1,
                 \})


### PR DESCRIPTION
Rough fix for https://github.com/dense-analysis/ale/issues/3492. I'm afraid I don't know much vimscript and am short on time. I haven't been able to figure out how to pass the linter name through sensibly, so it's hard-coded, which works OK as a hack for my purposes.

It looks to me like this problem is likely to affect *all* LSP linters, so I'm surprised noone else has encountered this issue so far.