### PR TITLE
Add sub_type to Elvis output

### DIFF
--- a/ale_linters/erlang/elvis.vim
+++ b/ale_linters/erlang/elvis.vim
@@ -12,6 +12,7 @@ function! ale_linters#erlang#elvis#Handle(buffer, lines) abort
         \   'lnum': str2nr(l:match[1]),
         \   'text': s:AbbreviateMessage(l:match[2]),
         \   'type': 'W',
+        \   'sub_type': 'style',
         \})
     endfor
 

--- a/test/handler/test_erlang_elvis_handler.vader
+++ b/test/handler/test_erlang_elvis_handler.vader
@@ -11,11 +11,13 @@ Execute(Warning messages should be handled):
   \     'lnum': 11,
   \     'text': "Replace the 'if' expression on line 11 with a 'case' expression or function clauses.",
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \   {
   \     'lnum': 20,
   \     'text': 'Remove the debug call to io:format/1 on line 20.',
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \ ],
   \ ale_linters#erlang#elvis#Handle(bufnr(''), [
@@ -30,6 +32,7 @@ Execute(Line length message shouldn't contain the line itself):
   \     'lnum': 24,
   \     'text': 'Line 24 is too long.',
   \     'type': 'W',
+  \     'sub_type': 'style',
   \   },
   \ ],
   \ ale_linters#erlang#elvis#Handle(bufnr(''), [


### PR DESCRIPTION
Elvis is Erlang style reviewer, thus all loclist objects should have `sub_type` set to `style`.
