### PR TITLE
Fix tidy fixer

### DIFF
--- a/autoload/ale/fixers/tidy.vim
+++ b/autoload/ale/fixers/tidy.vim
@@ -2,6 +2,7 @@
 " Description: Fixing HTML files with tidy.
 
 call ale#Set('html_tidy_executable', 'tidy')
+call ale#Set('html_tidy_fixer_options', '')
 call ale#Set('html_tidy_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale#fixers#tidy#Fix(buffer) abort
@@ -15,12 +16,24 @@ function! ale#fixers#tidy#Fix(buffer) abort
         return 0
     endif
 
+    let l:command = [ale#Escape(l:executable)]
+    call extend(l:command, ['-q', '--tidy-mark no', '--show-errors 0', '--show-warnings 0'])
+
+    let l:options = ale#Var(a:buffer, 'html_tidy_fixer_options')
+
+    if !empty(l:options)
+        call add(l:command, l:options)
+    endif
+
     let l:config = ale#path#FindNearestFile(a:buffer, '.tidyrc')
-    let l:config_options = !empty(l:config)
-    \   ? ' -q --tidy-mark no --show-errors 0 --show-warnings 0 -config ' . ale#Escape(l:config)
-    \   : ' -q --tidy-mark no --show-errors 0 --show-warnings 0'
+
+    if !empty(l:config)
+        call add(l:command, '-config ' . ale#Escape(l:config))
+    endif
+
+    call add(l:command, '-')
 
     return {
-    \   'command': ale#Escape(l:executable) . l:config_options,
+    \   'command':  join(l:command, ' '),
     \}
 endfunction

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -149,6 +149,18 @@ g:ale_html_tidy_options                               *g:ale_html_tidy_options*
   The recognized file encodings are as follows: ascii, big5, cp1252 (win1252),
   cp850 (ibm858), cp932 (shiftjis), iso-2022-jp (iso-2022), latin1, macroman
   (mac), sjis (shiftjis), utf-16le, utf-16, utf-8
+  
+
+g:ale_html_tidy_fixer_options                   *g:ale_html_tidy_fixer_options*
+                                                *b:ale_html_tidy_fixer_options*
+  Type: |String|
+  Default: `''`
+
+  The fixer as a different behavior then it has its own options. The options
+  always passed to tidy are :
+  '-q --tidy-mark no --show-errors 0 --show-warnings 0'
+  So if you want, for example, your html file to be indented you have to set
+  the options to '-i'. 
 
 
 g:ale_html_tidy_use_global                             *g:html_tidy_use_global*


### PR DESCRIPTION
Correct the command by adding a '-' at the end
Add a global variable to separate tidy linter and fixer options
Clean the way how the options are collected
Update documentation for tidy
