### PR TITLE
Fix truncated echo

### DIFF
--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -45,7 +45,10 @@ function! ale#hover#HandleTSServerResponse(conn_id, response) abort
             \&& (l:set_balloons is 1 || l:set_balloons is# 'hover')
                 call balloon_show(a:response.body.displayString)
             elseif get(l:options, 'truncated_echo', 0)
-                call ale#cursor#TruncatedEcho(split(a:response.body.displayString, "\n")[0])
+                let l:echo = split(a:response.body.displayString, "\n")
+                if len(l:echo) > 0
+                    call ale#cursor#TruncatedEcho(l:echo[0])
+                endif
             elseif g:ale_hover_to_floating_preview || g:ale_floating_preview
                 call ale#floating_preview#Show(split(a:response.body.displayString, "\n"), {
                 \   'filetype': 'ale-preview.message',

--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -45,9 +45,8 @@ function! ale#hover#HandleTSServerResponse(conn_id, response) abort
             \&& (l:set_balloons is 1 || l:set_balloons is# 'hover')
                 call balloon_show(a:response.body.displayString)
             elseif get(l:options, 'truncated_echo', 0)
-                let l:echo = split(a:response.body.displayString, "\n")
-                if len(l:echo) > 0
-                    call ale#cursor#TruncatedEcho(l:echo[0])
+                if !empty(a:response.body.displayString)
+                    call ale#cursor#TruncatedEcho(split(a:response.body.displayString, "\n")[0])
                 endif
             elseif g:ale_hover_to_floating_preview || g:ale_floating_preview
                 call ale#floating_preview#Show(split(a:response.body.displayString, "\n"), {


### PR DESCRIPTION
In typescript, when putting the cursor on a `>` character of an arrow function, the `body.displayString` comes back as an empty string, and means the split operation has 0 items, causing a failure when attempting to call TruncatedEcho with the 0 index.

Even if there's a better fix, I'd assume this is a good safety since we are ingesting external data?

Should fix #3512

