### PR TITLE
Implement gofumpt Fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -246,6 +246,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['go'],
 \       'description': 'Fix Go files with go fmt.',
 \   },
+\   'gofumpt': {
+\       'function': 'ale#fixers#gofumpt#Fix',
+\       'suggested_filetypes': ['go'],
+\       'description': 'Fix Go files with gofumpt, a stricter go fmt.',
+\   },
 \   'goimports': {
 \       'function': 'ale#fixers#goimports#Fix',
 \       'suggested_filetypes': ['go'],

--- a/autoload/ale/fixers/gofumpt.vim
+++ b/autoload/ale/fixers/gofumpt.vim
@@ -1,0 +1,17 @@
+" Author: David Houston <houstdav000>
+" Description: A stricter gofmt implementation.
+
+call ale#Set('go_gofumpt_executable', 'gofumpt')
+call ale#Set('go_gofumpt_options', '')
+
+function! ale#fixers#gofumpt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'go_gofumpt_executable')
+    let l:options = ale#Var(a:buffer, 'go_gofumpt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ale#Pad(l:options)
+    \       . ' -w -- %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -81,6 +81,24 @@ g:ale_go_gofmt_options                                 *g:ale_go_gofmt_options*
 
 
 ===============================================================================
+gofumpt                                                        *ale-go-gofumpt*
+
+g:ale_go_gofumpt_executable                       *g:ale_go_gofumpt_executable*
+                                                  *b:ale_go_gofumpt_executable*
+  Type: |String|
+  Default: `'gofumpt'`
+
+  Executable to run to use as the gofumpt fixer.
+
+g:ale_go_gofumpt_options                             *g:ale_go_gofumpt_options*
+                                                     *b:ale_go_gofumpt_options*
+  Type: |String|
+  Default: `''`
+
+  Options to pass to the gofumpt fixer.
+
+
+===============================================================================
 golangci-lint                                            *ale-go-golangci-lint*
 
 `golangci-lint` is a `lint_file` linter, which only lints files that are
@@ -148,7 +166,7 @@ g:ale_go_golines_options                             *g:ale_go_golines_options*
   Type: |String|
   Default: ''
 
-  Additional options passed to the golines command. By default golines has 
+  Additional options passed to the golines command. By default golines has
   --max-length=100 (lines above 100 characters will be wrapped)
 
 ===============================================================================

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -182,6 +182,7 @@ Notes:
   * `go mod`!!
   * `go vet`!!
   * `gofmt`
+  * `gofumpt`
   * `goimports`
   * `golangci-lint`!!
   * `golangserver`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2748,6 +2748,7 @@ documented in additional help files.
     bingo.................................|ale-go-bingo|
     gobuild...............................|ale-go-gobuild|
     gofmt.................................|ale-go-gofmt|
+    gofumpt...............................|ale-go-gofumpt|
     golangci-lint.........................|ale-go-golangci-lint|
     golangserver..........................|ale-go-golangserver|
     golines...............................|ale-go-golines|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -191,6 +191,7 @@ formatting.
   * [go mod](https://golang.org/cmd/go/) :warning: :floppy_disk:
   * [go vet](https://golang.org/cmd/vet/) :floppy_disk:
   * [gofmt](https://golang.org/cmd/gofmt/)
+  * [gofumpt](https://github.com/mvdan/gofumpt)
   * [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) :warning:
   * [golangci-lint](https://github.com/golangci/golangci-lint) :warning: :floppy_disk:
   * [golangserver](https://github.com/sourcegraph/go-langserver) :warning:

--- a/test/fixers/test_gofumpt_fixer.vader
+++ b/test/fixers/test_gofumpt_fixer.vader
@@ -5,14 +5,23 @@ After:
   call ale#assert#TearDownFixerTest()
 
 Execute(The gofumpt callback should return the correct default values):
-  AssertFixer {'command': ale#Escape('gofumpt') . ' -w -- %t'}
+  AssertFixer {
+  \    'read_temporary_file': 1,
+  \    'command': ale#Escape('gofumpt') . ' -w -- %t'
+  \}
 
 Execute(The gofumpt callback should allow custom gofumpt executables):
   let g:ale_go_gofumpt_executable = 'foo/bar'
 
-  AssertFixer {'command': ale#Escape('foo/bar') . ' -w -- %t'}
+  AssertFixer {
+  \    'read_temporary_file': 1,
+  \    'command': ale#Escape('foo/bar') . ' -w -- %t'
+  \}
 
 Execute(The gofumpt callback should allow custom gofumpt options):
   let g:ale_go_gofumpt_options = '--foobar'
 
-  AssertFixer {'command': ale#Escape('gofumpt') . '--foobar -w -- %t'}
+  AssertFixer {
+  \    'read_temporary_file': 1,
+  \    'command': ale#Escape('gofumpt') . ' --foobar -w -- %t'
+  \}

--- a/test/fixers/test_gofumpt_fixer.vader
+++ b/test/fixers/test_gofumpt_fixer.vader
@@ -1,5 +1,5 @@
 Before:
-  call ale#assert#SetupFixerTest('go', 'gofumpt')
+  call ale#assert#SetUpFixerTest('go', 'gofumpt')
 
 After:
   call ale#assert#TearDownFixerTest()

--- a/test/fixers/test_gofumpt_fixer.vader
+++ b/test/fixers/test_gofumpt_fixer.vader
@@ -1,0 +1,18 @@
+Before:
+  call ale#assert#SetupFixerTest('go', 'gofumpt')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The gofumpt callback should return the correct default values):
+  AssertFixer {'command': ale#Escape('gofumpt') . ' -w -- %t'}
+
+Execute(The gofumpt callback should allow custom gofumpt executables):
+  let g:ale_go_gofumpt_executable = 'foo/bar'
+
+  AssertFixer {'command': ale#Escape('foo/bar') . ' -w -- %t'}
+
+Execute(The gofumpt callback should allow custom gofumpt options):
+  let g:ale_go_gofumpt_options = '--foobar'
+
+  AssertFixer {'command': ale#Escape('gofumpt') . '--foobar -w -- %t'}


### PR DESCRIPTION
Add an implementation with test and documentation for the gofumpt go
code formatter, a stricter formatter than your standard "go fmt".

Closes #3653