### PR TITLE
Use echon over echom for cursor echo

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -27,13 +27,11 @@ function! ale#cursor#TruncatedEcho(original_message) abort
         silent! setlocal shortmess+=T
 
         try
-            let l:winwidth = winwidth(0)
-
             " echon will not display the message if it exceeds the width of
             " the window
-            if l:winwidth < strdisplaywidth(l:message)
+            if &columns < strdisplaywidth(l:message)
                 " Truncate message longer than window width with trailing '...'
-                let l:message = l:message[:l:winwidth - 5] . '...'
+                let l:message = l:message[:&columns - 5] . '...'
             endif
 
             echon l:message

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -28,12 +28,14 @@ function! ale#cursor#TruncatedEcho(original_message) abort
 
         try
             let l:winwidth = winwidth(0)
+
             " echon will not display the message if it exceeds the width of
             " the window
             if l:winwidth < strdisplaywidth(l:message)
                 " Truncate message longer than window width with trailing '...'
                 let l:message = l:message[:l:winwidth - 5] . '...'
             endif
+
             echon l:message
         catch /^Vim\%((\a\+)\)\=:E523/
             " Fallback into manual truncate (#1987)

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -27,6 +27,13 @@ function! ale#cursor#TruncatedEcho(original_message) abort
         silent! setlocal shortmess+=T
 
         try
+            let l:winwidth = winwidth(0)
+            " echon will not display the message if it exceeds the width of
+            " the window
+            if l:winwidth < strdisplaywidth(l:message)
+                " Truncate message longer than window width with trailing '...'
+                let l:message = l:message[:l:winwidth - 5] . '...'
+            endif
             echon l:message
         catch /^Vim\%((\a\+)\)\=:E523/
             " Fallback into manual truncate (#1987)
@@ -37,7 +44,7 @@ function! ale#cursor#TruncatedEcho(original_message) abort
                 let l:message = l:message[:l:winwidth - 4] . '...'
             endif
 
-            echon l:message
+            exec 'echomsg l:message'
         catch /E481/
             " Do nothing if running from a visual selection.
         endtry

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -16,6 +16,9 @@ function! ale#cursor#TruncatedEcho(original_message) abort
     let l:message = substitute(l:message, "\t", ' ', 'g')
     " Remove any newlines in the message.
     let l:message = substitute(l:message, "\n", '', 'g')
+    " Convert indentation groups into single spaces for better legibility when
+    " put on a single line
+    let l:message = substitute(l:message, ' \+', ' ', 'g')
 
     " We need to remember the setting for shortmess and reset it again.
     let l:shortmess_options = &l:shortmess

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -87,7 +87,7 @@ function! ale#cursor#EchoCursorWarning(...) abort
         elseif get(l:info, 'echoed')
             " We'll only clear the echoed message when moving off errors once,
             " so we don't continually clear the echo line.
-            echon
+            execute 'echo'
             let l:info.echoed = 0
         endif
     endif
@@ -150,7 +150,7 @@ function! s:ShowCursorDetailForItem(loc, options) abort
 
         " Clear the echo message if we manually displayed details.
         if !l:stay_here
-            echon
+            execute 'echo'
         endif
     endif
 endfunction

--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -27,7 +27,7 @@ function! ale#cursor#TruncatedEcho(original_message) abort
         silent! setlocal shortmess+=T
 
         try
-            exec "norm! :echomsg l:message\n"
+            echon l:message
         catch /^Vim\%((\a\+)\)\=:E523/
             " Fallback into manual truncate (#1987)
             let l:winwidth = winwidth(0)
@@ -37,7 +37,7 @@ function! ale#cursor#TruncatedEcho(original_message) abort
                 let l:message = l:message[:l:winwidth - 4] . '...'
             endif
 
-            exec 'echomsg l:message'
+            echon l:message
         catch /E481/
             " Do nothing if running from a visual selection.
         endtry
@@ -87,7 +87,7 @@ function! ale#cursor#EchoCursorWarning(...) abort
         elseif get(l:info, 'echoed')
             " We'll only clear the echoed message when moving off errors once,
             " so we don't continually clear the echo line.
-            execute 'echo'
+            echon
             let l:info.echoed = 0
         endif
     endif
@@ -150,7 +150,7 @@ function! s:ShowCursorDetailForItem(loc, options) abort
 
         " Clear the echo message if we manually displayed details.
         if !l:stay_here
-            execute 'echo'
+            echon
         endif
     endif
 endfunction

--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -46,7 +46,7 @@ function! ale#hover#HandleTSServerResponse(conn_id, response) abort
                 call balloon_show(a:response.body.displayString)
             elseif get(l:options, 'truncated_echo', 0)
                 if !empty(a:response.body.displayString)
-                    call ale#cursor#TruncatedEcho(split(a:response.body.displayString, "\n")[0])
+                    call ale#cursor#TruncatedEcho(a:response.body.displayString)
                 endif
             elseif g:ale_hover_to_floating_preview || g:ale_floating_preview
                 call ale#floating_preview#Show(split(a:response.body.displayString, "\n"), {
@@ -231,7 +231,7 @@ function! ale#hover#HandleLSPResponse(conn_id, response) abort
             \&& (l:set_balloons is 1 || l:set_balloons is# 'hover')
                 call balloon_show(join(l:lines, "\n"))
             elseif get(l:options, 'truncated_echo', 0)
-                call ale#cursor#TruncatedEcho(l:lines[0])
+                call ale#cursor#TruncatedEcho(join(l:lines[0], '\n'))
             elseif g:ale_hover_to_floating_preview || g:ale_floating_preview
                 call ale#floating_preview#Show(l:lines, {
                 \   'filetype': 'ale-preview.message',

--- a/test/script/custom-linting-rules
+++ b/test/script/custom-linting-rules
@@ -125,7 +125,7 @@ check_errors '==#' "Use 'is#' instead of '==#'. 0 ==# 'foobar' is true"
 check_errors '==?' "Use 'is?' instead of '==?'. 0 ==? 'foobar' is true"
 check_errors '!=#' "Use 'isnot#' instead of '!=#'. 0 !=# 'foobar' is false"
 check_errors '!=?' "Use 'isnot?' instead of '!=?'. 0 !=? 'foobar' is false"
-check_errors '^ *:\?echo' "Stray echo line. Use \`execute echo\` if you want to echo something"
+check_errors '^ *:\?echo\>' "Stray echo line. Use \`execute echo\` if you want to echo something"
 check_errors '^ *:\?redir' 'User execute() instead of redir'
 # Exclusions for grandfathered-in exceptions
 exclusions="clojure/clj_kondo.vim elixir/elixir_ls.vim go/golangci_lint.vim swift/swiftformat.vim"


### PR DESCRIPTION
I feel like dynamic messages like this really should not clutter the `:messages` view, since they are very ephemeral in nature.

This would be my first time contributing to Ale, I did look over the development stuff but if I missed something please let me know!