### PR TITLE
Implement virtual text support for vim

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2226,8 +2226,6 @@ g:ale_virtualtext_cursor                             *g:ale_virtualtext_cursor*
   Type: |Number|
   Default: `0`
 
-  This option only has any effect in NeoVim.
-
   When this option is set to `1`, a message will be shown when a cursor is
   near a warning or error. ALE will attempt to find the warning or error at a
   column nearest to the cursor when the cursor is resting on a line which


### PR DESCRIPTION
This implements virtual text support for vim 8.2. It requires the text property and the popup feature.
<img width="515" alt="Screenshot_20210923_020429" src="https://user-images.githubusercontent.com/21310755/134438095-0ecf1455-3242-4d3f-9b95-e8833dc1f4dd.png">

