### PR TITLE
Automatically find black config file

### DIFF
--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -213,6 +213,19 @@ g:ale_python_black_options                         *g:ale_python_black_options*
   This variable can be set to pass extra options to black.
 
 
+g:ale_python_black_use_config                   *g:ale_python_black_use_config*
+                                                *b:ale_python_black_use_config*
+  Type: |Number|
+  Default: `0`
+
+  Search for the closest config file (pyproject.toml).
+  if 0 then use only the options (see above g:ale_python_black_options)
+  if 1 then use both config and options
+  if 2 then use only the config
+  if the config file is not found, it will use the options no matter the
+  value set.
+
+
 g:ale_python_black_use_global                   *g:ale_python_black_use_global*
                                                 *b:ale_python_black_use_global*
   Type: |Number|


### PR DESCRIPTION
Black uses only one config file (_pyproject.toml_). So I add an option to search automatically for this config file through `ale#nearest` (for the current project).

This option is `g:ale_python_black_use_config`, by default it does nothing more than before this patch.

I created 3 modes :
- Use only the user options (`g:ale_python_black_options`) ; option 0 default
- Use both config and options ; option 1
- Use only the config file ; option 2

And if the config is not found it will always use  the user options, even with the option 2.