### PR TITLE
Add linter sh/checkbashisms

### DIFF
--- a/ale_linters/sh/checkbashisms.vim
+++ b/ale_linters/sh/checkbashisms.vim
@@ -1,0 +1,77 @@
+" Author: Ross Williams <ross@ross-williams.net>
+" Description: Lints sh files using checkbashisms
+" URL: https://launchpad.net/ubuntu/+source/devscripts/
+" Notes:      checkbashisms.pl can be downloaded from
+"             http://debian.inode.at/debian/pool/main/d/devscripts/
+"             as part of the devscripts package.
+
+call ale#Set('sh_checkbashisms_executable', 'checkbashisms')
+call ale#Set('sh_checkbashisms_options', '-fx')
+
+function! ale_linters#sh#checkbashisms#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'sh_checkbashisms_executable')
+endfunction
+
+function! ale_linters#sh#checkbashisms#GetCommand(buffer) abort
+    let l:options = ale#Var(a:buffer, 'sh_checkbashisms_options')
+    let l:executable = ale_linters#sh#checkbashisms#GetExecutable(a:buffer)
+
+    return ale#Escape(l:executable) . ' ' . l:options . ' ' . '-'
+endfunction
+
+function! ale_linters#sh#checkbashisms#Handle(buffer, lines) abort
+    " Matches patterns line the following:
+    "
+    " error: script.sh: unclosed parentheses, opened in line 2
+    " error: script.sh: parsing failed
+    " cannot open script script.sh for reading: invalid permissions
+    " possible bashism in script.sh line 123 ('command' with option other than -p):
+    let l:err_pattern  = '\v^(error): (.*): (.*)'
+    let l:err_line_pattern  = '\v^(error): (.*): (.*), opened in line (\d+)'
+    let l:warn_pattern = '\v^(possible bashism) in (.*) line (\d+) \((.*)\):'
+    let l:fail_pattern = '\v^(cannot open) script (.*) for reading: (.*)'
+
+    let l:output = []
+
+    let l:curdir = expand('#' . a:buffer . ':p:h')
+
+    for l:match in ale#util#GetMatches(a:lines, [l:err_pattern,l:err_line_pattern,l:warn_pattern,l:fail_pattern])
+      if !empty(l:match[1])
+        if l:match[1] ==# 'error'
+          if !empty(l:match[4])
+            call add(l:output, {
+            \   'lnum': str2nr(l:match[4]),
+            \   'text': l:match[3],
+            \})
+          else
+            call add(l:output, {
+            \   'lnum': 0,
+            \   'text': l:match[3],
+            \})
+          endif
+        elseif l:match[1] ==# 'cannot open'
+          call add(l:output, {
+          \   'lnum': 0,
+          \   'text': 'cannot open script for reading: ' . l:match[3],
+          \})
+        elseif l:match[1] ==# 'possible bashism'
+          call add(l:output, {
+          \   'lnum': str2nr(l:match[3]),
+          \   'text': l:match[1] . ': ' . l:match[4],
+          \   'type': 'W',
+          \})
+        else
+        endif
+      endif
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('sh', {
+\   'name': 'checkbashisms',
+\   'output_stream': 'stderr',
+\   'executable': function('ale_linters#sh#checkbashisms#GetExecutable'),
+\   'command': function('ale_linters#sh#checkbashisms#GetCommand'),
+\   'callback': 'ale_linters#sh#checkbashisms#Handle',
+\})

--- a/doc/ale-sh.txt
+++ b/doc/ale-sh.txt
@@ -26,6 +26,29 @@ g:ale_sh_bashate_options                             *g:ale_sh_bashate_options*
 <
 
 ===============================================================================
+checkbashisms                                            *ale-sh-checkbashisms*
+
+g:ale_sh_checkbashisms_executable           *g:ale_sh_checkbashisms_executable*
+                                            *b:ale_sh_checkbashisms_executable*
+  Type: |String|
+  Default: `'checkbashisms'`
+
+  This variable sets executable used for checkbashisms.
+
+
+g:ale_sh_checkbashisms_options                 *g:ale_sh_checkbashisms_options*
+                                               *b:ale_sh_checkbashisms_options*
+  Type: |String|
+  Default: `'-fx'`
+
+  With this variable we are able to pass extra arguments for checkbashisms.
+  For example to enable stricter POSIX-compliance checks:
+
+>
+  let g:ale_sh_checkbashisms_options = '-fxp'
+<
+
+===============================================================================
 sh-language-server                                     *ale-sh-language-server*
 
 g:ale_sh_language_server_executable        *g:ale_sh_language_server_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -37,6 +37,7 @@ Notes:
   * `gawk`
 * Bash
   * `bashate`
