### PR TITLE
Cppcheck buffered file only

### DIFF
--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -19,6 +19,16 @@ function! ale#handlers#cppcheck#GetBufferPathIncludeOptions(buffer) abort
 endfunction
 
 function! ale#handlers#cppcheck#GetCompileCommandsOptions(buffer) abort
+    " The compile_commands.json doesn't apply to headers and cppheck will
+    " bail out if it cannot find a file matching the filter, below. Skip out
+    " now, for headers. Also, suppress FPs; cppcheck is not meant to
+    " process lone header files.
+    let b:file_extension = fnamemodify(bufname(a:buffer), ':e')
+    if b:file_extension is# 'h' || b:file_extension is# 'hpp'
+        return ale#handlers#cppcheck#GetBufferPathIncludeOptions(a:buffer)
+        \   . ' --suppress=unusedStructMember'
+    endif
+
     " If the current buffer is modified, using compile_commands.json does no
     " good, so include the file's directory instead. It's not quite as good as
     " using --project, but is at least equivalent to running cppcheck on this

--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -23,7 +23,8 @@ function! ale#handlers#cppcheck#GetCompileCommandsOptions(buffer) abort
     " bail out if it cannot find a file matching the filter, below. Skip out
     " now, for headers. Also, suppress FPs; cppcheck is not meant to
     " process lone header files.
-    let b:file_extension = fnamemodify(bufname(a:buffer), ':e')
+    let b:buffer_name = bufname(a:buffer)
+    let b:file_extension = fnamemodify(b:buffer_name, ':e')
 
     if b:file_extension is# 'h' || b:file_extension is# 'hpp'
         return ale#handlers#cppcheck#GetBufferPathIncludeOptions(a:buffer)
@@ -45,11 +46,13 @@ function! ale#handlers#cppcheck#GetCompileCommandsOptions(buffer) abort
     " If we find it, we'll `cd` to where the compile_commands.json file is,
     " then use the file to set up import paths, etc.
     let [l:dir, l:json_path] = ale#c#FindCompileCommands(a:buffer)
+    let b:root_index = len(l:dir) + 1
+    let b:buffer_file= bufname(a:buffer)
 
     " By default, cppcheck processes every config in compile_commands.json.
     " Use --file-filter to limit to just the buffer file.
     return !empty(l:json_path)
-    \   ? '--project=' . ale#Escape(l:json_path[len(l:dir) + 1: ]) . ' --file-filter=' . ale#Escape(bufname(a:buffer))
+    \   ? '--project=' . ale#Escape(l:json_path[b:root_index: ]) . ' --file-filter=' . ale#Escape(b:buffer_file[b:root_index:])
     \   : ''
 endfunction
 

--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -24,6 +24,7 @@ function! ale#handlers#cppcheck#GetCompileCommandsOptions(buffer) abort
     " now, for headers. Also, suppress FPs; cppcheck is not meant to
     " process lone header files.
     let b:file_extension = fnamemodify(bufname(a:buffer), ':e')
+
     if b:file_extension is# 'h' || b:file_extension is# 'hpp'
         return ale#handlers#cppcheck#GetBufferPathIncludeOptions(a:buffer)
         \   . ' --suppress=unusedStructMember'

--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -35,8 +35,10 @@ function! ale#handlers#cppcheck#GetCompileCommandsOptions(buffer) abort
     " then use the file to set up import paths, etc.
     let [l:dir, l:json_path] = ale#c#FindCompileCommands(a:buffer)
 
+    " By default, cppcheck processes every config in compile_commands.json.
+    " Use --file-filter to limit to just the buffer file.
     return !empty(l:json_path)
-    \   ? '--project=' . ale#Escape(l:json_path[len(l:dir) + 1: ])
+    \   ? '--project=' . ale#Escape(l:json_path[len(l:dir) + 1: ]) . ' --file-filter=' . ale#Escape(bufname(a:buffer))
     \   : ''
 endfunction
 

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -51,3 +51,15 @@ Execute(cppcheck for C should include file dir if compile_commands.json file is 
   \   . ' --enable=style'
   \   . ' -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/cppcheck'))
   \   . ' %t'
