### PR TITLE
Add support for local PHPStan executables

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -6,6 +6,7 @@ let g:ale_php_phpstan_executable = get(g:, 'ale_php_phpstan_executable', 'phpsta
 let g:ale_php_phpstan_level = get(g:, 'ale_php_phpstan_level', '')
 let g:ale_php_phpstan_configuration = get(g:, 'ale_php_phpstan_configuration', '')
 let g:ale_php_phpstan_autoload = get(g:, 'ale_php_phpstan_autoload', '')
+call ale#Set('php_phpstan_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     let l:configuration = ale#Var(a:buffer, 'php_phpstan_configuration')
@@ -64,10 +65,16 @@ endfunction
 
 call ale#linter#Define('php', {
 \   'name': 'phpstan',
-\   'executable': {b -> ale#Var(b, 'php_phpstan_executable')},
+\   'executable': {buffer -> ale#path#FindExecutable(buffer, 'php_phpstan', [
+\       'vendor/bin/phpstan',
+\       'phpstan'
+\   ])},
 \   'command': {buffer -> ale#semver#RunWithVersionCheck(
 \       buffer,
-\       ale#Var(buffer, 'php_phpstan_executable'),
+\       ale#path#FindExecutable(buffer, 'php_phpstan', [
+\           'vendor/bin/phpstan',
+\           'phpstan'
+\       ]),
 \       '%e --version',
 \       function('ale_linters#php#phpstan#GetCommand'),
 \   )},

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -21,6 +21,26 @@ After:
   unlet! g:old_dir
   call ale#assert#TearDownLinterTest()
 
+Execute(The local phpstan executable should be used):
+  call mkdir('vendor/bin', 'p', 0750)
+  call writefile([''], 'vendor/bin/phpstan')
+  call ale#test#SetFilename('phpstan-test-files/foo/test.php')
+
+  let g:executable = ale#path#Simplify(g:dir . '/vendor/bin/phpstan')
+
+  AssertLinter g:executable,
+  \ ale#Escape(g:executable) . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' %s'
+
+Execute(use_global should override local executable detection):
+  let g:ale_php_phpstan_use_global = 1
+
+  call mkdir('vendor/bin', 'p', 0750)
+  call writefile([''], 'vendor/bin/phpstan')
+  call ale#test#SetFilename('phpstan-test-files/foo/test.php')
+
+  AssertLinter 'phpstan',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' %s'
+
 Execute(Custom executables should be used for the executable and command):
   let g:ale_php_phpstan_executable = 'phpstan_test'
 
@@ -65,7 +85,7 @@ Execute(Configuration dist file exists in current directory):
 
   AssertLinter 'phpstan', [
   \ ale#Escape('phpstan') . ' --version',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat raw %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json %s'
   \ ]
 
 Execute(Configuration file exists in current directory, but force phpstan level):


### PR DESCRIPTION
Usually you have PHPStan installed in your project. The location is `./vendor/bin/phpstan`.

This PR extends the PHPStan linter to pick up the project local executable if available.