### PR TITLE
Restore checkmake linebreaks

### DIFF
--- a/ale_linters/make/checkmake.vim
+++ b/ale_linters/make/checkmake.vim
@@ -20,6 +20,6 @@ endfunction
 call ale#linter#Define('make', {
 \   'name': 'checkmake',
 \   'executable': 'checkmake',
-\   'command': 'checkmake %s --format="{{.LineNumber}}:{{.Rule}}:{{.Violation}}"',
+\   'command': 'checkmake %s --format="{{.LineNumber}}:{{.Rule}}:{{.Violation}}{{\"\r\n\"}}"',
 \   'callback': 'ale_linters#make#checkmake#Handle',
 \})


### PR DESCRIPTION
Checkmake maintainers recently removed linebreak from internal formatter. This PR prevents checkmake errors from appearing as a single error.

For more description: see [No newlines in ALE output](https://github.com/mrtazz/checkmake/issues/60) end [remove newline for custom formatter](https://github.com/mrtazz/checkmake/pull/55).