### PR TITLE
Do not use tempfiles for ansible lint

### DIFF
--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -91,6 +91,7 @@ call ale#linter#Define('ansible', {
 \       '%e --version',
 \       function('ale_linters#ansible#ansible_lint#GetCommand'),
 \   )},
+\   'lint_file': 1,
 \   'callback': {buffer, lines -> ale#semver#RunWithVersionCheck(
 \       buffer,
 \       ale_linters#ansible#ansible_lint#GetExecutable(buffer),

--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -73,7 +73,7 @@ endfunction
 
 function! ale_linters#ansible#ansible_lint#GetCommand(buffer, version) abort
     let l:commands = {
-    \   '>=5.0.0': '%e --nocolor --parseable-severity -x yaml -',
+    \   '>=5.0.0': '%e --nocolor --parseable-severity -x yaml %s',
     \   '<5.0.0': '%e --nocolor -p %t'
     \}
     let l:command = ale#semver#GTE(a:version, [5, 0]) ? l:commands['>=5.0.0'] : l:commands['<5.0.0']

--- a/test/linter/test_ansible_lint.vader
+++ b/test/linter/test_ansible_lint.vader
@@ -13,7 +13,7 @@ Execute(The ansible_lint version <5.0.0 command callback should return default s
 
 Execute(The ansible_lint version >=5.0.0 command callback should return default string):
   GivenCommandOutput ['v5.1.2']
-  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --nocolor --parseable-severity -x yaml -'
+  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --nocolor --parseable-severity -x yaml %s'
 
 Execute(The ansible_lint executable should be configurable):
   let g:ale_ansible_ansible_lint_executable = '~/.local/bin/ansible-lint'


### PR DESCRIPTION
This changes the linter for ansible to not use temporary files by setting lint_file: 1 and changing the command from using stdin to %s.

Should fix #1814 completely

Linting tests pass, and I've verified that errors and warnings from running ansible-lint on the command line match the errors in ALE