### PR TITLE
Add fixer for "dotnet format"

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -396,6 +396,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['dart'],
 \       'description': 'Fix Dart files with dart format.',
 \   },
+\   'dotnet-format': {
+\       'function': 'ale#fixers#dotnet_format#Fix',
+\       'suggested_filetypes': ['cs'],
+\       'description': 'Fix C# files with dotnet format.',
+\   },
 \   'xmllint': {
 \       'function': 'ale#fixers#xmllint#Fix',
 \       'suggested_filetypes': ['xml'],

--- a/autoload/ale/fixers/dotnet_format.vim
+++ b/autoload/ale/fixers/dotnet_format.vim
@@ -1,0 +1,18 @@
+" Author: ghsang <gwonhyuksang@gmail.com>
+" Description: Integration of dotnet format with ALE.
+
+call ale#Set('cs_dotnet_format_executable', 'dotnet')
+call ale#Set('cs_dotnet_format_options', '')
+
+function! ale#fixers#dotnet_format#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'cs_dotnet_format_executable')
+    let l:options = ale#Var(a:buffer, 'cs_dotnet_format_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' format'
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' --folder --include %t "$(dirname %t)"',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-cs.txt
+++ b/doc/ale-cs.txt
@@ -91,6 +91,39 @@ g:ale_cs_csc_assemblies                               *g:ale_cs_csc_assemblies*
 <
 
 ===============================================================================
+dotnet-format                                            *ale-cs-dotnet-format*
+
+Installation
+-------------------------------------------------------------------------------
+
+Installing .NET SDK should probably ensure that `dotnet` is in your `$PATH`.
+For .NET 6 the `dotnet format` tool is already included in the .NET SDK. For
+.NET 5 or below you will have to manually install it using the instructions
+from listed in this repository: https://github.com/dotnet/format
+
+
+Options
+-------------------------------------------------------------------------------
+
+g:ale_cs_dotnet_format_executable           *g:ale_cs_dotnet_format_executable*
+                                            *b:ale_cs_dotnet_format_executable*
+  Type: |String|
+  Default: `'dotnet'`
+
+  This variable can be set to specify an absolute path to the
+  `dotnet` executable (or to specify an alternate executable).
+
+
+g:ale_cs_dotnet_format_options                 *g:ale_cs_dotnet_format_options*
+                                               *b:ale_cs_dotnet_format_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to the `dotnet format`
+  fixer.
+
+
+===============================================================================
 mcs                                                                *ale-cs-mcs*
 
   The `mcs` linter looks only for syntax errors while you type. See

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -66,6 +66,7 @@ Notes:
   * `uncrustify`
 * C#
   * `csc`!!
+  * `dotnet-format`
   * `mcs`
   * `mcsc`!!
   * `uncrustify`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2681,6 +2681,7 @@ documented in additional help files.
     uncrustify............................|ale-cpp-uncrustify|
   c#......................................|ale-cs-options|
     csc...................................|ale-cs-csc|
+    dotnet-format.........................|ale-cs-dotnet-format|
     mcs...................................|ale-cs-mcs|
     mcsc..................................|ale-cs-mcsc|
     uncrustify............................|ale-cs-uncrustify|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -75,6 +75,7 @@ formatting.
   * [uncrustify](https://github.com/uncrustify/uncrustify)
 * C#
   * [csc](http://www.mono-project.com/docs/about-mono/languages/csharp/) :floppy_disk: see:`help ale-cs-csc` for details and configuration
+  * [dotnet-format](https://github.com/dotnet/format)
   * [mcs](http://www.mono-project.com/docs/about-mono/languages/csharp/) see:`help ale-cs-mcs` for details
   * [mcsc](http://www.mono-project.com/docs/about-mono/languages/csharp/) :floppy_disk: see:`help ale-cs-mcsc` for details and configuration
   * [uncrustify](https://github.com/uncrustify/uncrustify)

--- a/test/fixers/test_dotnet_format_fixer_callback.vader
+++ b/test/fixers/test_dotnet_format_fixer_callback.vader
@@ -1,0 +1,41 @@
+Before:
+  Save g:ale_cs_dotnet_format_executable
+  Save g:ale_cs_dotnet_format_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_cs_dotnet_format_executable = 'xxxinvalid'
+  let g:ale_cs_dotnet_format_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The dotnet format callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/cs/testfile.cs')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format'
+  \     . ' --folder --include %t "$(dirname %t)"',
+  \ },
+  \ ale#fixers#dotnet_format#Fix(bufnr(''))
+
+Execute(The dotnet format callback should include custom dotnet format options):
+  let g:ale_cs_dotnet_format_options = "-l 80"
+  call ale#test#SetFilename('../test-files/cs/testfile.cs')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' format'
+  \     . ' ' . g:ale_cs_dotnet_format_options
+  \     . ' --folder --include %t "$(dirname %t)"',
+  \ },
+  \ ale#fixers#dotnet_format#Fix(bufnr(''))
+


### PR DESCRIPTION
The .NET ecosystem has an official tool for formatting its files: `dotnet format`
This adds support for that tool to ALE.
