### PR TITLE
Add support for `dart analyze`

### DIFF
--- a/ale_linters/dart/dart_analyze.vim
+++ b/ale_linters/dart/dart_analyze.vim
@@ -1,0 +1,28 @@
+" Author: ghsang <gwonhyuksang@gmail.com>
+" Description: Check Dart files with dart analyze
+
+call ale#Set('dart_analyze_executable', 'dart')
+
+function! ale_linters#dart#dart_analyze#Handle(buffer, lines) abort
+    let l:pattern = '\v^  ([a-z]+) - (.+):(\d+):(\d+) - (.+) - (.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'type': l:match[1] is# 'error' ? 'E' : 'W',
+        \   'text': l:match[6] . ': ' . l:match[5],
+        \   'lnum': str2nr(l:match[3]),
+        \   'col': str2nr(l:match[4]),
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('dart', {
+\   'name': 'dart_analyze',
+\   'executable': {b -> ale#Var(b, 'dart_analyze_executable')},
+\   'command': '%e analyze %s',
+\   'callback': 'ale_linters#dart#dart_analyze#Handle',
+\   'lint_file': 1,
+\})

--- a/doc/ale-dart.txt
+++ b/doc/ale-dart.txt
@@ -28,35 +28,31 @@ g:ale_dart_analysis_server_executable   *g:ale_dart_analysis_server_executable*
 
 
 ===============================================================================
-dartanalyzer                                            *ale-dart-dartanalyzer*
+dart-analyze                                                 *ale-dart-analyze*
 
 Installation
 -------------------------------------------------------------------------------
 
-Install Dart via whatever means. `dartanalyzer` will be included in the SDK.
+Installing Dart should probably ensure that `dart` is in your `$PATH`.
 
-You can add the SDK to `$PATH`, as described here:
-https://www.dartlang.org/tools/sdk
+In case it is not, try to set the executable option to its absolute path. : >
+  " Set the executable path for dart to the absolute path to it.
+  let g:ale_dart_format_executable = '/usr/lib/dart/bin/dart'
+ >
 
-If you have installed Dart on Linux, you can also try the following: >
-  " Set the executable path for dartanalyzer to the absolute path to it.
-  let g:ale_dart_dartanalyzer_executable = '/usr/lib/dart/bin/dartanalyzer'
-<
-... or similarly for wherever your Dart SDK lives. This should work without
-having to modify `$PATH`.
-
-ALE can only check for problems with `dartanalyzer` with the file on disk.
-See |ale-lint-file-linters|
+Install Dart via whatever means. `dart analyze` will be included in the SDK.
 
 Options
 -------------------------------------------------------------------------------
 
-g:ale_dart_dartanalyzer_executable         *g:ale_dart_dartanalyzer_executable*
-                                           *b:ale_dart_dartanalyzer_executable*
+g:ale_dart_analyze_executable                   *g:ale_dart_analyze_executable*
+                                                *b:ale_dart_analyze_executable*
   Type: |String|
-  Default: `'dartanalyzer'`
+  Default: `'dart'`
 
-  This variable can be set to change the path to dartanalyzer.
+  This variable can be set to specify an absolute path to the
+  format executable (or to specify an alternate executable).
+
 
 ===============================================================================
 dart-format                                                   *ale-dart-format*
@@ -89,6 +85,40 @@ g:ale_dart_format_options                           *g:ale_dart_format_options*
   Default: `''`
 
   This variable can be set to pass additional options to the dart format fixer.
+
+
+
+===============================================================================
+dartanalyzer                                            *ale-dart-dartanalyzer*
+
+Installation
+-------------------------------------------------------------------------------
+
+Install Dart via whatever means. `dartanalyzer` will be included in the SDK.
+
+You can add the SDK to `$PATH`, as described here:
+https://www.dartlang.org/tools/sdk
+
+If you have installed Dart on Linux, you can also try the following: >
+  " Set the executable path for dartanalyzer to the absolute path to it.
+  let g:ale_dart_dartanalyzer_executable = '/usr/lib/dart/bin/dartanalyzer'
+<
+... or similarly for wherever your Dart SDK lives. This should work without
+having to modify `$PATH`.
+
+ALE can only check for problems with `dartanalyzer` with the file on disk.
+See |ale-lint-file-linters|
+
+Options
+-------------------------------------------------------------------------------
+
+g:ale_dart_dartanalyzer_executable         *g:ale_dart_dartanalyzer_executable*
+                                           *b:ale_dart_dartanalyzer_executable*
+  Type: |String|
+  Default: `'dartanalyzer'`
+
+  This variable can be set to change the path to dartanalyzer.
+
 
 ===============================================================================
 dartfmt                                                      *ale-dart-dartfmt*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -124,6 +124,7 @@ Notes:
   * `dafny`!!
 * Dart
   * `analysis_server`
+  * `dart-analyze`!!
   * `dart-format`!!
   * `dartanalyzer`!!
   * `dartfmt`!!

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2698,8 +2698,9 @@ documented in additional help files.
     dafny.................................|ale-dafny-dafny|
   dart....................................|ale-dart-options|
     analysis_server.......................|ale-dart-analysis_server|
-    dartanalyzer..........................|ale-dart-dartanalyzer|
+    dart-analyze..........................|ale-dart-analyze|
     dart-format...........................|ale-dart-format|
+    dartanalyzer..........................|ale-dart-dartanalyzer|
     dartfmt...............................|ale-dart-dartfmt|
   desktop.................................|ale-desktop-options|
     desktop-file-validate.................|ale-desktop-desktop-file-validate|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -133,6 +133,7 @@ formatting.
   * [dafny](https://rise4fun.com/Dafny) :floppy_disk:
 * Dart
   * [analysis_server](https://github.com/dart-lang/sdk/tree/master/pkg/analysis_server)
+  * [dart-analyze](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli) :floppy_disk:
   * [dart-format](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)
   * [dartanalyzer](https://github.com/dart-lang/sdk/tree/master/pkg/analyzer_cli) :floppy_disk:
   * [dartfmt](https://github.com/dart-lang/sdk/tree/master/utils/dartfmt)

--- a/test/handler/test_dart_analyze_handler.vader
+++ b/test/handler/test_dart_analyze_handler.vader
@@ -1,0 +1,28 @@
+Before:
+  runtime ale_linters/dart/dart_analyze.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(Basic problems should be parsed correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'type': 'E',
+  \     'text': 'expected_token: Expected to find ''}''',
+  \     'lnum': 5,
+  \     'col': 1,
+  \   },
+  \   {
+  \     'type': 'W',
+  \     'text': 'invalid_assignment: A value of type ''String'' can''t be assigned to a variable of type ''int''',
+  \     'lnum': 2,
+  \     'col': 16,
+  \   },
+  \ ],
+  \ ale_linters#dart#dart_analyze#Handle(bufnr(''), [
+  \ 'Analyzing main.dart...',
+  \ '  error - main.dart:5:1 - Expected to find ''}'' - expected_token',
+  \ '  warning - main.dart:2:16 - A value of type ''String'' can''t be assigned to a variable of type ''int'' - invalid_assignment',
+  \ '1 error and 1 warning found.',
+  \ ])


### PR DESCRIPTION
It seems like `dartanalyzer` has been deprecated in favor of `dart analyze` (https://dart.dev/tools/dart-analyze).