### PR TITLE
Improve the thriftcheck handler pattern

### DIFF
--- a/ale_linters/thrift/thriftcheck.vim
+++ b/ale_linters/thrift/thriftcheck.vim
@@ -13,9 +13,9 @@ endfunction
 function! ale_linters#thrift#thriftcheck#Handle(buffer, lines) abort
     " Matches lines like the following:
     "
-    " file.thrift:1:1:error: "py" namespace must match "^idl\\." (namespace.pattern)
-    " file.thrift:3:5:warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)
-    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):(\d+):(\l+): (.*) \((.*)\)$'
+    " file.thrift:1:1: error: "py" namespace must match "^idl\\." (namespace.pattern)
+    " file.thrift:3:5: warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)
+    let l:pattern = '\v^[a-zA-Z]?:?[^:]+:(\d+):(\d+): ?([^:]+): (.+) \(([^\)]+)\)$'
 
     let l:output = []
 

--- a/test/handler/test_thriftcheck_handler.vader
+++ b/test/handler/test_thriftcheck_handler.vader
@@ -23,6 +23,6 @@ Execute(The thriftcheck handler should handle basic warnings and errors):
   \   },
   \ ],
   \ ale_linters#thrift#thriftcheck#Handle(1, [
-  \   'file.thrift:1:1:error: "py" namespace must match "^idl\\." (namespace.pattern)',
-  \   'file.thrift:3:5:warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)',
+  \   'file.thrift:1:1: error: "py" namespace must match "^idl\\." (namespace.pattern)',
+  \   'file.thrift:3:5: warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)',
   \ ])


### PR DESCRIPTION
More recent versions of thriftcheck use a more compliant GCC-style
output format which includes a space before the "severity" group.
This matches similar tools, like shellcheck.

This change adjusts the handler's pattern to parse this format in a
backwards-compatible way (even though backwards compatibility isn't
critical long-term as thriftcheck itself is close to its 1.0 release).