### PR TITLE
Fix 3674 - Add nocolor option to ansible-lint

### DIFF
--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -73,8 +73,8 @@ endfunction
 
 function! ale_linters#ansible#ansible_lint#GetCommand(buffer, version) abort
     let l:commands = {
-    \   '>=5.0.0': '%e --parseable-severity -x yaml -',
-    \   '<5.0.0': '%e -p %t'
+    \   '>=5.0.0': '%e --nocolor --parseable-severity -x yaml -',
+    \   '<5.0.0': '%e --nocolor -p %t'
     \}
     let l:command = ale#semver#GTE(a:version, [5, 0]) ? l:commands['>=5.0.0'] : l:commands['<5.0.0']
 

--- a/test/linter/test_ansible_lint.vader
+++ b/test/linter/test_ansible_lint.vader
@@ -9,14 +9,14 @@ After:
 
 Execute(The ansible_lint version <5.0.0 command callback should return default string):
   GivenCommandOutput ['v4.1.2']
-  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' -p %t'
+  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --nocolor -p %t'
 
 Execute(The ansible_lint version >=5.0.0 command callback should return default string):
   GivenCommandOutput ['v5.1.2']
-  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --parseable-severity -x yaml -'
+  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --nocolor --parseable-severity -x yaml -'
 
 Execute(The ansible_lint executable should be configurable):
   let g:ale_ansible_ansible_lint_executable = '~/.local/bin/ansible-lint'
   GivenCommandOutput ['v4.1.2']
   AssertLinter '~/.local/bin/ansible-lint',
-  \ ale#Escape('~/.local/bin/ansible-lint') . ' -p %t'
+  \ ale#Escape('~/.local/bin/ansible-lint') . ' --nocolor -p %t'


### PR DESCRIPTION
Adds --nocolor option to ansible-lint command.

Fixes: #3674
