### PR TITLE
Fixes for ALECodeAction

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -199,22 +199,12 @@ function! ale#codefix#ApplyLSPCodeAction(data, item) abort
         \   a:item.command,
         \   a:item.arguments,
         \)
-
         call ale#lsp#Send(a:data.connection_id, l:message)
 
         return
     endif
 
-    if has_key(a:item, 'command')
-    \&& type(a:item.command) == v:t_dict
-        let l:command = a:item.command
-        let l:message = ale#lsp#message#ExecuteCommand(
-        \   l:command.command,
-        \   l:command.arguments,
-        \)
-
-        let l:request_id = ale#lsp#Send(a:data.connection_id, l:message)
-    elseif has_key(a:item, 'edit')
+    if has_key(a:item, 'edit')
         let l:changes_map = ale#code_action#GetChanges(a:item.edit)
 
         if empty(l:changes_map)
@@ -230,6 +220,17 @@ function! ale#codefix#ApplyLSPCodeAction(data, item) abort
         \   },
         \   {},
         \)
+    endif
+
+    if has_key(a:item, 'command')
+    \&& type(a:item.command) == v:t_dict
+        let l:command = a:item.command
+        let l:message = ale#lsp#message#ExecuteCommand(
+        \   l:command.command,
+        \   l:command.arguments,
+        \)
+
+        call ale#lsp#Send(a:data.connection_id, l:message)
     endif
 endfunction
 

--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -194,6 +194,18 @@ endfunction
 
 function! ale#codefix#ApplyLSPCodeAction(data, item) abort
     if has_key(a:item, 'command')
+    \&& type(a:item.command) == v:t_string
+        let l:message = ale#lsp#message#ExecuteCommand(
+        \   a:item.command,
+        \   a:item.arguments,
+        \)
+
+        call ale#lsp#Send(a:data.connection_id, l:message)
+
+        return
+    endif
+
+    if has_key(a:item, 'command')
     \&& type(a:item.command) == v:t_dict
         let l:command = a:item.command
         let l:message = ale#lsp#message#ExecuteCommand(
@@ -202,14 +214,8 @@ function! ale#codefix#ApplyLSPCodeAction(data, item) abort
         \)
 
         let l:request_id = ale#lsp#Send(a:data.connection_id, l:message)
-    elseif has_key(a:item, 'edit') || has_key(a:item, 'arguments')
-        if has_key(a:item, 'edit')
-            let l:topass = a:item.edit
-        else
-            let l:topass = a:item.arguments[0]
-        endif
-
-        let l:changes_map = ale#code_action#GetChanges(l:topass)
+    elseif has_key(a:item, 'edit')
+        let l:changes_map = ale#code_action#GetChanges(a:item.edit)
 
         if empty(l:changes_map)
             return

--- a/test/test_codefix.vader
+++ b/test/test_codefix.vader
@@ -15,6 +15,7 @@ Before:
   let g:capability_checked = ''
   let g:conn_id = v:null
   let g:InitCallback = v:null
+  let g:call_order = []
 
   runtime autoload/ale/lsp_linter.vim
   runtime autoload/ale/lsp.vim
@@ -51,6 +52,7 @@ Before:
   endfunction
 
   function! ale#lsp#Send(conn_id, message) abort
+    call add(g:call_order, 'ale#lsp#Send')
     call add(g:message_list, a:message)
 
     return 42
@@ -61,6 +63,7 @@ Before:
   endfunction
 
   function! ale#code_action#HandleCodeAction(code_action, options) abort
+    call add(g:call_order, 'ale#code_action#HandleCodeAction')
     let g:handle_code_action_called = 1
     Assert !get(a:options, 'should_save')
     call add(g:code_actions, a:code_action)
@@ -91,6 +94,7 @@ After:
   unlet! g:options
   unlet! g:code_actions
   unlet! g:handle_code_action_called
+  unlet! g:call_order
 
   runtime autoload/ale/lsp_linter.vim
   runtime autoload/ale/lsp.vim
@@ -476,6 +480,24 @@ Execute(LSP Code Actions handles command responses):
   \ [[0, 'workspace/executeCommand', {'arguments': [{'file': '/foo/bar/file.ts', 'action': 'function_scope_1', 'endOffset': 0, 'refactor': 'Extract Symbol', 'endLine': 68, 'startLine': 65, 'startOffset': 1}], 'command': '_typescript.applyRefactoring'}]],
   \ g:message_list
 
