### PR TITLE
Add support for AVRA linting

### DIFF
--- a/ale_linters/avra/avra.vim
+++ b/ale_linters/avra/avra.vim
@@ -13,7 +13,7 @@ endfunction
 
 function! ale_linters#avra#avra#Handle(buffer, lines) abort
     " Note that we treat 'fatal' as errors.
-    let l:pattern = '^.\+(\(\d\+\)) : \(.\+\)   : \(.\+\)$'
+    let l:pattern = '^.\+(\(\d\+\))\s\+:\s\+\(.\+\):\s\+\(.\+\)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/ale_linters/avra/avra.vim
+++ b/ale_linters/avra/avra.vim
@@ -5,13 +5,10 @@ call ale#Set('avra_avra_executable', 'avra')
 call ale#Set('avra_avra_options', '')
 
 function! ale_linters#avra#avra#GetCommand(buffer) abort
-    let l:separator = has('win32') ? '\' : '/'
-    let l:output_null = has('win32') ? 'NUL' : '/dev/null'
-
     return '%e'
     \   . ' %t'
     \   . ale#Pad(ale#Var(a:buffer, 'avra_avra_options'))
-    \   . ' -o ' . l:output_null
+    \   . ' -o ' . g:ale#util#nul_file
 endfunction
 
 function! ale_linters#avra#avra#Handle(buffer, lines) abort

--- a/ale_linters/avra/avra.vim
+++ b/ale_linters/avra/avra.vim
@@ -1,0 +1,39 @@
+" Author: Utkarsh Verma <utkarshverma@protonmail.com>
+" Description: AVRA linter for avra syntax.
+
+call ale#Set('avra_avra_executable', 'avra')
+call ale#Set('avra_avra_options', '')
+
+function! ale_linters#avra#avra#GetCommand(buffer) abort
+    let l:separator = has('win32') ? '\' : '/'
+    let l:output_null = has('win32') ? 'NUL' : '/dev/null'
+
+    return '%e'
+    \   . ' %t'
+    \   . ale#Pad(ale#Var(a:buffer, 'avra_avra_options'))
+    \   . ' -o ' . l:output_null
+endfunction
+
+function! ale_linters#avra#avra#Handle(buffer, lines) abort
+    " Note that we treat 'fatal' as errors.
+    let l:pattern = '^.\+(\(\d\+\)) : \(.\+\)   : \(.\+\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \ 'lnum': l:match[1] + 0,
+        \ 'type': l:match[2] =~? 'Error' ? 'E' : 'W',
+        \ 'text': l:match[3],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('avra', {
+\   'name': 'avra',
+\   'output_stream': 'stderr',
+\   'executable': {b -> ale#Var(b, 'avra_avra_executable')},
+\   'command': function('ale_linters#avra#avra#GetCommand'),
+\   'callback': 'ale_linters#avra#avra#Handle',
+\})

--- a/ale_linters/avra/avra.vim
+++ b/ale_linters/avra/avra.vim
@@ -13,7 +13,7 @@ endfunction
 
 function! ale_linters#avra#avra#Handle(buffer, lines) abort
     " Note that we treat 'fatal' as errors.
-    let l:pattern = '^.\+(\(\d\+\))\s\+:\s\+\(.\+\):\s\+\(.\+\)$'
+    let l:pattern = '^\S\+(\(\d\+\))\s\+:\s\+\(\S\+\)\s\+:\s\+\(.\+\)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/doc/ale-avra.txt
+++ b/doc/ale-avra.txt
@@ -1,0 +1,26 @@
+===============================================================================
+ALE AVRA Integration                                         *ale-avra-options*
+
+
+===============================================================================
+avra                                                            *ale-avra-avra*
+
+g:ale_avra_avra_executable                         *g:ale_avra_avra_executable*
+                                                   *b:ale_avra_avra_executable*
+
+  Type: |String|
+  Default `'avra'`
+
+  This variable can be changed to use different executable for AVRA.
+
+
+g:ale_avra_avra_options                               *g:ale_avra_avra_options*
+                                                      *b:ale_avra_avra_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to AVRA.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -33,6 +33,8 @@ Notes:
   * `write-good`
 * ASM
   * `gcc`
+* AVRA
+  * `avra`
 * Awk
   * `gawk`
 * Bash

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2633,6 +2633,8 @@ documented in additional help files.
     textlint..............................|ale-asciidoc-textlint|
   asm.....................................|ale-asm-options|
     gcc...................................|ale-asm-gcc|
+  avra....................................|ale-avra-options|
+    avra..................................|ale-avra-avra|
   awk.....................................|ale-awk-options|
     gawk..................................|ale-awk-gawk|
   bats....................................|ale-bats-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -42,6 +42,8 @@ formatting.
   * [write-good](https://github.com/btford/write-good)
 * ASM
   * [gcc](https://gcc.gnu.org)
+* AVRA
+  * [avra](https://github.com/Ro5bert/avra)
 * Awk
   * [gawk](https://www.gnu.org/software/gawk/)
 * Bash

--- a/test/handler/test_avra_handler.vader
+++ b/test/handler/test_avra_handler.vader
@@ -1,0 +1,24 @@
+Before:
+  runtime ale_linters/avra/avra.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The avra handler should parse errors correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'text': "Unknown device: atmega3228p",
+  \     'type': 'E',
+  \   },
+  \   {
+  \     'lnum': 12,
+  \     'text': "Unknown directive: .EQ",
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#avra#avra#Handle(bufnr(''), [
+  \   "main.asm(3) : Error   : Unknown device: atmega3228p"
+  \   "main.asm(12) : Error   : Unknown directive: .EQ"
+  \ ])

--- a/test/handler/test_avra_handler.vader
+++ b/test/handler/test_avra_handler.vader
@@ -10,15 +10,15 @@ Execute(The avra handler should parse errors correctly):
   \   {
   \     'lnum': 3,
   \     'text': "Unknown device: atmega3228p",
-  \     'type': 'E',
+  \     'type': 'E'
   \   },
   \   {
   \     'lnum': 12,
   \     'text': "Unknown directive: .EQ",
-  \     'type': 'E',
-  \   },
+  \     'type': 'E'
+  \   }
   \ ],
   \ ale_linters#avra#avra#Handle(bufnr(''), [
-  \   "main.asm(3) : Error   : Unknown device: atmega3228p"
+  \   "main.asm(3) : Error   : Unknown device: atmega3228p",
   \   "main.asm(12) : Error   : Unknown directive: .EQ"
   \ ])

