### PR TITLE
racket: support racket-langserver lsp

### DIFF
--- a/ale_linters/racket/langserver.vim
+++ b/ale_linters/racket/langserver.vim
@@ -1,0 +1,7 @@
+call ale#linter#Define('racket', #{
+\   name: 'racket-langserver',
+\   lsp: 'stdio',
+\   executable: 'racket',
+\   command: '%e -l racket-langserver',
+\   project_root: function('ale#racket#FindProjectRoot'),
+\})

--- a/ale_linters/racket/langserver.vim
+++ b/ale_linters/racket/langserver.vim
@@ -1,7 +1,7 @@
-call ale#linter#Define('racket', #{
-\   name: 'racket-langserver',
-\   lsp: 'stdio',
-\   executable: 'racket',
-\   command: '%e -l racket-langserver',
-\   project_root: function('ale#racket#FindProjectRoot'),
+call ale#linter#Define('racket', {
+\   'name': 'racket-langserver',
+\   'lsp': 'stdio',
+\   'executable': 'racket',
+\   'command': '%e -l racket-langserver',
+\   'project_root': function('ale#racket#FindProjectRoot'),
 \})

--- a/ale_linters/racket/langserver.vim
+++ b/ale_linters/racket/langserver.vim
@@ -1,5 +1,5 @@
 call ale#linter#Define('racket', {
-\   'name': 'racket-langserver',
+\   'name': 'racket_langserver',
 \   'lsp': 'stdio',
 \   'executable': 'racket',
 \   'command': '%e -l racket-langserver',

--- a/autoload/ale/racket.vim
+++ b/autoload/ale/racket.vim
@@ -1,4 +1,4 @@
-function ale#racket#FindProjectRoot(buffer) abort
+function! ale#racket#FindProjectRoot(buffer) abort
     let l:cwd = expand('#' . a:buffer . ':p:h')
     let l:highest_init = l:cwd
 

--- a/autoload/ale/racket.vim
+++ b/autoload/ale/racket.vim
@@ -1,12 +1,12 @@
 function ale#racket#FindProjectRoot(buffer) abort
-  let l:cwd = expand('#' . a:buffer . ':p:h')
-  let l:highest_init = l:cwd
+    let l:cwd = expand('#' . a:buffer . ':p:h')
+    let l:highest_init = l:cwd
 
-  for l:path in ale#path#Upwards(l:cwd)
-    if filereadable(l:path.'/init.rkt')
-      let l:highest_init = l:path
-    endif
-  endfor
+    for l:path in ale#path#Upwards(l:cwd)
+        if filereadable(l:path.'/init.rkt')
+            let l:highest_init = l:path
+        endif
+    endfor
 
-  return l:highest_init
+    return l:highest_init
 endfunction

--- a/autoload/ale/racket.vim
+++ b/autoload/ale/racket.vim
@@ -1,0 +1,5 @@
+function ale#racket#FindProjectRoot(buffer) abort
+  let l:nearest_init = ale#path#FindNearestFile(a:buffer, 'init.rkt')
+  let l:cwd = expand('#' . a:buffer . ':p:h')
+  return empty(l:nearest_init) ? l:cwd : l:nearest_init
+endfunction

--- a/autoload/ale/racket.vim
+++ b/autoload/ale/racket.vim
@@ -1,5 +1,12 @@
 function ale#racket#FindProjectRoot(buffer) abort
-  let l:nearest_init = ale#path#FindNearestFile(a:buffer, 'init.rkt')
   let l:cwd = expand('#' . a:buffer . ':p:h')
-  return empty(l:nearest_init) ? l:cwd : l:nearest_init
+  let l:highest_init = l:cwd
+
+  for l:path in ale#path#Upwards(l:cwd)
+    if filereadable(l:path.'/init.rkt')
+      let l:highest_init = l:path
+    endif
+  endfor
+
+  return l:highest_init
 endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -428,6 +428,7 @@ Notes:
   * `styler`
 * Racket
   * `raco`
+  * `racket-langserver`
 * Re:VIEW
   * `redpen`
 * ReasonML

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -427,8 +427,8 @@ Notes:
   * `lintr`
   * `styler`
 * Racket
-  * `raco`
   * `racket-langserver`