+Execute(Code Actions from LSP containing both edit and command should be handled in that order):
+  call ale#codefix#SetMap({2: {
+  \ 'connection_id': 0,
+  \}})
+
+  call ale#codefix#HandleLSPResponse(1,
+  \ {'id': 2, 'jsonrpc': '2.0', 'result': [{'title': 'fake for testing'}, {'diagnostics': v:null, 'edit': {'changes': v:null, 'documentChanges': [{'edits': [{'range': {'end': {'character': 0, 'line': 0}, 'start': {'character': 0, 'line': 0}}, 'newText': 'def func_bomdjnxh():^@    a = 1return a^@^@^@'}, {'range': {'end': {'character': 9, 'line': 1}, 'start': {'character': 8, 'line': 1}}, 'newText': 'func_bomdjnxh()^@'}], 'textDocument': {'uri': 'file:///foo/bar/test.py', 'version': v:null}}]}, 'kind': 'refactor.extract', 'title': 'Extract expression into function ''func_bomdjnxh''', 'command': {'arguments': [{'file': '/foo/bar/file.ts', 'endOffset': 0, 'action': 'function_scope_1', 'startOffset': 1, 'startLine': 65, 'refactor': 'Extract Symbol', 'endLine': 68}], 'title': 'Extract to function in module scope', 'command': '_typescript.applyRefactoring'}}]})
+
+  AssertEqual g:call_order, ['ale#code_action#HandleCodeAction', 'ale#lsp#Send']
+
+  AssertEqual g:handle_code_action_called, 1
+  AssertEqual
+  \ [{'description': 'codeaction', 'changes': [{'fileName': '/foo/bar/test.py', 'textChanges': [{'end': {'offset': 1, 'line': 1}, 'newText': 'def func_bomdjnxh():^@    a = 1return a^@^@^@', 'start': {'offset': 1, 'line': 1}}, {'end': {'offset': 10, 'line': 2}, 'newText': 'func_bomdjnxh()^@', 'start': {'offset': 9, 'line': 2}}]}]}],
+  \ g:code_actions
+
+  AssertEqual
+  \ [[0, 'workspace/executeCommand', {'arguments': [{'file': '/foo/bar/file.ts', 'action': 'function_scope_1', 'endOffset': 0, 'refactor': 'Extract Symbol', 'endLine': 68, 'startLine': 65, 'startOffset': 1}], 'command': '_typescript.applyRefactoring'}]],
+  \ g:message_list
 
 Execute(Prints message when LSP code action returns no results):
   call ale#codefix#SetMap({3: {}})
@@ -548,3 +570,21 @@ Execute(LSP code action requests should be sent only for error with code):
   \   }]
   \ ],
   \ g:message_list[-1:]
+
+
+Given rust(Some rust file):
+  fn main() {}
+  struct Foo {}
+  impl std::fmt::Display for Foo {
+  }
+
+Execute(LSP Code Actions handles plain command response):
+  call ale#codefix#SetMap({2: {
+  \ 'connection_id': 0,
+  \}})
+  call ale#codefix#HandleLSPResponse(1,
+  \ {'id':2,'jsonrpc':'2.0','result':[{'title': 'fake for testing'}, {'title':'Line 4: Add `fn fmt(&self, _: &mut std::fmt::Formatter<''_>) -> std::result::Result<(), std::fmt::Error> { todo!() }\n`','command':'rls.applySuggestion-7764','arguments':[{'range':{'end':{'character':0,'line':3},'start':{'character':0,'line':3}},'uri':'file:///foo/bar/src/main.rs'},'fn fmt(&self, _: &mut std::fmt::Formatter<''_>) -> std::result::Result<(), std::fmt::Error> { todo!() }\n']}]})
+
+  AssertEqual
+  \ [[0, 'workspace/executeCommand', {'arguments': [{'range':{'end':{'character':0,'line':3},'start':{'character':0,'line':3}},'uri':'file:///foo/bar/src/main.rs'},'fn fmt(&self, _: &mut std::fmt::Formatter<''_>) -> std::result::Result<(), std::fmt::Error> { todo!() }\n'], 'command': 'rls.applySuggestion-7764'}]],
+  \ g:message_list

--- a/test/test_codefix.vader
+++ b/test/test_codefix.vader
@@ -445,14 +445,15 @@ Execute("workspace/applyEdit" from LSP should be handled):
   \ g:code_actions
 
 Execute(Code Actions from LSP should be handled with user input if there are more than one action):
-  call ale#codefix#SetMap({2: {}})
+  call ale#codefix#SetMap({2: {
+  \ 'connection_id': 0,
+  \}})
   call ale#codefix#HandleLSPResponse(1,
   \ {'id': 2, 'jsonrpc': '2.0', 'result': [{'title': 'fake for testing'}, {'arguments': [{'documentChanges': [{'edits': [{'range': {'end': {'character': 31, 'line': 2}, 'start': {'character': 31, 'line': 2}}, 'newText': ', createVideo'}], 'textDocument': {'uri': 'file:///foo/bar/file.ts', 'version': 1}}]}], 'title': 'Add ''createVideo'' to existing import declaration from "./video"', 'command': '_typescript.applyWorkspaceEdit'}]})
 
-  AssertEqual g:handle_code_action_called, 1
   AssertEqual
-  \ [{'description': 'codeaction', 'changes': [{'fileName': '/foo/bar/file.ts', 'textChanges': [{'end': {'offset': 32, 'line': 3}, 'newText': ', createVideo', 'start': {'offset': 32, 'line': 3}}]}]}],
-  \ g:code_actions
+  \ [[0, 'workspace/executeCommand', {'arguments': [{'documentChanges': [{'edits': [{'range': {'end': {'character': 31, 'line': 2}, 'start': {'character': 31, 'line': 2}}, 'newText': ', createVideo'}], 'textDocument': {'uri': 'file:///foo/bar/file.ts', 'version': 1}}]}], 'command': '_typescript.applyWorkspaceEdit'}]],
+  \ g:message_list
 
 Execute(Code Actions from LSP should be handled when returned with documentChanges):
   call ale#codefix#SetMap({2: {}})


### PR DESCRIPTION
* Handle cases where the selected action is a plain Command. This fixes #3543.
* When the selected action is a CodeAction, if it has an 'edit' and a 'command', execute both in that order.