+
+Execute(cppcheck for C header should include file dir and not use compile_commands.json):
+  call ale#test#SetFilename('../test-files/cppcheck/one/foo.h')
+
+  AssertLinter 'cppcheck',
+  \   ale#Escape('cppcheck')
+  \   . ' -q --language=c'
+  \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
+  \   . '  -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/cppcheck/one'))
+  \   . ' --suppress=unusedStructMember'
+  \   . ' --enable=style'
+  \   . ' %t'

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -15,25 +15,29 @@ Execute(The executable should be configurable):
   AssertLinter 'foobar', ale#Escape('foobar') . b:command_tail
 
 Execute(cppcheck for C should detect compile_commands.json files):
-  call ale#test#SetFilename('../test-files/cppcheck/one/foo.c')
+  let b:relative_path_filename = '../test-files/cppcheck/one/foo.c'
+  call ale#test#SetFilename(b:relative_path_filename)
+  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/one')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
-  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/one/foo.c'))
+  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should detect compile_commands.json files in build directories):
-  call ale#test#SetFilename('../test-files/cppcheck/with_build_dir/foo.c')
+  let b:relative_path_filename = '../test-files/cppcheck/with_build_dir/foo.c'
+  call ale#test#SetFilename(b:relative_path_filename)
+  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/with_build_dir')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
-  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/with_build_dir/foo.c'))
+  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should include file dir if compile_commands.json file is not found):

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -22,16 +22,18 @@ Execute(cppcheck for C should detect compile_commands.json files):
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
+  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/one/foo.c'))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should detect compile_commands.json files in build directories):
-  call ale#test#SetFilename('../test-files/cppcheck/with_build_dir/foo.cpp')
+  call ale#test#SetFilename('../test-files/cppcheck/with_build_dir/foo.c')
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/with_build_dir')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
+  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/with_build_dir/foo.c'))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should include file dir if compile_commands.json file is not found):

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -41,7 +41,7 @@ Execute(cppcheck for C should detect compile_commands.json files in build direct
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should include file dir if compile_commands.json file is not found):
-  call ale#test#SetFilename('../test-files/cppcheck/foo.cpp')
+  call ale#test#SetFilename('../test-files/cppcheck/foo.c')
 
   AssertLinter 'cppcheck',
   \   ale#Escape('cppcheck')

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -4,7 +4,6 @@ Before:
 
 After:
   unlet! b:command_tail
-  unlet! b:relative_path_filename
   call ale#assert#TearDownLinterTest()
 
 Execute(The executable should be configurable):
@@ -16,29 +15,25 @@ Execute(The executable should be configurable):
   AssertLinter 'foobar', ale#Escape('foobar') . b:command_tail
 
 Execute(cppcheck for C should detect compile_commands.json files):
-  let b:relative_path_filename = '../test-files/cppcheck/one/foo.c'
-  call ale#test#SetFilename(b:relative_path_filename)
-  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
+  call ale#test#SetFilename('../test-files/cppcheck/one/foo.c')
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/one')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
-  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
+  \   . ' --file-filter=' . ale#Escape('foo.c')
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should detect compile_commands.json files in build directories):
-  let b:relative_path_filename = '../test-files/cppcheck/with_build_dir/foo.c'
-  call ale#test#SetFilename(b:relative_path_filename)
-  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
+  call ale#test#SetFilename('../test-files/cppcheck/with_build_dir/foo.c')
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/with_build_dir')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
-  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
+  \   . ' --file-filter=' . ale#Escape('foo.c')
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should include file dir if compile_commands.json file is not found):

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -4,6 +4,7 @@ Before:
 
 After:
   unlet! b:command_tail
+  unlet! b:relative_path_filename
   call ale#assert#TearDownLinterTest()
 
 Execute(The executable should be configurable):

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -21,25 +21,29 @@ Execute(The executable should be configurable):
   AssertLinter 'foobar', ale#Escape('foobar') . b:command_tail
 
 Execute(cppcheck for C++ should detect compile_commands.json files):
