### PR TITLE
Fix link to jsonlint

### DIFF
--- a/supported-tools.md
+++ b/supported-tools.md
@@ -270,7 +270,7 @@ formatting.
 * JSON
   * [fixjson](https://github.com/rhysd/fixjson)
   * [jq](https://stedolan.github.io/jq/)
-  * [jsonlint](http://zaa.ch/jsonlint/)
+  * [jsonlint](https://github.com/zaach/jsonlint)
   * [prettier](https://github.com/prettier/prettier)
   * [spectral](https://github.com/stoplightio/spectral)
 * Julia


### PR DESCRIPTION
Just a small link fix, because the original domain doesn't exist anymore...