### PR TITLE
Fix 3897 - add poetry to isort

### DIFF
--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -5,6 +5,7 @@ call ale#Set('python_isort_executable', 'isort')
 call ale#Set('python_isort_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('python_isort_options', '')
 call ale#Set('python_isort_auto_pipenv', 0)
+call ale#Set('python_isort_auto_poetry', 0)
 
 function! ale#fixers#isort#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_isort_auto_pipenv'))
@@ -12,24 +13,34 @@ function! ale#fixers#isort#GetExecutable(buffer) abort
         return 'pipenv'
     endif
 
+    if (ale#Var(a:buffer, 'python_auto_poetry') || ale#Var(a:buffer, 'python_isort_auto_poetry'))
+    \ && ale#python#PoetryPresent(a:buffer)
+        return 'poetry'
+    endif
+
     return ale#python#FindExecutable(a:buffer, 'python_isort', ['isort'])
 endfunction
 
 function! ale#fixers#isort#Fix(buffer) abort
-    let l:options = ale#Var(a:buffer, 'python_isort_options')
     let l:executable = ale#fixers#isort#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv$'
-    \   ? ' run isort'
-    \   : ''
+    let l:cmd = [ale#Escape(l:executable)]
 
-    if !executable(l:executable) && l:executable isnot# 'pipenv'
-        return 0
+    if l:executable =~? 'pipenv\|poetry$'
+        call extend(l:cmd, ['run', 'isort'])
     endif
+
+    call add(l:cmd, '--filename %s')
+
+    let l:options = ale#Var(a:buffer, 'python_isort_options')
+
+    if !empty(l:options)
+        call add(l:cmd, l:options)
+    endif
+
+    call add(l:cmd, '-')
 
     return {
     \   'cwd': '%s:h',
-    \   'command': ale#Escape(l:executable) . l:exec_args
-    \   . ale#Pad('--filename %s')
-    \   . (!empty(l:options) ? ' ' . l:options : '') . ' -',
+    \   'command': join(l:cmd, ' ')
     \}
 endfunction

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -356,6 +356,15 @@ g:ale_python_isort_auto_pipenv                 *g:ale_python_isort_auto_pipenv*
   if true. This is overridden by a manually-set executable.
 
 
+g:ale_python_isort_auto_poetry                 *g:ale_python_isort_auto_poetry*
+                                               *b:ale_python_isort_auto_poetry*
+  Type: |Number|
+  Default: `0`
+
+  Detect whether the file is inside a poetry, and set the executable to `poetry`
+  if true. This is overridden by a manually-set executable.
+
+
 ===============================================================================
 mypy                                                          *ale-python-mypy*
 

--- a/test/fixers/test_isort_fixer_callback.vader
+++ b/test/fixers/test_isort_fixer_callback.vader
@@ -10,10 +10,6 @@ After:
   unlet! b:bin_dir
 
 Execute(The isort callback should return the correct default values):
-  AssertEqual
-  \ 0,
-  \ ale#fixers#isort#Fix(bufnr(''))
-
   silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
   \ {
@@ -24,10 +20,6 @@ Execute(The isort callback should return the correct default values):
 
 Execute(The isort callback should respect custom options):
   let g:ale_python_isort_options = '--multi-line=3 --trailing-comma'
-
-  AssertEqual
-  \ 0,
-  \ ale#fixers#isort#Fix(bufnr(''))
 
   silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
   AssertEqual
@@ -47,5 +39,17 @@ Execute(Pipenv is detected when python_isort_auto_pipenv is set):
   \ {
   \   'cwd': '%s:h',
   \   'command': ale#Escape('pipenv') . ' run isort' . ' --filename %s' . ' -'
+  \ },
+  \ ale#fixers#isort#Fix(bufnr(''))
+
+Execute(Poetry is detected when python_isort_auto_poetry is set):
+  let g:ale_python_isort_auto_poetry = 1
+
+  call ale#test#SetFilename('../test-files/python/poetry/whatever.py')
+
+  AssertEqual
+  \ {
+  \   'cwd': '%s:h',
+  \   'command': ale#Escape('poetry') . ' run isort' . ' --filename %s' . ' -'
   \ },
   \ ale#fixers#isort#Fix(bufnr(''))


### PR DESCRIPTION
Adds support for poetry to python isort fixer.

Closes #3897 #3896 