### PR TITLE
Update erlang format for OTP24

### DIFF
--- a/ale_linters/erlang/erlc.vim
+++ b/ale_linters/erlang/erlc.vim
@@ -25,7 +25,7 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
     " error.erl:4: variable 'B' is unbound
     " error.erl:3: Warning: function main/0 is unused
     " error.erl:4: Warning: variable 'A' is unused
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+): (Warning: )?(.+)$'
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):(\d+:)? (Warning: )?(.+)$'
 
     " parse_transforms are a special case. The error message does not indicate a location:
     " error.erl: undefined parse transform 'some_parse_transform'
@@ -65,8 +65,8 @@ function! ale_linters#erlang#erlc#Handle(buffer, lines) abort
         endif
 
         let l:line = l:match[2]
-        let l:warning_or_text = l:match[3]
-        let l:text = l:match[4]
+        let l:warning_or_text = l:match[4]
+        let l:text = l:match[5]
 
         " If this file is a header .hrl, ignore the following expected messages:
         " - 'no module definition'

--- a/test/linter/test_erlang_erlc.vader
+++ b/test/linter/test_erlang_erlc.vader
@@ -38,3 +38,25 @@ Execute(The command should accept configured options.):
     \   g:matched,
     \   -1,
     \   'Command error: expected [' . g:cmd . '] to match [' . g:regex . ']'
+
+Execute(Linter should recognize OTP23 format.):
+    let g:lines = ["t.erl:6: only association operators '=>' are allowed in map construction"]
+    let g:output_text = ale_linters#erlang#erlc#Handle(bufnr(''), g:lines)[0].text
+
+    let g:expected = "only association operators '=>' are allowed in map construction"
+    AssertEqual
+    \   g:output_text,
+    \   g:expected,
+    \   'Command error: expected [' . g:output_text . '] to match [' . g:expected . ']'
+
+Execute(Linter should recognize OTP24 format.):
+    let g:lines = ["t.erl:6:16: only association operators '=>' are allowed in map construction",
+    \              "%    6|   #{ a => A, b := B }.",
+    \              "%     |                ^"]
+    let g:output_text = ale_linters#erlang#erlc#Handle(bufnr(''), g:lines)[0].text
+
+    let g:expected = "only association operators '=>' are allowed in map construction"
+    AssertEqual
+    \   g:output_text,
+    \   g:expected,
+    \   'Command error: expected [' . g:output_text . '] to match [' . g:expected . ']'


### PR DESCRIPTION
Erlang's erlc error format includes the column in OTP24.
See https://blog.erlang.org/My-OTP-24-Highlights/#column-number-in-warnings-and-errors