--- a/test/linter/test_avra_avra.vader
+++ b/test/linter/test_avra_avra.vader
@@ -2,7 +2,7 @@ Before:
   call ale#assert#SetUpLinterTest('avra', 'avra')
 
   let b:command_tail = ' %t -o ' . g:ale#util#nul_file
-  let b:command_tail_opt = ' --max_errors 20 %t -o ' . g:ale#util#nul_file
+  let b:command_tail_opt = ' %t --max_errors 20 -o ' . g:ale#util#nul_file
 
 After:
   unlet! b:command_tail
@@ -21,7 +21,7 @@ Execute(The options should be configurable):
   let b:ale_avra_avra_options = '--max_errors 20'
 
   AssertLinter 'avra', ale#Escape('avra')
-  \ . ' --max_errors 20 %t -o ' . g:ale#util#nul_file
+  \ . ' %t --max_errors 20 -o ' . g:ale#util#nul_file
 
 Execute(The options should be used in command):
   let b:ale_avra_avra_options = '--max_errors 20'

--- a/test/linter/test_avra_avra.vader
+++ b/test/linter/test_avra_avra.vader
@@ -1,0 +1,29 @@
+Before:
+  call ale#assert#SetUpLinterTest('avra', 'avra')
+
+  let b:command_tail = ' %t -o ' . g:ale#util#nul_file
+  let b:command_tail_opt = ' --max_errors 20 %t -o ' . g:ale#util#nul_file
+
+After:
+  unlet! b:command_tail
+  unlet! b:command_tail_opt
+
+  call ale#assert#TearDownLinterTest()
+
+Execute(The executable should be configurable):
+  AssertLinter 'avra', ale#Escape('avra') . b:command_tail,
+
+  let b:ale_avra_avra_executable = '~/avra'
+
+  AssertLinter '~/avra', ale#Escape('~/avra') . b:command_tail
+
+Execute(The options should be configurable):
+  let b:ale_avra_avra_options = '--max_errors 20'
+
+  AssertLinter 'avra', ale#Escape('avra')
+  \ . ' --max_errors 20 %t -o ' . g:ale#util#nul_file
+
+Execute(The options should be used in command):
+  let b:ale_avra_avra_options = '--max_errors 20'
+
+  AssertLinter 'avra', ale#Escape('avra') . b:command_tail_opt


### PR DESCRIPTION
This PR adds support for AVR assembly linting through [`avra`](https://github.com/Ro5bert/avra).

This is the linter in action:
![Peek 2021-10-21 07-43](https://user-images.githubusercontent.com/31820255/138199549-182c7b69-87e5-461f-86a4-70e76f260cd9.gif)