### PR TITLE
Fix 3865 - Disable scriptencoding vint error.

### DIFF
--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+policies:
+  # Disable a violation that is thrown randomly for reasons I still
+  # do not understand.
+  ProhibitMissingScriptEncoding:
+    enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV PACKAGES="\
 RUN apk --update add $PACKAGES && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
 
-RUN pip install vim-vint==0.3.15
+RUN pip install vim-vint==0.3.21
 
 RUN git clone https://github.com/junegunn/vader.vim vader && \
     cd vader && git checkout c6243dd81c98350df4dec608fa972df98fa2a3af

--- a/run-tests
+++ b/run-tests
@@ -17,7 +17,7 @@ fi
 git_version=$(git describe --always --tags)
 
 # Used in all test scripts for running the selected Docker image.
-DOCKER_RUN_IMAGE="$image"
+DOCKER_RUN_IMAGE="$image:$image_tag"
 export DOCKER_RUN_IMAGE
 
 tests='test/*.vader test/*/*.vader test/*/*/*.vader test/*/*/*.vader'


### PR DESCRIPTION
- Add .vintrc.yaml configuration that disables the scriptencoding check
  (ProhibitMissingScriptEncoding) that is raised randomly.
- Upgrade vint to 0.3.21. Project seems to have stopped here and 0.4.0
  was never released.
- Ensure the run-test scripts use the correct docker image (e.g. add tag)
  .
