### PR TITLE
Implement statix Linter and Fixer

### DIFF
--- a/ale_linters/nix/statix.vim
+++ b/ale_linters/nix/statix.vim
@@ -6,14 +6,12 @@ call ale#Set('nix_statix_check_executable', 'statix')
 call ale#Set('nix_statix_check_options', '')
 
 function! ale_linters#nix#statix#GetCommand(buffer) abort
-    return '%e check -o errfmt'
+    return '%e check -o errfmt --stdin'
     \   . ale#Pad(ale#Var(a:buffer, 'nix_statix_check_options'))
-    \   . ' -- %t'
 endfunction
 
 call ale#linter#Define('nix', {
 \   'name': 'statix',
-\   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'nix_statix_check_executable')},
 \   'command': function('ale_linters#nix#statix#GetCommand'),
 \   'callback': 'ale#handlers#statix#Handle',

--- a/ale_linters/nix/statix.vim
+++ b/ale_linters/nix/statix.vim
@@ -13,7 +13,7 @@ endfunction
 
 call ale#linter#Define('nix', {
 \   'name': 'statix',
-\   'output_stream': 'stderr',
+\   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'nix_statix_check_executable')},
 \   'command': function('ale_linters#nix#statix#GetCommand'),
 \   'callback': 'ale#handlers#statix#Handle',

--- a/ale_linters/nix/statix.vim
+++ b/ale_linters/nix/statix.vim
@@ -1,0 +1,20 @@
+scriptencoding utf-8
+" Author: David Houston <houstdav000>
+" Description: statix analysis and suggestions for Nix files
+
+call ale#Set('nix_statix_check_executable', 'statix')
+call ale#Set('nix_statix_check_options', '')
+
+function! ale_linters#nix#statix#GetCommand(buffer) abort
+    return '%e check -o errfmt'
+    \   . ale#Pad(ale#Var(a:buffer, 'nix_statix_check_options'))
+    \   . ' -- %t'
+endfunction
+
+call ale#linter#Define('nix', {
+\   'name': 'statix',
+\   'output_stream': 'stderr',
+\   'executable': {b -> ale#Var(b, 'nix_statix_check_executable')},
+\   'command': function('ale_linters#nix#statix#GetCommand'),
+\   'callback': 'ale#handlers#statix#Handle',
+\})

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -191,6 +191,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['ruby'],
 \       'description': 'Fix ruby files with standardrb --fix',
 \   },
+\   'statix': {
+\       'function': 'ale#fixers#statix#Fix',
+\       'suggested_filetypes': ['nix'],
+\       'description': 'Fix common Nix antipatterns with statix fix',
+\   },
 \   'stylelint': {
 \       'function': 'ale#fixers#stylelint#Fix',
 \       'suggested_filetypes': ['css', 'sass', 'scss', 'sugarss', 'stylus'],

--- a/autoload/ale/fixers/statix.vim
+++ b/autoload/ale/fixers/statix.vim
@@ -1,0 +1,18 @@
+" Author: David Houston <houstdav000>
+" Description: Provide statix fix as a fixer for simple Nix antipatterns.
+
+call ale#Set('nix_statix_fix_executable', 'statix')
+call ale#Set('nix_statix_fix_options', '')
+
+function! ale#fixers#statix#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'nix_statix_fix_executable')
+    let l:options = ale#Var(a:buffer, 'nix_statix_fix_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ale#Pad('fix')
+    \       . ale#Pad('--stdin')
+    \       . ale#Pad(l:options),
+    \   'read_temporary_file': 0,
+    \}
+endfunction

--- a/autoload/ale/fixers/statix.vim
+++ b/autoload/ale/fixers/statix.vim
@@ -13,6 +13,5 @@ function! ale#fixers#statix#Fix(buffer) abort
     \       . ale#Pad('fix')
     \       . ale#Pad('--stdin')
     \       . ale#Pad(l:options),
-    \   'read_temporary_file': 0,
     \}
 endfunction

--- a/autoload/ale/handlers/statix.vim
+++ b/autoload/ale/handlers/statix.vim
@@ -1,0 +1,24 @@
+scriptencoding utf-8
+" Author: David Houston
+" Description: This file defines a handler function for statix's errorformat
+" output.
+
+function! ale#handlers#statix#Handle(buffer, lines) abort
+    " Look for lines like the following.
+    "
+    " flake.nix>46:13:W:3:This assignment is better written with `inherit`
+    let l:pattern = '\v^.*\>(\d+):(\d+):([A-Z]):(\d+):(.*)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': l:match[3],
+        \   'code': l:match[4],
+        \   'text': l:match[5],
+        \})
+    endfor
+
+    return l:output
+endfunction

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -58,6 +58,22 @@ g:ale_nix_statix_check_options                 *g:ale_nix_statix_check_options*
   This variable can be used to pass additional options to statix when running
   it as a linter.
 
