### PR TITLE
Add cppcheck handler match on misra msg

### DIFF
--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -50,7 +50,12 @@ function! ale#handlers#cppcheck#HandleCppCheckFormat(buffer, lines) abort
     "test.cpp:974:{column}: error:{inconclusive:inconclusive} Array 'n[3]' accessed at index 3, which is out of bounds. [arrayIndexOutOfBounds]\
     "    n[3]=3;
     "     ^
-    let l:pattern = '\v(\f+):(\d+):(\d+|\{column\}): (\w+):(\{inconclusive:inconclusive\})? ?(.*) \[(\w+)\]\'
+    "
+    "" OR if using the misra addon:
+    "test.c:1:16: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-2.7]\'
+    "void test( int parm ) {}
+    "               ^
+    let l:pattern = '\v(\f+):(\d+):(\d+|\{column\}): (\w+):(\{inconclusive:inconclusive\})? ?(.*) \[(%(\w[-.]?)+)\]\'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_cppcheck_handler.vader
+++ b/test/handler/test_cppcheck_handler.vader
@@ -63,6 +63,23 @@ Execute(Basic errors should be handled by cppcheck):
   \ '         ^',
   \ ])
 
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col' : 16,
+  \     'type': 'W',
+  \     'sub_type': 'style',
+  \     'text': 'misra violation (use --rule-texts=<file> to get proper output)',
+  \     'code': 'misra-c2012-2.7'
+  \   },
+  \ ],
+  \ ale#handlers#cppcheck#HandleCppCheckFormat(bufnr(''), [
+  \ 'test.cpp:1:16: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-2.7]\',
+  \ 'void test( int parm ) {}',
+  \ '               ^',
+  \ ])
+
 Execute(Problems from other files should be ignored by cppcheck):
   call ale#test#SetFilename('test.cpp')
 


### PR DESCRIPTION
- [x] Read the Contributing guide linked above first.
- [x] Read the documentation that comes with ALE with `:help ale-dev`.
- [x] Have fun!
- [x] ... write tests.

The incumbent regex did not match the misra code values because the code format includes `-` and `.`. The new regex does not validate the misra code format; rather, it just accepts the chars. For example, `misra-2.` would be accepted.