### PR TITLE
Adds fixer for golines

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -246,6 +246,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['go'],
 \       'description': 'Fix Go files imports with goimports.',
 \   },
+\   'golines': {
+\       'function': 'ale#fixers#golines#Fix',
+\       'suggested_filetypes': ['go'],
+\        'description': 'Fix Go file long lines with golines',
+\   },
 \   'gomod': {
 \       'function': 'ale#fixers#gomod#Fix',
 \       'suggested_filetypes': ['gomod'],

--- a/autoload/ale/fixers/golines.vim
+++ b/autoload/ale/fixers/golines.vim
@@ -1,0 +1,21 @@
+" Author Pig Frown <pigfrown@protonmail.com>
+" Description: Fix Go files long lines with golines"
+
+call ale#Set('go_golines_executable', 'golines')
+
+call ale#Set('go_golines_options', '')
+
+function! ale#fixers#golines#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'go_golines_executable')
+    let l:options = ale#Var(a:buffer, 'go_golines_options')
+    let l:env = ale#go#EnvString(a:buffer)
+
+    if !executable(l:executable)
+        return 0
+    endif
+
+    return {
+    \   'command': l:env . ale#Escape(l:executable)
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \}
+endfunction

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -133,6 +133,23 @@ g:ale_go_langserver_options                       *g:ale_go_langserver_options*
   `-gocodecompletion` option is ignored because it is handled automatically
   by the |g:ale_completion_enabled| variable.
 
+===============================================================================
+golines                                                          *ale-go-lines*
+
+g:ale_go_golines_executable                         *g:ale_go_lines_executable*
+                                                    *b:ale_go_lines_executable*
+  Type: |String|
+  Default: `'golines'`
+
+  Location of the golines binary file
+
+g:ale_go_golines_options                             *g:ale_go_golines_options*
+                                                     *b:ale_go_golines_options*
+  Type: |String|
+  Default: ''
+
+  Additional options passed to the golines command. By default golines has 
+  --max-length=100 (lines above 100 characters will be wrapped)
 
 ===============================================================================
 golint                                                          *ale-go-golint*

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -134,7 +134,7 @@ g:ale_go_langserver_options                       *g:ale_go_langserver_options*
   by the |g:ale_completion_enabled| variable.
 
 ===============================================================================
-golines                                                          *ale-go-lines*
+golines                                                        *ale-go-golines*
 
 g:ale_go_golines_executable                         *g:ale_go_lines_executable*
                                                     *b:ale_go_lines_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -184,6 +184,7 @@ Notes:
   * `golangci-lint`!!
   * `golangserver`
   * `golint`
+	* golines
   * `gometalinter`!!
   * `gopls`
   * `gosimple`!!

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -183,7 +183,7 @@ Notes:
   * `goimports`
   * `golangci-lint`!!
   * `golangserver`
-	* golines
+  * `golines`
   * `golint`
   * `gometalinter`!!
   * `gopls`

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -183,8 +183,8 @@ Notes:
   * `goimports`
   * `golangci-lint`!!
   * `golangserver`
-  * `golint`
 	* golines
+  * `golint`
   * `gometalinter`!!
   * `gopls`
   * `gosimple`!!

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2750,8 +2750,8 @@ documented in additional help files.
     gofmt.................................|ale-go-gofmt|
     golangci-lint.........................|ale-go-golangci-lint|
     golangserver..........................|ale-go-golangserver|
-    golint................................|ale-go-golint|
     golines...............................|ale-go-golines|
+    golint................................|ale-go-golint|
     gometalinter..........................|ale-go-gometalinter|
     gopls.................................|ale-go-gopls|
     govet.................................|ale-go-govet|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1,4 +1,4 @@
-*ale.txt*	Plugin to lint and fix files asynchronously
+*ale.txt* Plugin to lint and fix files asynchronously
 *ale*
 
 ALE - Asynchronous Lint Engine
@@ -2751,6 +2751,7 @@ documented in additional help files.
     golangci-lint.........................|ale-go-golangci-lint|
     golangserver..........................|ale-go-golangserver|
     golint................................|ale-go-golint|
+    golines...............................|ale-go-golines|
     gometalinter..........................|ale-go-gometalinter|
     gopls.................................|ale-go-gopls|
     govet.................................|ale-go-govet|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -193,6 +193,7 @@ formatting.
   * [golangci-lint](https://github.com/golangci/golangci-lint) :warning: :floppy_disk:
   * [golangserver](https://github.com/sourcegraph/go-langserver) :warning:
   * [golint](https://godoc.org/github.com/golang/lint)
+  * [golines](https://github.com/segmentio/golines)
   * [gometalinter](https://github.com/alecthomas/gometalinter) :warning: :floppy_disk:
   * [gopls](https://github.com/golang/go/wiki/gopls)
   * [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) :warning: :floppy_disk:

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -192,8 +192,8 @@ formatting.
   * [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) :warning:
   * [golangci-lint](https://github.com/golangci/golangci-lint) :warning: :floppy_disk:
   * [golangserver](https://github.com/sourcegraph/go-langserver) :warning:
-  * [golint](https://godoc.org/github.com/golang/lint)
   * [golines](https://github.com/segmentio/golines)
+  * [golint](https://godoc.org/github.com/golang/lint)
   * [gometalinter](https://github.com/alecthomas/gometalinter) :warning: :floppy_disk:
   * [gopls](https://github.com/golang/go/wiki/gopls)
   * [gosimple](https://github.com/dominikh/go-tools/tree/master/cmd/gosimple) :warning: :floppy_disk:

--- a/test/fixers/test_golines_fixer_callback.vader
+++ b/test/fixers/test_golines_fixer_callback.vader
@@ -1,0 +1,54 @@
+Before:
+  Save g:ale_go_golines_executable
+  Save g:ale_go_golines_options
+  Save g:ale_go_go111module
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_go_golines_executable = 'xxxinvalid'
+  let g:ale_go_golines_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  unlet! b:ale_go_go111module
+
+  call ale#test#RestoreDirectory()
+
+Execute(The golines callback should return 0 when the executable isn't executable):
+  AssertEqual
+  \ 0,
+  \ ale#fixers#golines#Fix(bufnr(''))
+
+
+Execute(The golines callback should return the correct default values):
+  let g:ale_go_golines_executable = has('win32') ? 'cmd' : 'echo'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_go_golines_executable),
+  \ },
+  \ ale#fixers#golines#Fix(bufnr(''))
+
+Execute(The golines callback should include custom golines options):
+  let g:ale_go_golines_executable = has('win32') ? 'cmd' : 'echo'
+  let g:ale_go_golines_options = "--max-len --shorten-comments"
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_go_golines_executable)
+  \     . ' ' . g:ale_go_golines_options,
+  \ },
+  \ ale#fixers#golines#Fix(bufnr(''))
+
+Execute(The golines callback should support Go environment variables):
+  let g:ale_go_golines_executable = has('win32') ? 'cmd' : 'echo'
+  let g:ale_go_go111module = 'off'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Env('GO111MODULE', 'off')
+  \     . ale#Escape(g:ale_go_golines_executable)
+  \ },
+  \ ale#fixers#golines#Fix(bufnr(''))


### PR DESCRIPTION
Adds a fixer for "golines" (https://github.com/segmentio/golines) , a tool that automatically wraps long lines in go files.

Based on the goimport and gofmt fixer/tests :) 
