### PR TITLE
Add option to clojure clj-kondo linter

### DIFF
--- a/ale_linters/clojure/clj_kondo.vim
+++ b/ale_linters/clojure/clj_kondo.vim
@@ -1,6 +1,18 @@
 " Author: Masashi Iizuka <liquidz.uo@gmail.com>
 " Description: linter for clojure using clj-kondo https://github.com/borkdude/clj-kondo
 
+call ale#Set('clojure_clj_kondo_options', '--cache')
+
+function! ale_linters#clojure#clj_kondo#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'clojure_clj_kondo_options')
+
+    let l:command = 'clj-kondo'
+    \   . ale#Pad(l:options)
+    \   . ' --lint %t'
+
+    return l:command
+endfunction
+
 function! ale_linters#clojure#clj_kondo#HandleCljKondoFormat(buffer, lines) abort
     " output format
     " <filename>:<line>:<column>: <issue type>: <message>
@@ -29,6 +41,6 @@ call ale#linter#Define('clojure', {
 \   'name': 'clj-kondo',
 \   'output_stream': 'stdout',
 \   'executable': 'clj-kondo',
-\   'command': 'clj-kondo --cache --lint %t',
+\   'command': function('ale_linters#clojure#clj_kondo#GetCommand'),
 \   'callback': 'ale_linters#clojure#clj_kondo#HandleCljKondoFormat',
 \})

--- a/doc/ale-clojure.txt
+++ b/doc/ale-clojure.txt
@@ -9,6 +9,14 @@ A minimal and opinionated linter for code that sparks joy.
 
 https://github.com/borkdude/clj-kondo
 
+g:ale_clojure_clj_kondo_options               *g:ale_clojure_clj_kondo_options*
+                                              *b:ale_clojure_clj_kondo_options*
+  Type: |String|
+  Default: `'--cache'`
+
+  This variable can be changed to modify options passed to clj-kondo.
+
+
 ===============================================================================
 joker                                                       *ale-clojure-joker*
 

--- a/test/linter/test_clj_kondo.vader
+++ b/test/linter/test_clj_kondo.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#assert#SetUpLinterTest('clojure', 'clj_kondo')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'clj-kondo', 'clj-kondo'
+  \   . ' --cache --lint %t'
+
+Execute(Extra options should be supported):
+  let g:ale_clojure_clj_kondo_options = '--config ./clj-kondo/config.edn'
+
+  AssertLinter 'clj-kondo', 'clj-kondo'
+  \   . ' --config ./clj-kondo/config.edn --lint %t'


### PR DESCRIPTION
Allow define `ale_clojure_clj_kondo_options` variable to change command options.

This would help #3412, by setting `--config path/to/config.edn` can make `clj-kondo` work correctly.

Small change, so only mininal linter test added here.