### PR TITLE
Find composer.json when searching for psalm

### DIFF
--- a/ale_linters/php/psalm.vim
+++ b/ale_linters/php/psalm.vim
@@ -6,6 +6,12 @@ call ale#Set('php_psalm_options', '')
 call ale#Set('php_psalm_use_global', get(g:, 'ale_use_global_executables', 0))
 
 function! ale_linters#php#psalm#GetProjectRoot(buffer) abort
+    let l:composer_path = ale#path#FindNearestFile(a:buffer, 'composer.json')
+
+    if (!empty(l:composer_path))
+        return fnamemodify(l:composer_path, ':h')
+    endif
+
     let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
 
     return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''

--- a/test/linter/test_psalm.vader
+++ b/test/linter/test_psalm.vader
@@ -36,3 +36,8 @@ Execute(User provided options should be used):
   AssertLinter 'psalm',
   \ ale#Escape('psalm')
   \ . ' --language-server --my-user-provided-option my-value'
+
+Execute(The project path should be correct for composer.json file):
+  call ale#test#SetFilename('../test-files/php/with-composer/test.php')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/php/with-composer')


### PR DESCRIPTION
This PR adds a lookup for a directory with `composer.json` in it when trying to find the `psalm` executable under `vendor/bin`.
Previously it looked for the `.git/` directory but some projects may not necessarily have their `vendor/bin` directory placed at their project root.

