### PR TITLE
Improve ALEFix performance for neovim

### DIFF
--- a/autoload/ale/fix.vim
+++ b/autoload/ale/fix.vim
@@ -32,7 +32,7 @@ function! ale#fix#ApplyQueuedFixes(buffer) abort
                 endif
             endif
         endif
-    catch /E21/
+    catch /E21\|E5555/
         " If we cannot modify the buffer now, try again later.
         let g:ale_fix_buffer_data[a:buffer] = l:data
 

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -522,7 +522,12 @@ function! ale#util#SetBufferContents(buffer, lines) abort
 
     " Use a Vim API for setting lines in other buffers, if available.
     if l:has_bufline_api
-        call setbufline(a:buffer, 1, l:new_lines)
+        if has('nvim')
+            call nvim_buf_set_lines(a:buffer, 0, l:first_line_to_remove, 0, l:new_lines)
+        else
+            call setbufline(a:buffer, 1, l:new_lines)
+        endif
+
         call deletebufline(a:buffer, l:first_line_to_remove, '$')
     " Fall back on setting lines the old way, for the current buffer.
     else

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -523,7 +523,13 @@ function! ale#util#SetBufferContents(buffer, lines) abort
     " Use a Vim API for setting lines in other buffers, if available.
     if l:has_bufline_api
         if has('nvim')
+            " save and restore signs to avoid flickering
+            let signs = sign_getplaced(a:buffer, {'group': 'ale'})[0].signs
+
             call nvim_buf_set_lines(a:buffer, 0, l:first_line_to_remove, 0, l:new_lines)
+
+            " restore signs (invalid line numbers will be skipped)
+            call sign_placelist(map(signs, {_, v -> extend(v, {'buffer': a:buffer})}))
         else
             call setbufline(a:buffer, 1, l:new_lines)
         endif


### PR DESCRIPTION
`nvim_buf_set_lines()` does not have the same problems with Treesitter, that `setbufline()` does have.