### PR TITLE
Python .tool versions

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -34,6 +34,7 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/Pipfile.lock')
         \|| filereadable(l:path . '/poetry.lock')
         \|| filereadable(l:path . '/pyproject.toml')
+        \|| filereadable(l:path . '/.tool_versions')
             return l:path
         endif
     endfor

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -38,6 +38,7 @@ ALE will look for configuration files with the following filenames. >
   Pipfile.lock
   poetry.lock
   pyproject.toml
+  .tool_versions
 <
 
 The first directory containing any of the files named above will be used.


### PR DESCRIPTION
This pull request adds .tool_versions to the list of config files used when determining the project root directory for python projects. Both the actual files checked and the corresponding documentation have been updated.

Rationale: 

A minimal python project may only be specifying a python version using a version management tool like asdf-vm, without providing other common python project configuration files.  asdf-vm in particular creates a single .tool_versions file in the managed directory. 

Currently, if .tool_versions is the only project config file, and any of the currently supported config files exist in a parent directory (eg: a global .pylintrc in the user's home directory), then ale will run the selected linters from that parent directory instead of the project directory. This can result in using a completely different version of python than that being used by vim itself.

By checking for .tool_versions in addition to other common python config files we ensure that python linters (whose behaviour typically depends on a particular python version) will run with the same version of python used by the project. This will also be the same python version used by vim itself when it is run from inside the project's directories.