### PR TITLE
Correct typo in python config filenames

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -34,7 +34,7 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/Pipfile.lock')
         \|| filereadable(l:path . '/poetry.lock')
         \|| filereadable(l:path . '/pyproject.toml')
-        \|| filereadable(l:path . '/.tool_versions')
+        \|| filereadable(l:path . '/.tool-versions')
             return l:path
         endif
     endfor

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -38,7 +38,7 @@ ALE will look for configuration files with the following filenames. >
   Pipfile.lock
   poetry.lock
   pyproject.toml
-  .tool_versions
+  .tool-versions
 <
 
 The first directory containing any of the files named above will be used.


### PR DESCRIPTION
In a previous PR I added asdf-vm's config file to the python project config files checked for. Unfortunately there was a typo in the file name .tool_versions should be .tool-versions. This PR corrects the typo in the autoload file and in the corresponding documentation.