### PR TITLE
linters: Add Linux Kernel checkpatch for C and DTS

### DIFF
--- a/ale_linters/c/checkpatch.vim
+++ b/ale_linters/c/checkpatch.vim
@@ -1,0 +1,21 @@
+" Author: Markus Schneider-Pargmann <dev@markussp.com>
+" Description: checkpatch.pl checker for Kernel Files
+
+call ale#Set('c_checkpatch_executable', 'scripts/checkpatch.pl')
+call ale#Set('c_checkpatch_options', '--strict')
+
+function! ale_linters#c#checkpatch#GetCommand(buffer) abort
+    return '%e --no-summary --no-tree --terse '
+    \   . ale#Pad(ale#Var(a:buffer, 'c_checkpatch_options'))
+    \   . ' --file %s'
+endfunction
+
+call ale#linter#Define('c', {
+\   'name': 'checkpatch',
+\   'output_stream': 'both',
+\   'executable': {b -> ale#Var(b, 'c_checkpatch_executable')},
+\   'cwd': function('ale#handlers#cppcheck#GetCwd'),
+\   'command': function('ale_linters#c#checkpatch#GetCommand'),
+\   'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\   'lint_file': 1,
+\})

--- a/ale_linters/dts/checkpatch.vim
+++ b/ale_linters/dts/checkpatch.vim
@@ -1,0 +1,21 @@
+" Author: Markus Schneider-Pargmann <dev@markussp.com>
+" Description: checkpatch.pl checker for Kernel Files
+
+call ale#Set('dts_checkpatch_executable', 'scripts/checkpatch.pl')
+call ale#Set('dts_checkpatch_options', '--strict')
+
+function! ale_linters#dts#checkpatch#GetCommand(buffer) abort
+    return '%e --no-summary --no-tree --terse '
+    \   . ale#Pad(ale#Var(a:buffer, 'dts_checkpatch_options'))
+    \   . ' --file %s'
+endfunction
+
+call ale#linter#Define('dts', {
+\   'name': 'checkpatch',
+\   'output_stream': 'both',
+\   'executable': {b -> ale#Var(b, 'dts_checkpatch_executable')},
+\   'cwd': function('ale#handlers#cppcheck#GetCwd'),
+\   'command': function('ale_linters#dts#checkpatch#GetCommand'),
+\   'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\   'lint_file': 1,
+\})


### PR DESCRIPTION
checkpatch.pl is a script that is supposed to be executed before your
patch is sent to the mailinglist. It checks your code and complains
about several things.

This patch uses that script for both C and DTS files.

Signed-off-by: Markus Schneider-Pargmann <msp@baylibre.com>