+g:ale_nix_statix_fix_executable                *g:ale_nix_fix_check_executable*
+                                               *b:ale_nix_fix_check_executable*
+  Type: |String|
+  Default: `'statix'`
+
+  This variable sets the executable used for statix when running it as a
+  fixer.
+
+g:ale_nix_statix_fix_options                     *g:ale_nix_statix_fix_options*
+                                                 *b:ale_nix_statix_fix_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to pass additional options to statix when running
+  it as a fixer.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -7,24 +7,24 @@ nixfmt                                                         *ale-nix-nixfmt*
 
 g:ale_nix_nixfmt_executable                       *g:ale_nix_nixfmt_executable*
                                                   *b:ale_nix_nixfmt_executable*
-  Type: String
-  Default: 'nixfmt'
+  Type: |String|
+  Default: `'nixfmt'`
 
   This variable sets the executable used for nixfmt.
 
 g:ale_nix_nixfmt_options                             *g:ale_nix_nixfmt_options*
                                                      *b:ale_nix_nixfmt_options*
-  Type: String
-  Default: ''
+  Type: |String|
+  Default: `''`
 
   This variable can be set to pass additional options to the nixfmt fixer.
 
 
 ===============================================================================
-nixpkgs-fmt                                                 *ale-nix-nixpkgs-fmt*
+nixpkgs-fmt                                               *ale-nix-nixpkgs-fmt*
 
-g:ale_nix_nixpkgsfmt_executable                *g:ale_nix_nixpkgsfmt_executable*
-                                               *b:ale_nix_nixpkgsfmt_executable*
+g:ale_nix_nixpkgsfmt_executable               *g:ale_nix_nixpkgsfmt_executable*
+                                              *b:ale_nix_nixpkgsfmt_executable*
   Type: |String|
   Default: `'nixpkgs-fmt'`
 
@@ -35,7 +35,28 @@ g:ale_nix_nixpkgsfmt_options                     *g:ale_nix_nixpkgsfmt_options*
   Type: |String|
   Default: `''`
 
-  This variable can be set to pass additional options to the nixpkgs-fmt fixer.
+  This variable can be set to pass additional options to the nixpkgs-fmt
+  fixer.
+
+
+===============================================================================
+statix                                                         *ale-nix-statix*
+
+g:ale_nix_statix_check_executable           *g:ale_nix_statix_check_executable*
+                                            *b:ale_nix_statix_check_executable*
+  Type: |String|
+  Default: `'statix'`
+
+  This variable sets the executable used for statix when running it as a
+  linter.
+
+g:ale_nix_statix_check_options                 *g:ale_nix_statix_check_options*
+                                               *b:ale_nix_statix_check_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to pass additional options to statix when running
+  it as a linter.
 
 
 ===============================================================================

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -340,6 +340,7 @@ Notes:
   * `nixfmt`
   * `nixpkgs-fmt`
   * `rnix-lsp`
+  * `statix`
 * nroff
   * `alex`!!
   * `proselint`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2879,6 +2879,7 @@ documented in additional help files.
   nix.....................................|ale-nix-options|
     nixfmt................................|ale-nix-nixfmt|
     nixpkgs-fmt...........................|ale-nix-nixpkgs-fmt|
