### PR TITLE
Fix lint tests failing due to multibyte chars.

### DIFF
--- a/ale_linters/mail/languagetool.vim
+++ b/ale_linters/mail/languagetool.vim
@@ -1,4 +1,4 @@
-" Author: Vincent (wahrwolf [ät] wolfpit.net)
+" Author: Vincent (wahrwolf [at] wolfpit.net)
 " Description: languagetool for mails
 
 

--- a/ale_linters/markdown/languagetool.vim
+++ b/ale_linters/markdown/languagetool.vim
@@ -1,4 +1,4 @@
-" Author: Vincent (wahrwolf [ät] wolfpit.net)
+" Author: Vincent (wahrwolf [at] wolfpit.net)
 " Description: languagetool for markdown files
 
 

--- a/autoload/ale/fixers/dhall_freeze.vim
+++ b/autoload/ale/fixers/dhall_freeze.vim
@@ -1,5 +1,5 @@
 " Author: toastal <toastal@protonmail.com>
-" Description: Dhall’s package freezing
+" Description: Dhall's package freezing
 
 call ale#Set('dhall_freeze_options', '')
 


### PR DESCRIPTION
For some reason CI tests started failing with these errors:

> ale_linters/eruby/erb.vim:1:1: Use scriptencoding when multibyte char exists (see :help :scriptencoding)
> ale_linters/mail/languagetool.vim:1:1: Use scriptencoding when multibyte char exists (see :help :scriptencoding)

Not sure at which point or what changed for this to happen but this MR
fixes it by removing the multibyte chars present on the problem files.

