### PR TITLE
Fix: Failed to execute rubocop fixer on other machine

### DIFF
--- a/autoload/ale/fixers/rubocop.vim
+++ b/autoload/ale/fixers/rubocop.vim
@@ -21,12 +21,10 @@ endfunction
 
 function! ale#fixers#rubocop#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_rubocop_executable')
-    let l:config = ale#path#FindNearestFile(a:buffer, '.rubocop.yml')
     let l:options = ale#Var(a:buffer, 'ruby_rubocop_options')
     let l:auto_correct_all = ale#Var(a:buffer, 'ruby_rubocop_auto_correct_all')
 
     return ale#ruby#EscapeExecutable(l:executable, 'rubocop')
-    \   . (!empty(l:config) ? ' --config ' . ale#Escape(l:config) : '')
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . (l:auto_correct_all ? ' --auto-correct-all' : ' --auto-correct')
     \   . ' --force-exclusion --stdin %s'

--- a/test/fixers/test_rubocop_fixer_callback.vader
+++ b/test/fixers/test_rubocop_fixer_callback.vader
@@ -24,18 +24,6 @@ Execute(The rubocop callback should return the correct default values):
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))
 
-Execute(The rubocop callback should include configuration files):
-  call ale#test#SetFilename('../test-files/ruby/with_config/dummy.rb')
-
-  AssertEqual
-  \ {
-  \   'process_with': 'ale#fixers#rubocop#PostProcess',
-  \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/ruby/with_config/.rubocop.yml'))
-  \     . ' --auto-correct --force-exclusion --stdin %s',
-  \ },
-  \ ale#fixers#rubocop#Fix(bufnr(''))
-
 Execute(The rubocop callback should include custom rubocop options):
   let g:ale_ruby_rubocop_options = '--except Lint/Debugger'
   call ale#test#SetFilename('../test-files/ruby/with_config/dummy.rb')
@@ -44,7 +32,6 @@ Execute(The rubocop callback should include custom rubocop options):
   \ {
   \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/ruby/with_config/.rubocop.yml'))
   \     . ' --except Lint/Debugger'
   \     . ' --auto-correct --force-exclusion --stdin %s',
   \ },
@@ -58,7 +45,6 @@ Execute(The rubocop callback should use auto-correct-all option when set):
   \ {
   \   'process_with': 'ale#fixers#rubocop#PostProcess',
   \   'command': ale#Escape(g:ale_ruby_rubocop_executable)
-  \     . ' --config ' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/ruby/with_config/.rubocop.yml'))
   \     . ' --auto-correct-all --force-exclusion --stdin %s'
   \ },
   \ ale#fixers#rubocop#Fix(bufnr(''))


### PR DESCRIPTION
## Expectation

I want to apply the fixer of rubocop in the container to the Ruby file that is volume mounted by docker-compose.
Use `b:ale_command_wrapper` and `b:ale_filename_mappings` to run fixer inside docker.

```vim
let b:ale_command_wrapper = 'docker-compose exec -T api bundle exec'
let b:ale_filename_mappings = { '*': [['/home/uplus/project', '/usr/src/app']] }
```

## Problem

Linter succeeded, but Fixer failed.

Linter Log(succeeded)

```text
['/bin/sh', '-c', 'docker-compose exec -T api bundle exec ''rubocop'' --format json --force-exclusion  --stdin ''/usr/src/app/Rakefile'' < ''/tmp/nvimSHY0Hz/2/Rakefile''']
```

Fixer Log(failed)

```text
['/bin/sh', '-c', 'docker-compose exec -T api bundle exec ''rubocop'' --config ''/home/uplus/project/.rubocop.yml'' --auto-correct --force-exclusion --stdin ''/usr/src/app/Rakefile'' < ''/tmp/nvimSHY0Hz/3/Rakefile''']
```

## Cause

Fixer fails because  host filepath is passed to `--config` of rubocop in the `container.`
Files targeted by Fixer are mapped as specified in `b:ale_filename_mappings`, but file path of ` --config` are not mapped.
Rubocop does not work because `--config` specified an invalid file path.


```text
['/bin/sh', '-c', 'docker-compose exec -T api bundle exec ''rubocop'' --config ''/home/uplus/project/.rubocop.yml'' --auto-correct --force-exclusion --stdin ''/usr/src/app/Rakefile'' < ''/tmp/nvimSHY0Hz/3/Rakefile''']
                                                                                 ^^^^^^^^^^^^^^^^^^^                                                           ^^^^^^^^^^^^
                                                                                 Host machine filepath(not mapped)                                             Container filepath(mapped)
```


## Solution

This problem can be resolved by removing `--config`.

Fixer Log(succeeded)
```text
['/bin/sh', '-c', 'docker-compose exec -T api bundle exec ''rubocop'' --auto-correct --force-exclusion --stdin ''/usr/src/app/Rakefile'' < ''/tmp/nvimwyKaEQ/6/Rakefile''']
```

According to the commit log, ALE specifies `--config` to resolve #732.
At that time, there seemed to be a problem that `.rubocop.yml` was not loaded when using rubocop fixer from ALE.

However current rubocop fixer reads `.rubocop.yml` even if ALE doesn't specify` --config`.
Also, in previous implementations, fixer specified `--config`, but linter did not specify` --config`, so the behavior could be different.

If ALE user wants to specify `--config`, it can be specified with `g:ale_ruby_rubocop_options`.