### PR TITLE
Initialize colors correctly if virtual text is loaded first

### DIFF
--- a/autoload/ale/highlight.vim
+++ b/autoload/ale/highlight.vim
@@ -22,6 +22,26 @@ if !hlexists('ALEInfo')
     highlight link ALEInfo ALEWarning
 endif
 
+if !hlexists('ALEVirtualTextError')
+    highlight link ALEVirtualTextError ALEError
+endif
+
+if !hlexists('ALEVirtualTextStyleError')
+    highlight link ALEVirtualTextStyleError ALEVirtualTextError
+endif
+
+if !hlexists('ALEVirtualTextWarning')
+    highlight link ALEVirtualTextWarning ALEWarning
+endif
+
+if !hlexists('ALEVirtualTextStyleWarning')
+    highlight link ALEVirtualTextStyleWarning ALEVirtualTextWarning
+endif
+
+if !hlexists('ALEVirtualTextInfo')
+    highlight link ALEVirtualTextInfo ALEVirtualTextWarning
+endif
+
 " The maximum number of items for the second argument of matchaddpos()
 let s:MAX_POS_VALUES = 8
 let s:MAX_COL_SIZE = 1073741824 " pow(2, 30)

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -18,26 +18,6 @@ elseif has('textprop') && has('popupwin')
     let s:has_virt_text = 1
 endif
 
-if !hlexists('ALEVirtualTextError')
-    highlight link ALEVirtualTextError ALEError
-endif
-
-if !hlexists('ALEVirtualTextStyleError')
-    highlight link ALEVirtualTextStyleError ALEVirtualTextError
-endif
-
-if !hlexists('ALEVirtualTextWarning')
-    highlight link ALEVirtualTextWarning ALEWarning
-endif
-
-if !hlexists('ALEVirtualTextStyleWarning')
-    highlight link ALEVirtualTextStyleWarning ALEVirtualTextWarning
-endif
-
-if !hlexists('ALEVirtualTextInfo')
-    highlight link ALEVirtualTextInfo ALEVirtualTextWarning
-endif
-
 function! ale#virtualtext#Clear() abort
     if !s:has_virt_text
         return

--- a/test/test_highlight_placement.vader
+++ b/test/test_highlight_placement.vader
@@ -10,6 +10,7 @@ Before:
   Save g:ale_exclude_highlights
   Save b:ale_exclude_highlights
 
+  runtime autoload/ale/virtualtext.vim
   runtime autoload/ale/highlight.vim
 
   let g:ale_run_synchronously = 1
@@ -98,6 +99,10 @@ Before:
     endif
   endfunction
 
+  function! GetLinkedGroup(grp) abort
+    return synIDattr(synIDtrans(hlID(a:grp)), 'name')
+  endfunction
+
   call ale#linter#Define('testft', {
   \ 'name': 'x',
   \ 'executable': has('win32') ? 'cmd': 'echo',
@@ -119,6 +124,9 @@ After:
   call ale#linter#Reset()
   call clearmatches()
   call ale#sign#Clear()
+  if has('textprop') && has('popupwin')
+    call prop_type_delete('ale')
+  endif
   highlight clear SomeOtherGroup
 
   runtime autoload/ale/highlight.vim
@@ -128,6 +136,15 @@ Given testft(A Javscript file with warnings/errors):
   bar
   baz wat
   line four
+
+" Autoloading virtualtext.vim first should still properly initialize hl-groups
+Execute(Loading virtualtext first does not break highlight groups):
+  AssertEqual
+  \ "SpellBad",
+  \ GetLinkedGroup("ALEError")
+  AssertEqual
+  \ "SpellCap",
+  \ GetLinkedGroup("ALEWarning")
 
 Execute(Highlights should be set when a linter runs):
   ALELint


### PR DESCRIPTION
See commit message for more details.

Do we need a test for this?