### PR TITLE
Make run-tests compatible with Podman

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -170,7 +170,7 @@ fi
 find test -name '*.swp' -delete
 
 # Check if docker un image is available locally
-has_image=$(docker images ls --filter reference="${image}:${image_tag}" --quiet | wc -l)
+has_image=$(docker images --quiet "${image}:${image_tag}" | wc -l)
 
 if [ "$has_image" -eq 0 ]
 then


### PR DESCRIPTION
This fixes `Error: cannot specify an image and a filter(s)` if one was using Podman instead of a normal Docker installation and of course still works with normal Docker.