### PR TITLE
[python/pyre.vim] Fix pyre persistent behavior

### DIFF
--- a/ale_linters/python/pyre.vim
+++ b/ale_linters/python/pyre.vim
@@ -22,12 +22,15 @@ endfunction
 
 function! ale_linters#python#pyre#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyre#GetExecutable(a:buffer)
-
-    let l:exec_args = l:executable =~? 'pipenv\|poetry$'
-    \   ? ' run pyre persistent'
-    \   : ' persistent'
+    let l:exec_args = (l:executable =~? 'pipenv\|poetry$' ? ' run pyre' : '') . ' persistent'
 
     return ale#Escape(l:executable) . l:exec_args
+endfunction
+
+function! ale_linters#python#pyre#GetCwd(buffer) abort
+    let l:local_config = ale#path#FindNearestFile(a:buffer, '.pyre_configuration.local')
+
+    return fnamemodify(l:local_config, ':h')
 endfunction
 
 call ale#linter#Define('python', {
@@ -37,4 +40,5 @@ call ale#linter#Define('python', {
 \   'command': function('ale_linters#python#pyre#GetCommand'),
 \   'project_root': function('ale#python#FindProjectRoot'),
 \   'completion_filter': 'ale#completion#python#CompletionItemFilter',
+\   'cwd': function('ale_linters#python#pyre#GetCwd'),
 \})


### PR DESCRIPTION
It's necessary to provide a `-l` option to pyre with the closest parent
directory containing a `.pyre_configuration.local` file, or simply
change directory (cwd) to the root of the pyre project. Thanks to Ken
Verbosky for the code that fixes this.

Error seen when not using such a solution:

```
1031.473923 on 6: Dropping message 'ƛ Background task unexpectedly quited: Invalid configuration: Cannot find any source files to analyze. Either `source_directories` or `targets` must be specified.
```

Issue with this approach is that if you are editing files under
different projects, the `pyre persistent` process is not re-created for
each file. We have to do `:ALEStopAlllsps` in order for the process to
start with the new working directory.