### PR TITLE
Add a thriftcheck linter

### DIFF
--- a/ale_linters/thrift/thriftcheck.vim
+++ b/ale_linters/thrift/thriftcheck.vim
@@ -1,0 +1,46 @@
+" Author: Jon Parise <jon@indelible.org>
+
+call ale#Set('thrift_thriftcheck_executable', 'thriftcheck')
+call ale#Set('thrift_thriftcheck_options', '')
+
+function! ale_linters#thrift#thriftcheck#GetCommand(buffer) abort
+    return '%e'
+    \   . ale#Pad(ale#Var(a:buffer, 'thrift_thriftcheck_options'))
+    \   . ' --stdin-filename %s'
+    \   . ' %t'
+endfunction
+
+function! ale_linters#thrift#thriftcheck#Handle(buffer, lines) abort
+    " Matches lines like the following:
+    "
+    " file.thrift:1:1:error: "py" namespace must match "^idl\\." (namespace.pattern)
+    " file.thrift:3:5:warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)
+    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):(\d+):(\l+): (.*) \((.*)\)$'
+
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        if l:match[3] is# 'warning'
+            let l:type = 'W'
+        else
+            let l:type = 'E'
+        endif
+
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:type,
+        \   'text': l:match[4],
+        \   'code': l:match[5],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('thrift', {
+\   'name': 'thriftcheck',
+\   'executable': {b -> ale#Var(b, 'thrift_thriftcheck_executable')},
+\   'command': function('ale_linters#thrift#thriftcheck#GetCommand'),
+\   'callback': 'ale_linters#thrift#thriftcheck#Handle',
+\})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -533,6 +533,7 @@ Notes:
   * `write-good`
 * Thrift
   * `thrift`
+  * `thriftcheck`
 * TypeScript
   * `deno`
   * `eslint`

--- a/doc/ale-thrift.txt
+++ b/doc/ale-thrift.txt
@@ -43,4 +43,23 @@ g:ale_thrift_thrift_options                       *g:ale_thrift_thrift_options*
   arguments that are passed to the thrift compiler.
 
 ===============================================================================
+thriftcheck                                            *ale-thrift-thriftcheck*
+
+g:ale_thrift_thriftcheck_executable       *g:ale_thrift_thriftcheck_executable*
+                                          *b:ale_thrift_thriftcheck_executable*
+  Type: |String|
+  Default: `'thriftcheck'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_thrift_thriftcheck_options             *g:ale_thrift_thriftcheck_options*
+                                             *b:ale_thrift_thriftcheck_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to customize the additional command-line
+  arguments that are passed to thriftcheck.
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3053,6 +3053,7 @@ documented in additional help files.
     write-good............................|ale-text-write-good|
   thrift..................................|ale-thrift-options|
     thrift................................|ale-thrift-thrift|
+    thriftcheck...........................|ale-thrift-thriftcheck|
   typescript..............................|ale-typescript-options|
     deno..................................|ale-typescript-deno|
     eslint................................|ale-typescript-eslint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -542,6 +542,7 @@ formatting.
   * [write-good](https://github.com/btford/write-good) :warning:
 * Thrift
   * [thrift](http://thrift.apache.org/)
+  * [thriftcheck](https://github.com/pinterest/thriftcheck)
 * TypeScript
   * [deno](https://deno.land/)
   * [eslint](http://eslint.org/)

--- a/test/handler/test_thriftcheck_handler.vader
+++ b/test/handler/test_thriftcheck_handler.vader
@@ -1,0 +1,28 @@
+Before:
+    runtime ale_linters/thrift/thriftcheck.vim
+
+After:
+    call ale#linter#Reset()
+
+Execute(The thriftcheck handler should handle basic warnings and errors):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': '"py" namespace must match "^idl\\."',
+  \     'code': 'namespace.pattern',
+  \   },
+  \   {
+  \     'lnum': 3,
+  \     'col': 5,
+  \     'type': 'W',
+  \     'text': '64-bit integer constant -2147483649 may not work in all languages',
+  \     'code': 'int.64bit',
+  \   },
+  \ ],
+  \ ale_linters#thrift#thriftcheck#Handle(1, [
+  \   'file.thrift:1:1:error: "py" namespace must match "^idl\\." (namespace.pattern)',
+  \   'file.thrift:3:5:warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)',
+  \ ])

--- a/test/linter/test_thriftcheck.vader
+++ b/test/linter/test_thriftcheck.vader
@@ -1,0 +1,21 @@
+Before:
+  call ale#assert#SetUpLinterTest('thrift', 'thriftcheck')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'thriftcheck', ale#Escape('thriftcheck')
+  \ . ' --stdin-filename %s %t'
+
+Execute(The executable should be configurable):
+  let b:ale_thrift_thriftcheck_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar')
+  \ . ' --stdin-filename %s %t'
+
+Execute(The string of options should be configurable):
+  let b:ale_thrift_thriftcheck_options = '--errors-only'
+
+  AssertLinter 'thriftcheck', ale#Escape('thriftcheck')
+  \ . ' --errors-only --stdin-filename %s %t'


### PR DESCRIPTION
ThriftCheck (https://github.com/pinterest/thriftcheck) is a linter for
Thrift IDL files.