+  * `raco`
 * Re:VIEW
   * `redpen`
 * ReasonML

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -437,6 +437,7 @@ formatting.
   * [styler](https://github.com/r-lib/styler)
 * Racket
   * [raco](https://docs.racket-lang.org/raco/)
+  * [racket-langserver](https://github.com/jeapostrophe/racket-langserver/tree/master)
 * Re:VIEW
   * [redpen](http://redpen.cc/)
 * ReasonML

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -436,8 +436,8 @@ formatting.
   * [lintr](https://github.com/jimhester/lintr)
   * [styler](https://github.com/r-lib/styler)
 * Racket
-  * [raco](https://docs.racket-lang.org/raco/)
   * [racket-langserver](https://github.com/jeapostrophe/racket-langserver/tree/master)
+  * [raco](https://docs.racket-lang.org/raco/)
 * Re:VIEW
   * [redpen](http://redpen.cc/)
 * ReasonML

--- a/test/linter/test_racket_langserver.vader
+++ b/test/linter/test_racket_langserver.vader
@@ -1,0 +1,45 @@
+" Author: D. Ben Knoble <https://github.com/benknoble>
+" Description: Tests for racket-langserver lsp linter.
+Before:
+  call ale#assert#SetUpLinterTest('racket', 'langserver')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(command callback should return default string):
+  AssertLinter 'racket', ale#Escape('racket -l racket-langserver')
+
+Execute(should set racket-langserver for deep module 3):
+  call ale#test#SetFilename('../test-files/racket/many-inits/a/b/c/foo.rkt')
+  AssertLSPLanguage 'racket'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject ale#test#GetFilename('../test-files/racket/many-inits')
+
+Execute(should set racket-langserver for deep module 2):
+  call ale#test#SetFilename('../test-files/racket/many-inits/a/b/foo.rkt')
+  AssertLSPLanguage 'racket'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject ale#test#GetFilename('../test-files/racket/many-inits')
+
+Execute(should set racket-langserver for deep module 1):
+  call ale#test#SetFilename('../test-files/racket/many-inits/a/foo.rkt')
+  AssertLSPLanguage 'racket'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject ale#test#GetFilename('../test-files/racket/many-inits')
+
+Execute(should set racket-langserver for top-level module):
+  call ale#test#SetFilename('../test-files/racket/many-inits/foo.rkt')
+  AssertLSPLanguage 'racket'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject ale#test#GetFilename('../test-files/racket/many-inits')
+
+Execute(should set racket-langserver for non-package module or script):
+  call ale#test#SetFilename('../test-files/racket/simple-script/foo.rkt')
+  AssertLSPLanguage 'racket'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject ale#test#GetFilename('../test-files/racket/simple-script/')

--- a/test/linter/test_racket_langserver.vader
+++ b/test/linter/test_racket_langserver.vader
@@ -7,7 +7,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(command callback should return default string):
-  AssertLinter 'racket', ale#Escape('racket -l racket-langserver')
+  AssertLinter 'racket', ale#Escape('racket').' -l racket-langserver'
 
 Execute(should set racket-langserver for deep module 3):
   call ale#test#SetFilename('../test-files/racket/many-inits/a/b/c/foo.rkt')
@@ -42,4 +42,4 @@ Execute(should set racket-langserver for non-package module or script):
   AssertLSPLanguage 'racket'
   AssertLSPOptions {}
   AssertLSPConfig {}
-  AssertLSPProject ale#test#GetFilename('../test-files/racket/simple-script/')
+  AssertLSPProject ale#test#GetFilename('../test-files/racket/simple-script')

--- a/test/test-files/racket/many-inits/a/b/c/foo.rkt
+++ b/test/test-files/racket/many-inits/a/b/c/foo.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+
+(displayln "foo")

--- a/test/test-files/racket/many-inits/a/b/c/init.rkt
+++ b/test/test-files/racket/many-inits/a/b/c/init.rkt
@@ -1,0 +1,1 @@
+#lang info

--- a/test/test-files/racket/many-inits/a/b/foo.rkt
+++ b/test/test-files/racket/many-inits/a/b/foo.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+
+(displayln "foo")

--- a/test/test-files/racket/many-inits/a/b/init.rkt
+++ b/test/test-files/racket/many-inits/a/b/init.rkt
@@ -1,0 +1,1 @@
+#lang info

--- a/test/test-files/racket/many-inits/a/foo.rkt
+++ b/test/test-files/racket/many-inits/a/foo.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+
+(displayln "foo")

--- a/test/test-files/racket/many-inits/a/init.rkt
+++ b/test/test-files/racket/many-inits/a/init.rkt
@@ -1,0 +1,1 @@
+#lang info

--- a/test/test-files/racket/many-inits/foo.rkt
+++ b/test/test-files/racket/many-inits/foo.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+
+(displayln "foo")

--- a/test/test-files/racket/many-inits/init.rkt
+++ b/test/test-files/racket/many-inits/init.rkt
@@ -1,0 +1,1 @@
+#lang info

--- a/test/test-files/racket/simple-script/foo.rkt
+++ b/test/test-files/racket/simple-script/foo.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+
+(displayln "foo")


### PR DESCRIPTION
Not sure what tests are reasonable for an LSP linter. This worked for me after `raco pkg install racket-langserver`.

Notably, before I did that, the LSP didn't work (obviously), but I could see no error messages; only "executable check—success" for `racket`.