-  call ale#test#SetFilename('../test-files/cppcheck/one/foo.cpp')
+  let b:relative_path_filename = '../test-files/cppcheck/one/foo.cpp'
+  call ale#test#SetFilename(b:relative_path_filename)
+  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/one')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
-  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/one/foo.cpp'))
+  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should detect compile_commands.json files in build directories):
-  call ale#test#SetFilename('../test-files/cppcheck/with_build_dir/foo.cpp')
+  let b:relative_path_filename = '../test-files/cppcheck/with_build_dir/foo.cpp'
+  call ale#test#SetFilename(b:relative_path_filename)
+  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/with_build_dir')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
-  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/with_build_dir/foo.cpp'))
+  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should include file dir if compile_commands.json file is not found):

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -10,6 +10,7 @@ After:
   endif
 
   unlet! b:command_tail
+  unlet! b:relative_path_filename
   call ale#assert#TearDownLinterTest()
 
 Execute(The executable should be configurable):
@@ -55,6 +56,18 @@ Execute(cppcheck for C++ should include file dir if compile_commands.json file i
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --enable=style'
   \   . ' -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/cppcheck'))
+  \   . ' %t'
+
+Execute(cppcheck for C++ header should include file dir and not use compile_commands.json):
+  call ale#test#SetFilename('../test-files/cppcheck/one/foo.hpp')
+
+  AssertLinter 'cppcheck',
+  \   ale#Escape('cppcheck')
+  \   . ' -q --language=c++'
+  \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
+  \   . '  -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/cppcheck/one'))
+  \   . ' --suppress=unusedStructMember'
+  \   . ' --enable=style'
   \   . ' %t'
 
 Execute(cppcheck for C++ should ignore compile_commands.json file if buffer is modified):

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -10,7 +10,6 @@ After:
   endif
 
   unlet! b:command_tail
-  unlet! b:relative_path_filename
   call ale#assert#TearDownLinterTest()
 
 Execute(The executable should be configurable):
@@ -22,29 +21,25 @@ Execute(The executable should be configurable):
   AssertLinter 'foobar', ale#Escape('foobar') . b:command_tail
 
 Execute(cppcheck for C++ should detect compile_commands.json files):
-  let b:relative_path_filename = '../test-files/cppcheck/one/foo.cpp'
-  call ale#test#SetFilename(b:relative_path_filename)
-  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
+  call ale#test#SetFilename('../test-files/cppcheck/one/foo.cpp')
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/one')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
-  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
+  \   . ' --file-filter=' . ale#Escape('foo.cpp')
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should detect compile_commands.json files in build directories):
-  let b:relative_path_filename = '../test-files/cppcheck/with_build_dir/foo.cpp'
-  call ale#test#SetFilename(b:relative_path_filename)
-  let b:full_path_filename = ale#test#GetFilename(b:relative_path_filename)
+  call ale#test#SetFilename('../test-files/cppcheck/with_build_dir/foo.cpp')
 
   AssertLinterCwd ale#path#Simplify(g:dir . '/../test-files/cppcheck/with_build_dir')
   AssertLinter 'cppcheck', ale#Escape('cppcheck')
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
-  \   . ' --file-filter=' . ale#Escape(b:full_path_filename)
+  \   . ' --file-filter=' . ale#Escape('foo.cpp')
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should include file dir if compile_commands.json file is not found):

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -28,6 +28,7 @@ Execute(cppcheck for C++ should detect compile_commands.json files):
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
+  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/one/foo.cpp'))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should detect compile_commands.json files in build directories):
@@ -38,6 +39,7 @@ Execute(cppcheck for C++ should detect compile_commands.json files in build dire
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
+  \   . ' --file-filter=' . ale#Escape(ale#path#Simplify('/testplugin/test/test-files/cppcheck/with_build_dir/foo.cpp'))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should include file dir if compile_commands.json file is not found):


### PR DESCRIPTION
Cppcheck can take a long time to check a large project and has --file-filter option to check only the files in the project that match the filter. The PR adds logic to check only the file in the buffer.

Cppcheck isn't designed to work on header files without being included in the c/cc/cpp file. This PR also addresses that issue by skipping `--project` option and adding `--suppress` for discovered false positive, `unusedStructMember`.
