### PR TITLE
Rewrite Alex Integration to Use stdin

### DIFF
--- a/autoload/ale/handlers/alex.vim
+++ b/autoload/ale/handlers/alex.vim
@@ -11,8 +11,9 @@ endfunction
 
 function! ale#handlers#alex#CreateCommandCallback(flags) abort
     return {b -> ale#node#Executable(b, ale#handlers#alex#GetExecutable(b))
-    \            . ' %s '
-    \            . a:flags}
+    \            . ' --stdin '
+    \            . a:flags
+    \}
 endfunction
 
 function! ale#handlers#alex#Handle(buffer, lines) abort
@@ -38,6 +39,7 @@ endfunction
 " Define a linter for a specific filetype. Accept flags to adapt to the filetype.
 "    no flags  treat input as markdown
 "    --html    treat input as HTML
+"    --mdx     treat input as MDX
 "    --text    treat input as plaintext
 function! ale#handlers#alex#DefineLinter(filetype, flags) abort
     call ale#Set('alex_executable', 'alex')
@@ -49,6 +51,5 @@ function! ale#handlers#alex#DefineLinter(filetype, flags) abort
     \   'command': ale#handlers#alex#CreateCommandCallback(a:flags),
     \   'output_stream': 'stderr',
     \   'callback': 'ale#handlers#alex#Handle',
-    \   'lint_file': 1,
     \})
 endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -24,7 +24,7 @@ Notes:
   * `apkbuild-lint`
   * `secfixes-check`
 * AsciiDoc
-  * `alex`!!
+  * `alex`
   * `languagetool`!!
   * `proselint`
   * `redpen`
@@ -227,7 +227,7 @@ Notes:
 * HCL
   * `terraform-fmt`
 * HTML
-  * `alex`!!
+  * `alex`
   * `angular`
   * `fecs`
   * `html-beautify`
@@ -286,7 +286,7 @@ Notes:
   * `ktlint`
   * `languageserver`
 * LaTeX (tex)
-  * `alex`!!
+  * `alex`
   * `chktex`
   * `lacheck`
   * `proselint`
@@ -308,14 +308,14 @@ Notes:
   * `luafmt`
   * `stylua`
 * Mail
-  * `alex`!!
+  * `alex`
   * `languagetool`!!
   * `proselint`
   * `vale`
 * Make
   * `checkmake`
 * Markdown
-  * `alex`!!
+  * `alex`
   * `languagetool`!!
   * `markdownlint`!!
   * `mdl`
@@ -344,7 +344,7 @@ Notes:
   * `rnix-lsp`
   * `statix`
 * nroff
-  * `alex`!!
+  * `alex`
   * `proselint`
   * `write-good`
 * Objective-C
@@ -389,12 +389,12 @@ Notes:
   * `psalm`!!
   * `tlint`
 * PO
-  * `alex`!!
+  * `alex`
   * `msgfmt`
   * `proselint`
   * `write-good`
 * Pod
-  * `alex`!!
+  * `alex`
   * `proselint`
   * `write-good`
 * Pony
@@ -457,7 +457,7 @@ Notes:
   * `reason-language-server`
   * `refmt`
 * reStructuredText
-  * `alex`!!
+  * `alex`
   * `proselint`
   * `redpen`
   * `rstcheck`
@@ -540,11 +540,11 @@ Notes:
   * `terraform-lsp`
   * `tflint`
 * Texinfo
-  * `alex`!!
+  * `alex`
   * `proselint`
   * `write-good`
 * Text^
-  * `alex`!!
+  * `alex`
   * `languagetool`!!
   * `proselint`
   * `redpen`
@@ -584,14 +584,14 @@ Notes:
   * `vimls`
   * `vint`
 * Vim help^
-  * `alex`!!
+  * `alex`
   * `proselint`
   * `write-good`
 * Vue
   * `prettier`
   * `vls`
 * XHTML