+  * checkbashisms
   * `language-server`
   * `shell` (-n flag)
   * `shellcheck`
@@ -48,6 +49,7 @@ Notes:
 * BibTeX
   * `bibclean`
 * Bourne Shell
+  * checkbashisms
   * `shell` (-n flag)
   * `shellcheck`
   * `shfmt`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3013,6 +3013,7 @@ documented in additional help files.
     stylelint.............................|ale-scss-stylelint|
   sh......................................|ale-sh-options|
     bashate...............................|ale-sh-bashate|
+    checkbashisms.........................|ale-sh-checkbashisms|
     sh-language-server....................|ale-sh-language-server|
     shell.................................|ale-sh-shell|
     shellcheck............................|ale-sh-shellcheck|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -46,6 +46,7 @@ formatting.
   * [gawk](https://www.gnu.org/software/gawk/)
 * Bash
   * [bashate](https://github.com/openstack/bashate)
+  * [checkbashisms](https://launchpad.net/ubuntu/+source/devscripts/)
   * [language-server](https://github.com/mads-hartmann/bash-language-server)
   * shell [-n flag](https://www.gnu.org/software/bash/manual/bash.html#index-set)
   * [shellcheck](https://www.shellcheck.net/)
@@ -57,6 +58,7 @@ formatting.
 * BibTeX
   * [bibclean](http://ftp.math.utah.edu/pub/bibclean/)
 * Bourne Shell
+  * [checkbashisms](https://launchpad.net/ubuntu/+source/devscripts/)
   * shell [-n flag](http://linux.die.net/man/1/sh)
   * [shellcheck](https://www.shellcheck.net/)
   * [shfmt](https://github.com/mvdan/sh)

--- a/test/handler/test_checkbashisms_handler.vader
+++ b/test/handler/test_checkbashisms_handler.vader
@@ -1,0 +1,30 @@
+Before:
+  runtime ale_linters/sh/checkbashisms.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The checkbashisms handler should handle basic errors or warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 2,
+  \     'type': 'W',
+  \     'text': 'possible bashism: ''command'' with option other than -p',
+  \   },
+  \   {
+  \     'lnum': 2,
+  \     'type': 'E',
+  \     'text': 'unclosed parentheses',
+  \   },
+  \   {
+  \     'lnum': 0,
+  \     'type': 'E',
+  \     'text': 'cannot open script for reading: insufficient permissions',
+  \   },
+  \ ],
+  \ ale#handlers#checkbashisms#Handle(bufnr(''), [
+  \   'possible bashism in script.sh line 2 (''command'' with option other than -p):',
+  \   'error: script.sh: unclosed parentheses, opened in line 2',
+  \   'cannot open script test.sh for reading: insufficient permissions',
+  \ ])

--- a/test/linter/test_checkbashisms.vader
+++ b/test/linter/test_checkbashisms.vader
@@ -1,0 +1,17 @@
+Before:
+  call ale#assert#SetUpLinterTest('sh', 'checkbashisms')
+  call ale#test#SetFilename('test.sh')
+
+  let b:suffix = ' -fx -'
+
+After:
+  unlet! b:suffix
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default checkbashisms command should be correct):
+  AssertLinter 'checkbashisms', ale#Escape('checkbashisms') . b:suffix
+
+Execute(The checkbashisms command should accept options):
+  let b:ale_sh_checkbashisms_options = '-xp'
+
+  AssertLinter 'checkbashisms', ale#Escape('checkbashisms') . ' -xp -'


### PR DESCRIPTION
Added a linter for checkbashisms, as it has some specific lints for helping write cross-platform shell scripts that ShellCheck does not (e.g. checking whether flags to builtin commands are POSIX or bash-specific).