### PR TITLE
Fix 3801 - Add ALEDummySign some width.

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -85,7 +85,7 @@ execute 'sign define ALEStyleWarningSign text=' . s:EscapeSignText(g:ale_sign_st
 \   . ' texthl=ALEStyleWarningSign linehl=ALEWarningLine'
 execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 \   . ' texthl=ALEInfoSign linehl=ALEInfoLine'
-sign define ALEDummySign text=\ 
+sign define ALEDummySign text=\  texthl=ALEInfoSign
 
 if g:ale_sign_highlight_linenrs && has('nvim-0.3.2')
     if !hlexists('ALEErrorSignLineNr')

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -85,7 +85,7 @@ execute 'sign define ALEStyleWarningSign text=' . s:EscapeSignText(g:ale_sign_st
 \   . ' texthl=ALEStyleWarningSign linehl=ALEWarningLine'
 execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 \   . ' texthl=ALEInfoSign linehl=ALEInfoLine'
-sign define ALEDummySign
+sign define ALEDummySign text=\ 
 
 if g:ale_sign_highlight_linenrs && has('nvim-0.3.2')
     if !hlexists('ALEErrorSignLineNr')

--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -85,7 +85,7 @@ execute 'sign define ALEStyleWarningSign text=' . s:EscapeSignText(g:ale_sign_st
 \   . ' texthl=ALEStyleWarningSign linehl=ALEWarningLine'
 execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 \   . ' texthl=ALEInfoSign linehl=ALEInfoLine'
-sign define ALEDummySign text=\  texthl=ALEInfoSign
+sign define ALEDummySign text=\  texthl=SignColumn
 
 if g:ale_sign_highlight_linenrs && has('nvim-0.3.2')
     if !hlexists('ALEErrorSignLineNr')


### PR DESCRIPTION
Due to changes in NeoVim 0.5 the g:ale_sign_column_always configuration
stopped working.

This PR sets the ALEDummySign to a blank space so when g:
ale_sign_column_always is set we have a sign with 1 width allowing the
configuration to work as before.

- NeoVim issue: https://github.com/neovim/neovim/issues/13635
- Superceds #3672
- Closes #3801