### PR TITLE
Cppcheck backwards compat 1.34

### DIFF
--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -43,10 +43,14 @@ endfunction
 function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
     " Look for lines like the following.
     "
-    "test.cpp:974:6: error: Array 'n[3]' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]\
+    "test.cpp:974:6: error:inconclusive Array 'n[3]' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]\
     "    n[3]=3;
     "     ^
-    let l:pattern = '\v^(\f+):(\d+):(\d+): (\w+): (.*) \[(\w+)\]\'
+    "" OR if cppcheck doesn't support {column} or {inconclusive:text}:
+    "test.cpp:974:{column}: error:{inconclusive:inconclusive} Array 'n[3]' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]\
+    "    n[3]=3;
+    "     ^
+    let l:pattern = '\v(\f+):(\d+):(\d+|\{column\}): (\w+):(\{inconclusive:inconclusive\})* (.*) \[(\w+)\]\'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
@@ -56,8 +60,8 @@ function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
             \   'col':      str2nr(l:match[3]),
             \   'type':     l:match[4] is# 'error' ? 'E' : 'W',
             \   'sub_type': l:match[4] is# 'style' ? 'style' : '',
-            \   'text':     l:match[5],
-            \   'code':     l:match[6]
+            \   'text':     l:match[6],
+            \   'code':     l:match[7]
             \})
         endif
     endfor

--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -50,14 +50,14 @@ function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
     "test.cpp:974:{column}: error:{inconclusive:inconclusive} Array 'n[3]' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]\
     "    n[3]=3;
     "     ^
-    let l:pattern = '\v(\f+):(\d+):(\d+|\{column\}): (\w+):(\{inconclusive:inconclusive\})* (.*) \[(\w+)\]\'
+    let l:pattern = '\v(\f+):(\d+):(\d+|\{column\}): (\w+):(\{inconclusive:inconclusive\})? ?(.*) \[(\w+)\]\'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         if ale#path#IsBufferPath(a:buffer, l:match[1])
             call add(l:output, {
             \   'lnum':     str2nr(l:match[2]),
-            \   'col':      str2nr(l:match[3]),
+            \   'col':      match(l:match[3],'{column}') >= 0 ? 1 : str2nr(l:match[3]),
             \   'type':     l:match[4] is# 'error' ? 'E' : 'W',
             \   'sub_type': l:match[4] is# 'style' ? 'style' : '',
             \   'text':     l:match[6],

--- a/test/handler/test_cppcheck_handler.vader
+++ b/test/handler/test_cppcheck_handler.vader
@@ -35,6 +35,34 @@ Execute(Basic errors should be handled by cppcheck):
   \ '         ^',
   \ ])
 
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 974,
+  \     'col' : 1,
+  \     'type': 'E',
+  \     'sub_type': '',
+  \     'text': 'inconclusive Array ''n[3]'' accessed at index 3, which is out of bounds.',
+  \     'code': 'arrayIndexOutOfBounds'
+  \   },
+  \   {
+  \     'lnum': 1185,
+  \     'col' : 1,
+  \     'type': 'W',
+  \     'sub_type': 'style',
+  \     'text': 'The scope of the variable ''indxStr'' can be reduced.',
+  \     'code': 'variableScope'
+  \   },
+  \ ],
+  \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
+  \ 'test.cpp:974:{column}: error:inconclusive Array ''n[3]'' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]\',
+  \ '    n[3]=3;',
+  \ '     ^',
+  \ 'test.cpp:1185:{column}: style:{inconclusive:inconclusive} The scope of the variable ''indxStr'' can be reduced. [variableScope]\',
+  \ '    char indxStr[16];',
+  \ '         ^',
+  \ ])
+
 Execute(Problems from other files should be ignored by cppcheck):
   call ale#test#SetFilename('test.cpp')
 


### PR DESCRIPTION
Add support for cppcheck versions that don't support `{column}` or `{inconclusive:text}` in `--template`. This merge parses the output with and without the support and defaults to column 1.