+    statix................................|ale-nix-statix|
   nroff...................................|ale-nroff-options|
     write-good............................|ale-nroff-write-good|
   objc....................................|ale-objc-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -348,8 +348,8 @@ formatting.
   * [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate)
   * [nixfmt](https://github.com/serokell/nixfmt)
   * [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)
-  * [statix](https://github.com/nerdypepper/statix)
   * [rnix-lsp](https://github.com/nix-community/rnix-lsp)
+  * [statix](https://github.com/nerdypepper/statix)
 * nroff
   * [alex](https://github.com/wooorm/alex) :floppy_disk:
   * [proselint](http://proselint.com/)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -348,6 +348,7 @@ formatting.
   * [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate)
   * [nixfmt](https://github.com/serokell/nixfmt)
   * [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)
+  * [statix](https://github.com/nerdypepper/statix)
   * [rnix-lsp](https://github.com/nix-community/rnix-lsp)
 * nroff
   * [alex](https://github.com/wooorm/alex) :floppy_disk:

--- a/test/fixers/test_statix_fixer.vader
+++ b/test/fixers/test_statix_fixer.vader
@@ -1,0 +1,18 @@
+Before:
+  call ale#assert#SetUpFixerTest('nix', 'statix')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The callback should return the correct default values):
+  AssertFixer { 'command': ale#Escape('statix') . ' fix --stdin' }
+
+Execute(The callback should include a custom runtime):
+  let g:ale_nix_statix_fix_executable = 'foo/bar'
+
+  AssertFixer { 'command': ale#Escape('foo/bar') . ' fix --stdin' }
+
+Execute(The callback should include custom options):
+  let g:ale_nix_statix_fix_options = '--foobar'
+
+  AssertFixer { 'command': ale#Escape('statix') . ' fix --stdin --foobar' }

--- a/test/handler/test_statix_handler.vader
+++ b/test/handler/test_statix_handler.vader
@@ -12,5 +12,5 @@ Execute(The statix handler should handle statix output):
   \   },
   \ ],
   \ ale#handlers#statix#Handle(bufnr(''),
-  \   'flake.nix>46:13:W:3:This assignment is better written with `inherit`'
+  \   '<stdin>>46:13:W:3:This assignment is better written with `inherit`'
   \)

--- a/test/handler/test_statix_handler.vader
+++ b/test/handler/test_statix_handler.vader
@@ -1,0 +1,16 @@
+Execute(The statix handler should handle statix output):
+  call ale#test#SetFilename('flake.nix')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 46,
+  \     'type': 'W',
+  \     'col': 13,
+  \     'code': '3',
+  \     'text': 'This assignment is better written with `inherit`'
+  \   },
+  \ ],
+  \ ale#handlers#statix#Handle(bufnr(''),
+  \   'flake.nix>46:13:W:3:This assignment is better written with `inherit`'
+  \)

--- a/test/linter/test_nix_statix.vader
+++ b/test/linter/test_nix_statix.vader
@@ -5,15 +5,15 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The statix command should be correct):
-  AssertLinter 'statix', ale#Escape('statixi') . 'check -o errfmt -- %t'
+  AssertLinter 'statix', ale#Escape('statix') . ' check -o errfmt -- %t'
 
 Execute(Additional statix options should be configurable):
-  let b:ale_nix_statix_options = '--foobar'
+  let g:ale_nix_statix_check_options = '--foobar'
 
   AssertLinter 'statix',
-  \ ale#Escape('statix') . 'check -o errfmt --foobar -- %t'
+  \ ale#Escape('statix') . ' check -o errfmt --foobar -- %t'
 
 Execute(The statix command should be configurable):
-  let b:ale_nix_statix_executable = 'foo/bar'
+  let g:ale_nix_statix_check_executable = 'foo/bar'
 
-  AssertLinter 'foo/bar', ale#Escape('foo/bar') . 'check -o errfmt -- %t'
+  AssertLinter 'foo/bar', ale#Escape('foo/bar') . ' check -o errfmt -- %t'

--- a/test/linter/test_nix_statix.vader
+++ b/test/linter/test_nix_statix.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpLinterTest('nix', 'statix')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The statix command should be correct):
+  AssertLinter 'statix', ale#Escape('statixi') . 'check -o errfmt -- %t'
+
+Execute(Additional statix options should be configurable):
+  let b:ale_nix_statix_options = '--foobar'
+
+  AssertLinter 'statix',
+  \ ale#Escape('statix') . 'check -o errfmt --foobar -- %t'
+
+Execute(The statix command should be configurable):
+  let b:ale_nix_statix_executable = 'foo/bar'
+
+  AssertLinter 'foo/bar', ale#Escape('foo/bar') . 'check -o errfmt -- %t'

--- a/test/linter/test_nix_statix.vader
+++ b/test/linter/test_nix_statix.vader
@@ -5,15 +5,15 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The statix command should be correct):
-  AssertLinter 'statix', ale#Escape('statix') . ' check -o errfmt -- %t'
+  AssertLinter 'statix', ale#Escape('statix') . ' check -o errfmt --stdin'
 
 Execute(Additional statix options should be configurable):
   let g:ale_nix_statix_check_options = '--foobar'
 
   AssertLinter 'statix',
-  \ ale#Escape('statix') . ' check -o errfmt --foobar -- %t'
+  \ ale#Escape('statix') . ' check -o errfmt --stdin --foobar'
 
 Execute(The statix command should be configurable):
   let g:ale_nix_statix_check_executable = 'foo/bar'
 
-  AssertLinter 'foo/bar', ale#Escape('foo/bar') . ' check -o errfmt -- %t'
+  AssertLinter 'foo/bar', ale#Escape('foo/bar') . ' check -o errfmt --stdin'


### PR DESCRIPTION
Write an implementation for statix to use as both a linter and a fixer, using `statix check` and `statix fix` respectively. 

I previously made a PR for this as #3967, and closed it when I realized there were breaking changes with the v0.4.0 release. This implementation works with v0.4.0, and adds fixer support as well.

Made some minor ale-nix.txt formatting fixes as well left over from my previous implementation of nixfmt and from nixpkgs-fmt.