-  * `alex`!!
+  * `alex`
   * `proselint`
   * `write-good`
 * XML

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -33,7 +33,7 @@ formatting.
   * [apkbuild-lint](https://gitlab.alpinelinux.org/Leo/atools)
   * [secfixes-check](https://gitlab.alpinelinux.org/Leo/atools)
 * AsciiDoc
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [languagetool](https://languagetool.org/) :floppy_disk:
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)
@@ -236,7 +236,7 @@ formatting.
 * HCL
   * [terraform-fmt](https://github.com/hashicorp/terraform)
 * HTML
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [angular](https://www.npmjs.com/package/@angular/language-server)
   * [fecs](http://fecs.baidu.com/)
   * [html-beautify](https://beautifier.io/)
@@ -295,7 +295,7 @@ formatting.
   * [ktlint](https://ktlint.github.io)
   * [languageserver](https://github.com/fwcd/KotlinLanguageServer) see `:help ale-integration-kotlin` for configuration instructions
 * LaTeX
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [chktex](http://www.nongnu.org/chktex/)
   * [lacheck](https://www.ctan.org/pkg/lacheck)
   * [proselint](http://proselint.com/)
@@ -317,14 +317,14 @@ formatting.
   * [luafmt](https://github.com/trixnz/lua-fmt)
   * [stylua](https://github.com/johnnymorganz/stylua)
 * Mail
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [languagetool](https://languagetool.org/) :floppy_disk:
   * [proselint](http://proselint.com/)
   * [vale](https://github.com/ValeLint/vale)
 * Make
   * [checkmake](https://github.com/mrtazz/checkmake)
 * Markdown
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [languagetool](https://languagetool.org/) :floppy_disk:
   * [markdownlint](https://github.com/DavidAnson/markdownlint) :floppy_disk:
   * [mdl](https://github.com/mivok/markdownlint)
@@ -353,7 +353,7 @@ formatting.
   * [rnix-lsp](https://github.com/nix-community/rnix-lsp)
   * [statix](https://github.com/nerdypepper/statix)
 * nroff
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [proselint](http://proselint.com/)
   * [write-good](https://github.com/btford/write-good)
 * Objective-C
@@ -398,12 +398,12 @@ formatting.
   * [psalm](https://getpsalm.org) :floppy_disk:
   * [tlint](https://github.com/tightenco/tlint)
 * PO
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [msgfmt](https://www.gnu.org/software/gettext/manual/html_node/msgfmt-Invocation.html)
   * [proselint](http://proselint.com/)
   * [write-good](https://github.com/btford/write-good)
 * Pod
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [proselint](http://proselint.com/)
   * [write-good](https://github.com/btford/write-good)
 * Pony
@@ -466,7 +466,7 @@ formatting.
   * [reason-language-server](https://github.com/jaredly/reason-language-server)
   * [refmt](https://github.com/reasonml/reason-cli)
 * reStructuredText
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [proselint](http://proselint.com/)
   * [redpen](http://redpen.cc/)
   * [rstcheck](https://github.com/myint/rstcheck)
@@ -549,11 +549,11 @@ formatting.
   * [terraform-lsp](https://github.com/juliosueiras/terraform-lsp)
   * [tflint](https://github.com/wata727/tflint)
 * Texinfo
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [proselint](http://proselint.com/)
   * [write-good](https://github.com/btford/write-good)
 * Text
-  * [alex](https://github.com/wooorm/alex) :warning: :floppy_disk:
+  * [alex](https://github.com/get-alex/alex) :warning:
   * [languagetool](https://languagetool.org/) :floppy_disk:
   * [proselint](http://proselint.com/) :warning:
   * [redpen](http://redpen.cc/) :warning:
@@ -593,14 +593,14 @@ formatting.
   * [vimls](https://github.com/iamcco/vim-language-server)
   * [vint](https://github.com/Kuniwak/vint)
 * Vim help
-  * [alex](https://github.com/wooorm/alex) :warning: :floppy_disk:
+  * [alex](https://github.com/get-alex/alex) :warning:
   * [proselint](http://proselint.com/) :warning:
   * [write-good](https://github.com/btford/write-good) :warning:
 * Vue
   * [prettier](https://github.com/prettier/prettier)
   * [vls](https://github.com/vuejs/vetur/tree/master/server)
 * XHTML
-  * [alex](https://github.com/wooorm/alex) :floppy_disk:
+  * [alex](https://github.com/get-alex/alex)
   * [proselint](http://proselint.com/)
   * [write-good](https://github.com/btford/write-good)
 * XML

--- a/test/linter/test_alex.vader
+++ b/test/linter/test_alex.vader
@@ -7,14 +7,14 @@ After:
 
 Execute(The global executable should be used when the local one cannot be found):
   AssertLinter 'alex',
-  \ ale#Escape('alex') . ' %s --text',
+  \ ale#Escape('alex') . ' --stdin --text',
 
 Execute(Should use the node_modules/.bin executable, if available):
   call ale#test#SetFilename('../test-files/alex/node-modules/test_file.tex')
 
   AssertLinter ale#path#Simplify(g:dir . '/../test-files/alex/node-modules/node_modules/.bin/alex'),
   \ ale#Escape(ale#path#Simplify(g:dir . '/../test-files/alex/node-modules/node_modules/.bin/alex'))
-  \ . ' %s --text',
+  \ . ' --stdin --text',
 
 Execute(Should use the node_modules/alex executable, if available):
   call ale#test#SetFilename('../test-files/alex/node-modules-2/test_file.tex')
@@ -22,7 +22,7 @@ Execute(Should use the node_modules/alex executable, if available):
   AssertLinter ale#path#Simplify(g:dir . '/../test-files/alex/node-modules-2/node_modules/alex/cli.js'),
   \ (has('win32') ? 'node.exe ' : '')
   \ . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/alex/node-modules-2/node_modules/alex/cli.js'))
-  \ . ' %s --text',
+  \ . ' --stdin --text',
 
 Execute(Should let users configure a global executable and override local paths):
   call ale#test#SetFilename('../test-files/write-good/node-modules-2/test_file.tex')
@@ -31,4 +31,4 @@ Execute(Should let users configure a global executable and override local paths)
   let g:ale_alex_use_global = 1
 
   AssertLinter '/path/to/custom/alex',
-  \ ale#Escape('/path/to/custom/alex') . ' %s --text'
+  \ ale#Escape('/path/to/custom/alex') . ' --stdin --text'


### PR DESCRIPTION
Since having been added, the `alex` tool has added support for linting
on stdin. Rewrite this integration to reduce the number of tools
requiring disk-write access.

Been sitting on this for a second; waited for `alex` to be added to nixpkgs.

Closes #3971