### PR TITLE
Adds --memory-limit support for phpstan

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -6,6 +6,7 @@ let g:ale_php_phpstan_executable = get(g:, 'ale_php_phpstan_executable', 'phpsta
 let g:ale_php_phpstan_level = get(g:, 'ale_php_phpstan_level', '')
 let g:ale_php_phpstan_configuration = get(g:, 'ale_php_phpstan_configuration', '')
 let g:ale_php_phpstan_autoload = get(g:, 'ale_php_phpstan_autoload', '')
+let g:ale_php_phpstan_memory_limit = get(g:, 'ale_php_phpstan_memory_limit', '128M')
 call ale#Set('php_phpstan_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
@@ -17,6 +18,11 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     let l:autoload = ale#Var(a:buffer, 'php_phpstan_autoload')
     let l:autoload_option = !empty(l:autoload)
     \   ? ' -a ' . ale#Escape(l:autoload)
+    \   : ''
+
+    let l:memory_limit = ale#Var(a:buffer, 'php_phpstan_memory_limit')
+    let l:memory_limit_option = !empty(l:memory_limit)
+    \   ? ' --memory-limit ' . ale#Escape(l:memory_limit)
     \   : ''
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')
@@ -41,6 +47,7 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     \   . l:configuration_option
     \   . l:autoload_option
     \   . l:level_option
+    \   . l:memory_limit_option
     \   . ' %s'
 endfunction
 

--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -1,4 +1,4 @@
-" Author: medains <https://github.com/medains>, ardis <https://github.com/ardisdreelath>
+" Author: medains <https://github.com/medains>, ardis <https://github.com/ardisdreelath>, Arizard <https://github.com/Arizard>
 " Description: phpstan for PHP files
 
 " Set to change the ruleset

--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -6,7 +6,7 @@ let g:ale_php_phpstan_executable = get(g:, 'ale_php_phpstan_executable', 'phpsta
 let g:ale_php_phpstan_level = get(g:, 'ale_php_phpstan_level', '')
 let g:ale_php_phpstan_configuration = get(g:, 'ale_php_phpstan_configuration', '')
 let g:ale_php_phpstan_autoload = get(g:, 'ale_php_phpstan_autoload', '')
-let g:ale_php_phpstan_memory_limit = get(g:, 'ale_php_phpstan_memory_limit', '128M')
+let g:ale_php_phpstan_memory_limit = get(g:, 'ale_php_phpstan_memory_limit', '')
 call ale#Set('php_phpstan_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#php#phpstan#GetCommand(buffer, version) abort

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -187,6 +187,15 @@ g:ale_php_phpstan_autoload                         *g:ale_php_phpstan_autoload*
   This variable sets path to phpstan autoload file.
 
 
+g:ale_php_phpstan_memory-limit                 *g:ale_php_phpstan_memory-limit*
+                                               *b:ale_php_phpstan_memory-limit*
+  Type: |String|
+  Default: `'128M'`
+
+  This variable sets the memory limit for phpstan analysis. This is a string
+  in the same format as `php.ini` accepts, e.g. `128M`, `1G`.
+
+
 ===============================================================================
 psalm                                                           *ale-php-psalm*
 

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -190,7 +190,7 @@ g:ale_php_phpstan_autoload                         *g:ale_php_phpstan_autoload*
 g:ale_php_phpstan_memory-limit                 *g:ale_php_phpstan_memory-limit*
                                                *b:ale_php_phpstan_memory-limit*
   Type: |String|
-  Default: `'128M'`
+  Default: `''`
 
   This variable sets the memory limit for phpstan analysis. This is a string
   in the same format as `php.ini` accepts, e.g. `128M`, `1G`.

--- a/doc/ale-php.txt
+++ b/doc/ale-php.txt
@@ -187,7 +187,7 @@ g:ale_php_phpstan_autoload                         *g:ale_php_phpstan_autoload*
   This variable sets path to phpstan autoload file.
 
 
-g:ale_php_phpstan_memory-limit                 *g:ale_php_phpstan_memory-limit*
+g:ale_php_phpstan_memory_limit                 *g:ale_php_phpstan_memory-limit*
                                                *b:ale_php_phpstan_memory-limit*
   Type: |String|
   Default: `''`

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -118,4 +118,4 @@ Execute(Memory limit parameter is added to the command):
   let g:ale_php_phpstan_memory_limit = '500M'
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json --memory-limit ' . ale#Escape('500M') . ' -l ' . ale#Escape('4') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' --memory-limit ' . ale#Escape('500M') . ' %s'

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -113,3 +113,9 @@ Execute(Autoload parameter is added to the command):
 
   AssertLinter 'phpstan',
   \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -a ' . ale#Escape('autoload.php') . ' -l ' . ale#Escape('4') . ' %s'
+
+Execute(Memory limit parameter is added to the command):
+  let g:ale_php_phpstan_memory_limit = '500M'
+
+  AssertLinter 'phpstan',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json --memory-limit ' . ale#Escape('500M') . ' -l ' . ale#Escape('4') . ' %s'


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

This PR adds support for the phpstan `--memory-limit` command line option.
This is configurable using the `g:ale_php_phpstan_memory_limit` variable.

* Added config variable
* Added test to `test_phpstan.vader` to confirm the option is being appended to the command.
* Added documentation
