### PR TITLE
WIP - add neovim 0.6 to run-tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,8 @@ jobs:
         vim-version:
           - '--vim-80-only'
           - '--vim-82-only'
-          - '--neovim-02-only'
-          - '--neovim-04-only'
           - '--neovim-05-only'
+          - '--neovim-06-only'
           - '--linters-only'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         vim-version:
           - '--vim-80-only'
           - '--vim-82-only'
-          - '--neovim-05-only'
+          - '--neovim-02-only'
           - '--neovim-06-only'
           - '--linters-only'
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM testbed/vim:23
+FROM testbed/vim:20
 
 RUN install_vim -tag v8.0.0027 -build \
                 -tag v8.2.2401 -build \
-                -tag neovim:v0.5.0 -build \
+                -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.6.1 -build
 
 ENV PACKAGES="\
@@ -24,4 +24,4 @@ RUN git clone https://github.com/junegunn/vader.vim vader && \
 
 ARG GIT_VERSION
 LABEL Version=${GIT_VERSION}
-LABEL Name=w0rp/ale
+LABEL Name=denseanalysis/ale

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM testbed/vim:20
+FROM testbed/vim:23
 
 RUN install_vim -tag v8.0.0027 -build \
                 -tag v8.2.2401 -build \
-                -tag neovim:v0.2.0 -build \
-                -tag neovim:v0.4.4 -build \
                 -tag neovim:v0.5.0 -build \
-                -tag neovim:v0.6.0 -build
+                -tag neovim:v0.6.1 -build
 
 ENV PACKAGES="\
     bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN install_vim -tag v8.0.0027 -build \
                 -tag v8.2.2401 -build \
                 -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.4.4 -build \
-                -tag neovim:v0.5.0 -build
+                -tag neovim:v0.5.0 -build \
+                -tag neovim:v0.6.0 -build
 
 ENV PACKAGES="\
     bash \

--- a/autoload/ale/test.vim
+++ b/autoload/ale/test.vim
@@ -62,25 +62,34 @@ function! ale#test#SetFilename(path) abort
     silent! noautocmd execute 'file ' . fnameescape(l:full_path)
 endfunction
 
-function! s:RemoveModule(results) abort
+function! RemoveNewerKeys(results) abort
     for l:item in a:results
         if has_key(l:item, 'module')
             call remove(l:item, 'module')
         endif
+
+        if has_key(l:item, 'end_col')
+            call remove(l:item, 'end_col')
+        endif
+
+        if has_key(l:item, 'end_lnum')
+            call remove(l:item, 'end_lnum')
+        endif
     endfor
 endfunction
 
-" Return loclist data without the module string, only in newer Vim versions.
-function! ale#test#GetLoclistWithoutModule() abort
+" Return loclist data with only the keys supported by the lowest Vim versions.
+function! ale#test#GetLoclistWithoutNewerKeys() abort
     let l:results = getloclist(0)
-    call s:RemoveModule(l:results)
+    call RemoveNewerKeys(l:results)
 
     return l:results
 endfunction
 
-function! ale#test#GetQflistWithoutModule() abort
+" Return quickfix data with only the keys supported by the lowest Vim versions.
+function! ale#test#GetQflistWithoutNewerKeys() abort
     let l:results = getqflist()
-    call s:RemoveModule(l:results)
+    call RemoveNewerKeys(l:results)
 
     return l:results
 endfunction

--- a/run-tests
+++ b/run-tests
@@ -27,6 +27,7 @@ quiet_flag=''
 run_neovim_02_tests=1
 run_neovim_04_tests=1
 run_neovim_05_tests=1
+run_neovim_06_tests=1
 run_vim_80_tests=1
 run_vim_82_tests=1
 run_linters=1
@@ -47,6 +48,7 @@ while [ $# -ne 0 ]; do
         run_neovim_02_tests=0
         run_neovim_04_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         run_linters=0
         shift
     ;;
@@ -59,6 +61,7 @@ while [ $# -ne 0 ]; do
     --neovim-02-only)
         run_neovim_04_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
         run_linters=0
@@ -67,6 +70,7 @@ while [ $# -ne 0 ]; do
     --neovim-04-only)
         run_neovim_02_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
         run_linters=0
@@ -75,6 +79,16 @@ while [ $# -ne 0 ]; do
     --neovim-05-only)
         run_neovim_02_tests=0
         run_neovim_04_tests=0
+        run_neovim_06_tests=0
+        run_vim_80_tests=0
+        run_vim_82_tests=0
+        run_linters=0
+        shift
+    ;;
+    --neovim-06-only)
+        run_neovim_02_tests=0
+        run_neovim_04_tests=0
+        run_neovim_05_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
         run_linters=0
@@ -84,6 +98,7 @@ while [ $# -ne 0 ]; do
         run_neovim_02_tests=0
         run_neovim_04_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         run_linters=0
         shift
     ;;
@@ -91,6 +106,7 @@ while [ $# -ne 0 ]; do
         run_neovim_02_tests=0
         run_neovim_04_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
@@ -99,6 +115,7 @@ while [ $# -ne 0 ]; do
         run_neovim_02_tests=0
         run_neovim_04_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         run_vim_80_tests=0
         run_linters=0
         shift
@@ -109,6 +126,7 @@ while [ $# -ne 0 ]; do
         run_neovim_02_tests=0
         run_neovim_04_tests=0
         run_neovim_05_tests=0
+        run_neovim_06_tests=0
         shift
     ;;
     --fast)
@@ -116,7 +134,8 @@ while [ $# -ne 0 ]; do
         run_vim_82_tests=0
         run_neovim_02_tests=0
         run_neovim_04_tests=0
-        run_neovim_05_tests=1
+        run_neovim_05_tests=0
+        run_neovim_06_tests=1
         shift
     ;;
     --help)
@@ -133,6 +152,7 @@ while [ $# -ne 0 ]; do
         echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
         echo '  --neovim-04-only  Run tests only for NeoVim 0.4'
         echo '  --neovim-05-only  Run tests only for NeoVim 0.5'
+        echo '  --neovim-06-only  Run tests only for NeoVim 0.6'
         echo '  --vim-only        Run tests only for Vim'
         echo '  --vim-80-only     Run tests only for Vim 8.0'
         echo '  --vim-82-only     Run tests only for Vim 8.2'
@@ -239,7 +259,8 @@ for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neov
     || ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.4 ]] && ((run_neovim_04_tests)) ) \
-    || ( [[ $vim =~ ^neovim-v0.5 ]] && ((run_neovim_05_tests)) ); then
+    || ( [[ $vim =~ ^neovim-v0.5 ]] && ((run_neovim_05_tests)) ) \
+    || ( [[ $vim =~ ^neovim-v0.6 ]] && ((run_neovim_06_tests)) ); then
         echo "Starting Vim: $vim..."
         file_number=$((file_number+1))
         test/script/run-vader-tests $quiet_flag $verbose_flag "$vim" "$tests" \

--- a/run-tests
+++ b/run-tests
@@ -24,8 +24,6 @@ tests='test/*.vader test/*/*.vader test/*/*/*.vader test/*/*/*.vader'
 # These flags are forwarded to the script for running Vader tests.
 verbose_flag=''
 quiet_flag=''
-run_neovim_02_tests=1
-run_neovim_04_tests=1
 run_neovim_05_tests=1
 run_neovim_06_tests=1
 run_vim_80_tests=1
@@ -45,8 +43,6 @@ while [ $# -ne 0 ]; do
     --build-image)
         run_vim_80_tests=0
         run_vim_82_tests=0
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_neovim_06_tests=0
         run_linters=0
@@ -58,27 +54,7 @@ while [ $# -ne 0 ]; do
         run_linters=0
         shift
     ;;
-    --neovim-02-only)
-        run_neovim_04_tests=0
-        run_neovim_05_tests=0
-        run_neovim_06_tests=0
-        run_vim_80_tests=0
-        run_vim_82_tests=0
-        run_linters=0
-        shift
-    ;;
-    --neovim-04-only)
-        run_neovim_02_tests=0
-        run_neovim_05_tests=0
-        run_neovim_06_tests=0
-        run_vim_80_tests=0
-        run_vim_82_tests=0
-        run_linters=0
-        shift
-    ;;
     --neovim-05-only)
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_06_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
@@ -86,8 +62,6 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --neovim-06-only)
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
@@ -95,16 +69,12 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --vim-only)
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_neovim_06_tests=0
         run_linters=0
         shift
     ;;
     --vim-80-only)
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_neovim_06_tests=0
         run_vim_82_tests=0
@@ -112,8 +82,6 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --vim-82-only)
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_neovim_06_tests=0
         run_vim_80_tests=0
@@ -123,8 +91,6 @@ while [ $# -ne 0 ]; do
     --linters-only)
         run_vim_80_tests=0
         run_vim_82_tests=0
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_neovim_06_tests=0
         shift
@@ -132,8 +98,6 @@ while [ $# -ne 0 ]; do
     --fast)
         run_vim_80_tests=0
         run_vim_82_tests=0
-        run_neovim_02_tests=0
-        run_neovim_04_tests=0
         run_neovim_05_tests=0
         run_neovim_06_tests=1
         shift
@@ -149,8 +113,6 @@ while [ $# -ne 0 ]; do
         echo '  -q                Hide output for successful tests'
         echo '  --build-image     Run docker image build only.'
         echo '  --neovim-only     Run tests only for NeoVim'
-        echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
-        echo '  --neovim-04-only  Run tests only for NeoVim 0.4'
         echo '  --neovim-05-only  Run tests only for NeoVim 0.5'
         echo '  --neovim-06-only  Run tests only for NeoVim 0.6'
         echo '  --vim-only        Run tests only for Vim'
@@ -257,8 +219,6 @@ trap cancel_tests INT TERM
 for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neovim\|^vim' ); do
     if ( [[ $vim =~ ^vim-v8.0 ]] && ((run_vim_80_tests)) ) \
     || ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
-    || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
-    || ( [[ $vim =~ ^neovim-v0.4 ]] && ((run_neovim_04_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.5 ]] && ((run_neovim_05_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.6 ]] && ((run_neovim_06_tests)) ); then
         echo "Starting Vim: $vim..."

--- a/run-tests
+++ b/run-tests
@@ -24,7 +24,7 @@ tests='test/*.vader test/*/*.vader test/*/*/*.vader test/*/*/*.vader'
 # These flags are forwarded to the script for running Vader tests.
 verbose_flag=''
 quiet_flag=''
-run_neovim_05_tests=1
+run_neovim_02_tests=1
 run_neovim_06_tests=1
 run_vim_80_tests=1
 run_vim_82_tests=1
@@ -43,7 +43,7 @@ while [ $# -ne 0 ]; do
     --build-image)
         run_vim_80_tests=0
         run_vim_82_tests=0
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_neovim_06_tests=0
         run_linters=0
         shift
@@ -54,7 +54,7 @@ while [ $# -ne 0 ]; do
         run_linters=0
         shift
     ;;
-    --neovim-05-only)
+    --neovim-02-only)
         run_neovim_06_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
@@ -62,27 +62,27 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --neovim-06-only)
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_vim_80_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --vim-only)
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_neovim_06_tests=0
         run_linters=0
         shift
     ;;
     --vim-80-only)
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_neovim_06_tests=0
         run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --vim-82-only)
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_neovim_06_tests=0
         run_vim_80_tests=0
         run_linters=0
@@ -91,14 +91,14 @@ while [ $# -ne 0 ]; do
     --linters-only)
         run_vim_80_tests=0
         run_vim_82_tests=0
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_neovim_06_tests=0
         shift
     ;;
     --fast)
         run_vim_80_tests=0
         run_vim_82_tests=0
-        run_neovim_05_tests=0
+        run_neovim_02_tests=0
         run_neovim_06_tests=1
         shift
     ;;
@@ -113,7 +113,7 @@ while [ $# -ne 0 ]; do
         echo '  -q                Hide output for successful tests'
         echo '  --build-image     Run docker image build only.'
         echo '  --neovim-only     Run tests only for NeoVim'
-        echo '  --neovim-05-only  Run tests only for NeoVim 0.5'
+        echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
         echo '  --neovim-06-only  Run tests only for NeoVim 0.6'
         echo '  --vim-only        Run tests only for Vim'
         echo '  --vim-80-only     Run tests only for Vim 8.0'
@@ -219,7 +219,7 @@ trap cancel_tests INT TERM
 for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neovim\|^vim' ); do
     if ( [[ $vim =~ ^vim-v8.0 ]] && ((run_vim_80_tests)) ) \
     || ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
-    || ( [[ $vim =~ ^neovim-v0.5 ]] && ((run_neovim_05_tests)) ) \
+    || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.6 ]] && ((run_neovim_06_tests)) ); then
         echo "Starting Vim: $vim..."
         file_number=$((file_number+1))

--- a/test/fix/test_ale_fix.vader
+++ b/test/fix/test_ale_fix.vader
@@ -499,7 +499,7 @@ Execute(ALEFix should fix files on the save event):
     \   'nr': -1,
     \   'pattern': '',
     \   'valid': 1,
-    \}], ale#test#GetLoclistWithoutModule()
+    \}], ale#test#GetLoclistWithoutNewerKeys()
   endif
 
 Expect(The buffer should be modified):
@@ -547,7 +547,7 @@ Execute(ALEFix should run the linters with b:ale_lint_on_save = 1):
     \   'nr': -1,
     \   'pattern': '',
     \   'valid': 1,
-    \}], ale#test#GetLoclistWithoutModule()
+    \}], ale#test#GetLoclistWithoutNewerKeys()
   endif
 
 Expect(The buffer should be modified):
@@ -579,7 +579,7 @@ Execute(ALEFix should not fix files on :wq):
   Assert &modified, 'The was not marked as ''modified'''
 
   " We should not run the linter.
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Expect(The buffer should not be modified):
   a
@@ -619,7 +619,7 @@ Execute(ALEFix should still lint with no linters to be applied):
     \   'nr': -1,
     \   'pattern': '',
     \   'valid': 1,
-    \}], ale#test#GetLoclistWithoutModule()
+    \}], ale#test#GetLoclistWithoutNewerKeys()
   endif
 
 Expect(The buffer should be the same):
@@ -655,7 +655,7 @@ Execute(ALEFix should still lint when nothing was fixed on save):
     \   'nr': -1,
     \   'pattern': '',
     \   'valid': 1,
-    \}], ale#test#GetLoclistWithoutModule()
+    \}], ale#test#GetLoclistWithoutNewerKeys()
   endif
 
 Expect(The buffer should be the same):
@@ -679,7 +679,7 @@ Execute(ALEFix should not lint the buffer on save if linting on save is disabled
 
   Assert !filereadable(g:test_filename), 'The file should not have been saved'
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Expect(The buffer should be the same):
   a
@@ -702,7 +702,7 @@ Execute(ALEFix should not lint the buffer on save if linting on save is disabled
 
   Assert !filereadable(g:test_filename), 'The file should not have been saved'
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Expect(The buffer should be the same):
   a

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -5,7 +5,7 @@ Before:
 After:
   " Remove a test file we might open for some tests.
   if &buftype != 'nofile'
-    :q!
+    set nomodified
     set buftype=nofile
   endif
 

--- a/test/linter/test_cspell.vader
+++ b/test/linter/test_cspell.vader
@@ -60,6 +60,8 @@ Execute(Should let users configure a global executable and override local paths)
   \  . ' lint --no-color --no-progress --no-summary -- stdin'
 
 Execute(Additional cspell options should be configurable):
+  call ale#test#SetFilename('../test-files/dummy')
+
   let g:ale_cspell_options = '--foobar'
 
   AssertLinter

--- a/test/linter/test_flake8.vader
+++ b/test/linter/test_flake8.vader
@@ -56,7 +56,7 @@ Execute(The option for disabling changing directories should work):
   \]
 
 Execute(The option for changing directory to project root should work):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_tox/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_tox/namespace/foo/bar.py')
 
   AssertLinterCwd ale#python#FindProjectRootIni(bufnr(''))
   call ale#semver#ResetVersionCache()
@@ -67,7 +67,7 @@ Execute(The option for changing directory to project root should work):
 
 Execute(The option for changing directory to file dir should work):
   let g:ale_python_flake8_change_directory = 'file'
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_tox/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_tox/namespace/foo/bar.py')
 
   AssertLinter 'flake8', [
   \ ale#Escape('flake8') . ' --version',
@@ -98,6 +98,8 @@ Execute(The flake8 command callback should let you set options):
   \]
 
 Execute(You should be able to set a custom executable and it should be escaped):
+  call ale#test#SetFilename('../test-files/dummy')
+
   let g:ale_python_flake8_executable = 'executable with spaces'
 
   AssertLinterCwd ['%s:h', '%s:h']
@@ -110,7 +112,7 @@ Execute(You should be able to set a custom executable and it should be escaped):
   \]
 
 Execute(The flake8 callbacks should detect virtualenv directories):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/with_virtualenv/subdir/foo/bar.py')
 
   let b:executable = ale#path#Simplify(
   \ g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/flake8'
@@ -124,35 +126,35 @@ Execute(The flake8 callbacks should detect virtualenv directories):
   \]
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via Manifest.in):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_manifest/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_manifest/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_manifest'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via setup.cf):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_setup/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_setup/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_setup'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via pytest.ini):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_pytest/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_pytest/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_pytest'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via tox.ini):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_tox/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_tox/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_tox'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for non-namespace package):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/no_virtualenv/subdir/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/no_virtualenv/subdir/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/no_virtualenv/subdir'),
@@ -160,7 +162,7 @@ Execute(The FindProjectRoot should detect the project root directory for non-nam
 
 " Some users currently run flake8 this way, so we should support it.
 Execute(Using `python -m flake8` should be supported for running flake8):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/with_virtualenv/subdir/foo/bar.py')
 
   let g:ale_python_flake8_executable = 'python'
   let g:ale_python_flake8_options = '-m flake8 --some-option'

--- a/test/linter/test_flakehell.vader
+++ b/test/linter/test_flakehell.vader
@@ -48,7 +48,7 @@ Execute(The option for disabling changing directories should work):
   \]
 
 Execute(The option for changing directory to project root should work):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_tox/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_tox/namespace/foo/bar.py')
 
   AssertLinterCwd ale#python#FindProjectRootIni(bufnr(''))
   call ale#semver#ResetVersionCache()
@@ -59,7 +59,7 @@ Execute(The option for changing directory to project root should work):
 
 Execute(The option for changing directory to file dir should work):
   let g:ale_python_flakehell_change_directory = 'file'
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_tox/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_tox/namespace/foo/bar.py')
 
   AssertLinter 'flakehell', [
   \ ale#Escape('flakehell') . ' --version',
@@ -84,6 +84,7 @@ Execute(The flakehell command callback should let you set options):
 
 Execute(You should be able to set a custom executable and it should be escaped):
   let g:ale_python_flakehell_executable = 'executable with spaces'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinterCwd ['%s:h', '%s:h']
   call ale#semver#ResetVersionCache()
@@ -96,7 +97,7 @@ Execute(You should be able to set a custom executable and it should be escaped):
   \]
 
 Execute(The flakehell callbacks should detect virtualenv directories):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/with_virtualenv/subdir/foo/bar.py')
 
   let b:executable = ale#path#Simplify(
   \ g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/flakehell'
@@ -111,35 +112,35 @@ Execute(The flakehell callbacks should detect virtualenv directories):
   \]
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via Manifest.in):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_manifest/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_manifest/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_manifest'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via setup.cf):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_setup/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_setup/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_setup'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via pytest.ini):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_pytest/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_pytest/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_pytest'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for namespace package via tox.ini):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/namespace_package_tox/namespace/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/namespace_package_tox/namespace/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/namespace_package_tox'),
   \ ale#python#FindProjectRoot(bufnr(''))
 
 Execute(The FindProjectRoot should detect the project root directory for non-namespace package):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/no_virtualenv/subdir/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/no_virtualenv/subdir/foo/bar.py')
 
   AssertEqual
   \ ale#path#Simplify(g:dir . '/../test-files/python/no_virtualenv/subdir'),
@@ -147,7 +148,7 @@ Execute(The FindProjectRoot should detect the project root directory for non-nam
 
 " Some users currently run flakehell this way, so we should support it.
 Execute(Using `python -m flakehell` should be supported for running flakehell):
-  silent execute 'file ' . fnameescape(g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py')
+  call ale#test#SetFilename('../test-files/python/with_virtualenv/subdir/foo/bar.py')
 
   let g:ale_python_flakehell_executable = 'python'
   let g:ale_python_flakehell_options = '--some-option'

--- a/test/linter/test_haml_hamllint.vader
+++ b/test/linter/test_haml_hamllint.vader
@@ -38,4 +38,6 @@ Execute(The command should include a .rubocop.yml and a .haml-lint if both are f
 
 Execute(The executable can be overridden):
   let b:ale_haml_hamllint_executable = 'bin/haml-lint'
+  call ale#test#SetFilename('../test-files/dummy')
+
   AssertLinter 'bin/haml-lint', 'bin/haml-lint %t'

--- a/test/linter/test_haskell_hie.vader
+++ b/test/linter/test_haskell_hie.vader
@@ -17,9 +17,9 @@ Execute(The default executable should be correct):
 Execute(The project root should be detected correctly):
   AssertLSPProject g:dir
 
-  call ale#test#SetFilename('hie_paths/file.hs')
+  call ale#test#SetFilename('../test-files/hie_paths/file.hs')
 
-  AssertLSPProject ale#path#Simplify(g:dir . '/hie_paths')
+  AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/hie_paths')
 
 Execute(The executable should be configurable):
   let g:ale_haskell_hie_executable = 'foobar'

--- a/test/linter/test_less_stylelint.vader
+++ b/test/linter/test_less_stylelint.vader
@@ -26,6 +26,7 @@ Execute(The global override should work):
 
 Execute(Extra options should be configurable):
   let b:ale_less_stylelint_options = '--whatever'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'stylelint',
   \ ale#Escape('stylelint') . ' --whatever --stdin-filename %s'

--- a/test/linter/test_ocaml_ols.vader
+++ b/test/linter/test_ocaml_ols.vader
@@ -36,5 +36,6 @@ Execute(The gloabl executable should always be used when use_global is set):
 
 Execute(The executable should be configurable):
   let g:ale_ocaml_ols_executable = 'foobar'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'foobar', ale#Escape('foobar') . ' --stdio'

--- a/test/linter/test_php_langserver.vader
+++ b/test/linter/test_php_langserver.vader
@@ -5,6 +5,8 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
+  call ale#test#SetFilename('../test-files/dummy')
+
   AssertLinter 'php-language-server.php',
   \ 'php ' . ale#Escape('php-language-server.php')
 

--- a/test/linter/test_psalm.vader
+++ b/test/linter/test_psalm.vader
@@ -32,6 +32,7 @@ Execute(Vendor executables should be detected):
 
 Execute(User provided options should be used):
   let g:ale_php_psalm_options = '--my-user-provided-option my-value'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'psalm',
   \ ale#Escape('psalm')

--- a/test/linter/test_pyflakes.vader
+++ b/test/linter/test_pyflakes.vader
@@ -34,6 +34,7 @@ Execute(You should be able to override the pyflakes virtualenv lookup):
 
 Execute(Setting executable to 'pipenv' appends 'run pyflakes'):
   let g:ale_python_pyflakes_executable = 'path/to/pipenv'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'path/to/pipenv',
   \ ale#Escape('path/to/pipenv') . ' run pyflakes %t',

--- a/test/linter/test_pylsp.vader
+++ b/test/linter/test_pylsp.vader
@@ -41,6 +41,7 @@ Execute(You should be able to override the pylsp virtualenv lookup):
 
 Execute(Setting executable to 'pipenv' appends 'run pylsp'):
   let g:ale_python_pylsp_executable = 'path/to/pipenv'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'path/to/pipenv', ale#Escape('path/to/pipenv') . ' run pylsp'
 

--- a/test/linter/test_pyre.vader
+++ b/test/linter/test_pyre.vader
@@ -34,6 +34,7 @@ Execute(You should be able to override the pyre virtualenv lookup):
 
 Execute(Setting executable to 'pipenv' appends 'run pyre'):
   let g:ale_python_pyre_executable = 'path/to/pipenv'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'path/to/pipenv',
   \ ale#Escape('path/to/pipenv') . ' run pyre persistent'

--- a/test/linter/test_reason_ols.vader
+++ b/test/linter/test_reason_ols.vader
@@ -37,5 +37,6 @@ Execute(The gloabl executable should always be used when use_global is set):
 
 Execute(The executable should be configurable):
   let g:ale_reason_ols_executable = 'foobar'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'foobar', ale#Escape('foobar') . ' --stdio'

--- a/test/linter/test_rust_analyzer.vader
+++ b/test/linter/test_rust_analyzer.vader
@@ -8,18 +8,19 @@ Execute(The default executable path should be correct):
   AssertLinter 'rust-analyzer', ale#Escape('rust-analyzer')
 
 Execute(The project root should be detected correctly in cargo projects):
-  AssertLSPProject ''
-
   call ale#test#SetFilename('../test-files/rust/cargo/testfile.rs')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/rust/cargo')
 
 Execute(The project root should be detected correctly in non-cargo projects):
-  AssertLSPProject ''
-
   call ale#test#SetFilename('../test-files/rust/rust-project/testfile.rs')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/rust/rust-project')
+
+Execute(The project root should be empty when no project files can be detected):
+  call ale#test#SetFilename('../test-files/dummy')
+
+  AssertLSPProject ''
 
 Execute(Should accept configuration settings):
   AssertLSPConfig {}

--- a/test/linter/test_rust_rls.vader
+++ b/test/linter/test_rust_rls.vader
@@ -17,12 +17,15 @@ Execute(The toolchain should be ommitted if not given):
 
   AssertLinter 'rls', ale#Escape('rls')
 
-Execute(The project root should be detected correctly):
-  AssertLSPProject ''
-
+Execute(The project root should be detected correctly for cargo projects):
   call ale#test#SetFilename('../test-files/rust/cargo/testfile.rs')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/rust/cargo')
+
+Execute(The project root should be empty when no project files can be detected):
+  call ale#test#SetFilename('../test-files/dummy')
+
+  AssertLSPProject ''
 
 Execute(Should accept configuration settings):
   AssertLSPConfig {}

--- a/test/linter/test_rustc.vader
+++ b/test/linter/test_rustc.vader
@@ -5,9 +5,13 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
+  call ale#test#SetFilename('../test-files/dummy')
+
   AssertLinter 'rustc', 'rustc --error-format=json --emit=mir -o /dev/null -'
 
 Execute(The options should be configurable):
+  call ale#test#SetFilename('../test-files/dummy')
+
   let b:ale_rust_rustc_options = '--foo'
 
   AssertLinter 'rustc', 'rustc --error-format=json --foo -'

--- a/test/linter/test_scss_stylelint.vader
+++ b/test/linter/test_scss_stylelint.vader
@@ -25,6 +25,8 @@ Execute(The global override should work):
   AssertLinter 'foobar', ale#Escape('foobar') . '  --stdin-filename %s'
 
 Execute(Extra options should be configurable):
+  call ale#test#SetFilename('../test-files/dummy')
+
   let b:ale_scss_stylelint_options = '--configFile ''/absolute/path/to/file'''
 
   AssertLinter 'stylelint',

--- a/test/linter/test_sugarss_stylelint.vader
+++ b/test/linter/test_sugarss_stylelint.vader
@@ -25,6 +25,8 @@ Execute(The global override should work):
   AssertLinter 'foobar', ale#Escape('foobar') . '  --syntax=sugarss --stdin-filename %s'
 
 Execute(Extra options should be configurable):
+  call ale#test#SetFilename('../test-files/dummy')
+
   let b:ale_sugarss_stylelint_options = '--configFile ''/absolute/path/to/file'''
 
   AssertLinter 'stylelint',

--- a/test/linter/test_terraform_ls.vader
+++ b/test/linter/test_terraform_ls.vader
@@ -2,10 +2,6 @@ Before:
   call ale#assert#SetUpLinterTest('terraform', 'terraform_ls')
 
 After:
-  if isdirectory(g:dir . '/.terraform')
-    call delete(g:dir . '/.terraform', 'd')
-  endif
-
   unlet! b:ale_terraform_terraform_executable
   unlet! b:ale_terraform_ls_executable
   unlet! b:ale_terraform_ls_options
@@ -40,22 +36,7 @@ Execute(Should set custom options):
   AssertLinter 'terraform-ls',
   \ ale#Escape('terraform-ls') . ' serve --bar'
 
-Execute(Should return current directory if it contains .terraform directory):
-  call mkdir(g:dir . '/.terraform')
-  AssertLSPProject g:dir
-
 Execute(Should return nearest directory with .terraform if found in parent directory):
   call ale#test#SetFilename('../test-files/terraform/main.tf')
 
-  let b:parent_dir = ale#path#Simplify(g:dir . '/..')
-  let b:tf_dir = b:parent_dir . '/.terraform'
-
-  if !isdirectory(b:tf_dir)
-    call mkdir(b:tf_dir)
-  endif
-
-  AssertLSPProject b:parent_dir
-
-  call delete(b:tf_dir, 'd')
-  unlet!b:parent_dir
-  unlet!b:tf_dir
+  AssertLSPProject ale#test#GetFilename('../test-files/terraform')

--- a/test/linter/test_terraform_lsp.vader
+++ b/test/linter/test_terraform_lsp.vader
@@ -2,10 +2,6 @@ Before:
   call ale#assert#SetUpLinterTest('terraform', 'terraform_lsp')
 
 After:
-  if isdirectory(g:dir . '/.terraform')
-    call delete(g:dir . '/.terraform', 'd')
-  endif
-
   unlet! b:ale_terraform_langserver_executable
   unlet! b:ale_terraform_langserver_options
 
@@ -27,22 +23,7 @@ Execute(Should set custom options):
   AssertLinter 'terraform-lsp',
   \ ale#Escape('terraform-lsp') . ' --bar'
 
-Execute(Should return current directory if it contains .terraform directory):
-  call mkdir(g:dir . '/.terraform')
-  AssertLSPProject g:dir
-
 Execute(Should return nearest directory with .terraform if found in parent directory):
   call ale#test#SetFilename('../test-files/terraform/main.tf')
 
-  let b:parent_dir = ale#path#Simplify(g:dir . '/..')
-  let b:tf_dir = b:parent_dir . '/.terraform'
-
-  if !isdirectory(b:tf_dir)
-    call mkdir(b:tf_dir)
-  endif
-
-  AssertLSPProject b:parent_dir
-
-  call delete(b:tf_dir, 'd')
-  unlet!b:parent_dir
-  unlet!b:tf_dir
+  AssertLSPProject ale#test#GetFilename('../test-files/terraform')

--- a/test/linter/test_vim_vimls.vader
+++ b/test/linter/test_vim_vimls.vader
@@ -70,7 +70,8 @@ Execute(should let the global executable to be used):
   AssertLinter 'vim-language-server',
   \ ale#Escape('vim-language-server') . ' --stdio'
 
-Execute(should let the executable to be configured):
+Execute(should allow the executable to be configured):
   let g:ale_vim_vimls_executable = 'foobar'
+  call ale#test#SetFilename('../test-files/dummy')
 
   AssertLinter 'foobar', ale#Escape('foobar') . ' --stdio'

--- a/test/lsp/test_engine_lsp_response_handling.vader
+++ b/test/lsp/test_engine_lsp_response_handling.vader
@@ -108,7 +108,7 @@ Execute(tsserver syntax error responses should be handled correctly):
   \     'pattern': '',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
   " After we get empty syntax errors, we should clear them.
   call ale#lsp_linter#HandleLSPResponse(1, {
@@ -125,7 +125,7 @@ Execute(tsserver syntax error responses should be handled correctly):
   AssertEqual
   \ [
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
   " Syntax errors on the project root should not populate the LocList.
   call ale#lsp_linter#HandleLSPResponse(1, {
@@ -154,7 +154,7 @@ Execute(tsserver syntax error responses should be handled correctly):
   AssertEqual
   \ [
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(tsserver semantic error responses should be handled correctly):
   runtime ale_linters/typescript/tsserver.vim
@@ -222,7 +222,7 @@ Execute(tsserver semantic error responses should be handled correctly):
   \     'pattern': '',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
   " After we get empty syntax errors, we should clear them.
   call ale#lsp_linter#HandleLSPResponse(1, {
@@ -239,7 +239,7 @@ Execute(tsserver semantic error responses should be handled correctly):
   AssertEqual
   \ [
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
   " Semantic errors on the project root should not populate the LocList.
   call ale#lsp_linter#HandleLSPResponse(1, {
@@ -268,7 +268,7 @@ Execute(tsserver semantic error responses should be handled correctly):
   AssertEqual
   \ [
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(tsserver errors should mark tsserver no longer active):
   let b:ale_linters = ['tsserver']
@@ -350,7 +350,7 @@ Execute(LSP diagnostics responses should be handled correctly):
   \     'text': 'Missing JRE 1-8'
   \    }
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(LSP diagnostics responses on project root should not populate loclist):
   let b:ale_linters = ['eclipselsp']
@@ -388,7 +388,7 @@ Execute(LSP diagnostics responses on project root should not populate loclist):
   AssertEqual
   \ [
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(LSP errors should mark linters no longer active):
   let b:ale_linters = ['pylsp']

--- a/test/script/run-vader-tests
+++ b/test/script/run-vader-tests
@@ -37,13 +37,18 @@ done
 vim="$1"
 tests="$2"
 
-# Neovim 0.6+ requires headless argument to load Vader tests.
+echo "$vim"
+
 case $vim in
+    neovim-v0.2*)
+        headless=''
+    ;;
+    # Neovim 0.6+ requires headless argument to load Vader tests.
     neovim*)
-        headless="--headless"
+        headless='--headless'
     ;;
     *)
-        headless=""
+        headless=''
     ;;
 esac
 

--- a/test/script/run-vader-tests
+++ b/test/script/run-vader-tests
@@ -36,6 +36,17 @@ done
 
 vim="$1"
 tests="$2"
+
+# Neovim 0.6+ requires headless argument to load Vader tests.
+case $vim in
+    neovim*)
+        headless="--headless"
+    ;;
+    *)
+        headless=""
+    ;;
+esac
+
 # This file will be used to track if tests ran or not.
 # We can't use a variable, because we need to set a value in a sub-shell.
 run_file="$(mktemp -t tests_ran.XXXXXXXX)"
@@ -132,7 +143,7 @@ while [ "$tries" -lt 5 ]; do
     exit_code=0
     set -o pipefail
     docker run -a stderr -e VADER_OUTPUT_FILE=/dev/stderr "${docker_flags[@]}" \
-        "/vim-build/bin/$vim" -u test/vimrc \
+        "/vim-build/bin/$vim" -u test/vimrc ${headless} \
         "+Vader! $tests" 2>&1 | filter-vader-output | color-vader-output || exit_code=$?
     set +o pipefail
 

--- a/test/smoke_test.vader
+++ b/test/smoke_test.vader
@@ -70,7 +70,7 @@ Execute(Linters should run with the default options):
     call ale#Queue(0, '')
     call ale#test#WaitForJobs(2000)
 
-    let g:results = ale#test#GetLoclistWithoutModule()
+    let g:results = ale#test#GetLoclistWithoutNewerKeys()
 
     if g:results == g:expected_results
       break
@@ -137,7 +137,7 @@ Execute(Linters should run in PowerShell too):
     \   'pattern': '',
     \   'valid': 1,
     \ },
-    \], ale#test#GetLoclistWithoutModule()
+    \], ale#test#GetLoclistWithoutNewerKeys()
   endif
 
 Execute(Previous errors should be removed when linters change):
@@ -171,7 +171,7 @@ Execute(Previous errors should be removed when linters change):
     call ale#Queue(0, '')
     call ale#test#WaitForJobs(2000)
 
-    let g:results = ale#test#GetLoclistWithoutModule()
+    let g:results = ale#test#GetLoclistWithoutNewerKeys()
 
     if g:results == g:expected_results
       break

--- a/test/test_ale_lint_command.vader
+++ b/test/test_ale_lint_command.vader
@@ -68,10 +68,10 @@ Execute(ALELint should run the linters):
       sleep 1ms
     endif
 
-    if ale#test#GetLoclistWithoutModule() == g:expected_loclist
+    if ale#test#GetLoclistWithoutNewerKeys() == g:expected_loclist
       break
     endif
   endfor
 
   " Check the loclist
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()

--- a/test/test_ale_populate_command.vader
+++ b/test/test_ale_populate_command.vader
@@ -79,18 +79,18 @@ Execute(ALEPopulateQuickfix should have results):
       sleep 1ms
     endif
 
-    if ale#test#GetLoclistWithoutModule() == g:expected_loclist
+    if ale#test#GetLoclistWithoutNewerKeys() == g:expected_loclist
       break
     endif
   endfor
 
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
-  AssertEqual [], ale#test#GetQflistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
+  AssertEqual [], ale#test#GetQflistWithoutNewerKeys()
 
   ALEPopulateLocList
   AssertNotEqual 0, get(getloclist(0, {'winid':0}), 'winid', 0)
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
 
   ALEPopulateQuickfix
-  AssertEqual g:expected_loclist, ale#test#GetQflistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetQflistWithoutNewerKeys()

--- a/test/test_ale_toggle.vader
+++ b/test/test_ale_toggle.vader
@@ -120,7 +120,7 @@ Execute(ALEToggle should reset everything and then run again):
   call ale#test#FlushJobs()
 
   " First check that everything is there...
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual [0, [[2, 1000001, 'ALEErrorSign']]], ale#sign#FindCurrentSigns(bufnr('%'))
 
   " Only check the legacy matches if not using the new NeoVIM API.
@@ -138,7 +138,7 @@ Execute(ALEToggle should reset everything and then run again):
 
   " Everything should be cleared.
   Assert !has_key(g:ale_buffer_info, bufnr('')), 'The g:ale_buffer_info Dictionary was not removed'
-  AssertEqual [], ale#test#GetLoclistWithoutModule(), 'The loclist was not cleared'
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys(), 'The loclist was not cleared'
   AssertEqual [0, []], ale#sign#FindCurrentSigns(bufnr('%')), 'The signs were not cleared'
 
   if !g:has_nvim_highlight
@@ -151,7 +151,7 @@ Execute(ALEToggle should reset everything and then run again):
   ALEToggle
   call ale#test#FlushJobs()
 
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual [0, [[2, 1000001, 'ALEErrorSign']]], ale#sign#FindCurrentSigns(bufnr('%'))
 
   if !g:has_nvim_highlight
@@ -211,18 +211,18 @@ Execute(ALEDisable should reset everything and stay disabled):
   ALELint
   call ale#test#FlushJobs()
 
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
 
   ALEDisable
   call ale#test#FlushJobs()
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 0, g:ale_enabled
 
   ALEDisable
   call ale#test#FlushJobs()
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 0, g:ale_enabled
 
 Execute(ALEEnable should enable ALE and lint again):
@@ -231,7 +231,7 @@ Execute(ALEEnable should enable ALE and lint again):
   ALEEnable
   call ale#test#FlushJobs()
 
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 1, g:ale_enabled
 
 Execute(ALEReset should reset everything for a buffer):
@@ -241,7 +241,7 @@ Execute(ALEReset should reset everything for a buffer):
   call ale#test#FlushJobs()
 
   " First check that everything is there...
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual [0, [[2, 1000001, 'ALEErrorSign']]], ale#sign#FindCurrentSigns(bufnr('%'))
 
   if !g:has_nvim_highlight
@@ -258,7 +258,7 @@ Execute(ALEReset should reset everything for a buffer):
 
   " Everything should be cleared.
   Assert !has_key(g:ale_buffer_info, bufnr('')), 'The g:ale_buffer_info Dictionary was not removed'
-  AssertEqual [], ale#test#GetLoclistWithoutModule(), 'The loclist was not cleared'
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys(), 'The loclist was not cleared'
   AssertEqual [0, []], ale#sign#FindCurrentSigns(bufnr('%')), 'The signs were not cleared'
 
   if !g:has_nvim_highlight
@@ -274,7 +274,7 @@ Execute(ALEToggleBuffer should reset everything and then run again):
   call ale#test#FlushJobs()
 
   " First check that everything is there...
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual [0, [[2, 1000001, 'ALEErrorSign']]], ale#sign#FindCurrentSigns(bufnr('%'))
 
   if !g:has_nvim_highlight
@@ -290,7 +290,7 @@ Execute(ALEToggleBuffer should reset everything and then run again):
 
   " Everything should be cleared.
   Assert !has_key(g:ale_buffer_info, bufnr('')), 'The g:ale_buffer_info Dictionary was not removed'
-  AssertEqual [], ale#test#GetLoclistWithoutModule(), 'The loclist was not cleared'
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys(), 'The loclist was not cleared'
   AssertEqual [0, []], ale#sign#FindCurrentSigns(bufnr('%')), 'The signs were not cleared'
 
   if !g:has_nvim_highlight
@@ -301,7 +301,7 @@ Execute(ALEToggleBuffer should reset everything and then run again):
   ALEToggleBuffer
   call ale#test#FlushJobs()
 
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual [0, [[2, 1000001, 'ALEErrorSign']]], ale#sign#FindCurrentSigns(bufnr('%'))
 
   if !g:has_nvim_highlight
@@ -317,12 +317,12 @@ Execute(ALEDisableBuffer should reset everything and stay disabled):
   ALELint
   call ale#test#FlushJobs()
 
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
 
   ALEDisableBuffer
   call ale#test#FlushJobs()
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 0, b:ale_enabled
 
 Execute(ALEEnableBuffer should enable ALE and lint again):
@@ -331,7 +331,7 @@ Execute(ALEEnableBuffer should enable ALE and lint again):
   ALEEnableBuffer
   call ale#test#FlushJobs()
 
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 1, b:ale_enabled
 
 Execute(ALEEnableBuffer should complain when ALE is disabled globally):
@@ -342,7 +342,7 @@ Execute(ALEEnableBuffer should complain when ALE is disabled globally):
     ALEEnableBuffer
   redir END
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 0, b:ale_enabled
   AssertEqual 0, g:ale_enabled
   AssertEqual
@@ -356,7 +356,7 @@ Execute(ALEResetBuffer should reset everything for a buffer):
   call ale#test#FlushJobs()
 
   " First check that everything is there...
-  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutModule()
+  AssertEqual g:expected_loclist, ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual [0, [[2, 1000001, 'ALEErrorSign']]], ale#sign#FindCurrentSigns(bufnr('%'))
 
   if !g:has_nvim_highlight
@@ -373,7 +373,7 @@ Execute(ALEResetBuffer should reset everything for a buffer):
 
   " Everything should be cleared.
   Assert !has_key(g:ale_buffer_info, bufnr('')), 'The g:ale_buffer_info Dictionary was not removed'
-  AssertEqual [], ale#test#GetLoclistWithoutModule(), 'The loclist was not cleared'
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys(), 'The loclist was not cleared'
   AssertEqual [0, []], ale#sign#FindCurrentSigns(bufnr('%')), 'The signs were not cleared'
 
   if !g:has_nvim_highlight

--- a/test/test_code_action_corner_cases.vader
+++ b/test/test_code_action_corner_cases.vader
@@ -34,16 +34,24 @@ Before:
   Save &fileformats
   set fileformats=unix
 
-  let g:file = tempname()
-
   function! TestChanges(contents, changes) abort
-    call writefile(split(a:contents, '\n', 1), g:file, 'bS')
+    let l:file = tempname()
 
-    call ale#code_action#ApplyChanges(g:file, a:changes, {
-    \ 'should_save': 1,
-    \})
+    try
+      call writefile(split(a:contents, '\n', 1), l:file, 'bs')
 
-    return join(readfile(g:file, 'b'), "\n")
+      call ale#code_action#ApplyChanges(l:file, a:changes, {
+      \ 'should_save': 1,
+      \})
+
+      let l:result = join(readfile(l:file, 'b'), "\n")
+    finally
+      if filereadable(l:file)
+        call delete(l:file)
+      endif
+    endtry
+
+    return l:result
   endfunction!
 
   function! MkPos(line, offset) abort
@@ -59,16 +67,6 @@ Before:
   endfunction!
 
 After:
-  if bufnr(g:file) != -1
-    execute ':bp! | :bd! ' . bufnr(g:file)
-  endif
-
-  if filereadable(g:file)
-    call delete(g:file)
-  endif
-
-  unlet! g:file
-
   delfunction TestChanges
   delfunction MkPos
   delfunction MkInsert

--- a/test/test_computed_lint_file_values.vader
+++ b/test/test_computed_lint_file_values.vader
@@ -125,13 +125,13 @@ Execute(lint_file results where the result is eventually computed should be run)
   \     'valid': 1,
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(Linters where lint_file eventually evaluates to 1 shouldn't be run if we don't want to run them):
   call ale#Queue(0, '')
   call ale#test#FlushJobs()
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(Keeping computed lint_file jobs running should work):
   AssertEqual 'testlinter2', ale#linter#Get('foobar')[1].name

--- a/test/test_errors_removed_after_filetype_changed.vader
+++ b/test/test_errors_removed_after_filetype_changed.vader
@@ -58,7 +58,7 @@ Execute(Error should be removed when the filetype changes to something else we c
   call ale#test#FlushJobs()
   sleep 1ms
 
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys())
 
   noautocmd let &filetype = 'foobar2'
 
@@ -67,7 +67,7 @@ Execute(Error should be removed when the filetype changes to something else we c
   sleep 1ms
 
   " We should get some items from the second filetype.
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys())
 
   noautocmd let &filetype = 'xxx'
 
@@ -75,4 +75,4 @@ Execute(Error should be removed when the filetype changes to something else we c
   call ale#test#FlushJobs()
   sleep 1ms
 
-  AssertEqual 0, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 0, len(ale#test#GetLoclistWithoutNewerKeys())

--- a/test/test_lint_file_linters.vader
+++ b/test/test_lint_file_linters.vader
@@ -51,7 +51,7 @@ Before:
   function! GetSimplerLoclist()
     let l:loclist = []
 
-    for l:item in ale#test#GetLoclistWithoutModule()
+    for l:item in ale#test#GetLoclistWithoutNewerKeys()
       call add(l:loclist, {
       \ 'lnum': l:item.lnum,
       \ 'col': l:item.col,

--- a/test/test_lint_on_enter_when_file_changed.vader
+++ b/test/test_lint_on_enter_when_file_changed.vader
@@ -62,7 +62,7 @@ Execute(The file changed event function should lint the current buffer when it h
   \   'nr': -1,
   \   'pattern': '',
   \   'valid': 1,
-  \ }], ale#test#GetLoclistWithoutModule()
+  \ }], ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(The buffer should be checked after entering it after the file has changed):
   let b:ale_file_changed = 1
@@ -81,4 +81,4 @@ Execute(The buffer should be checked after entering it after the file has change
   \   'nr': -1,
   \   'pattern': '',
   \   'valid': 1,
-  \ }], ale#test#GetLoclistWithoutModule()
+  \ }], ale#test#GetLoclistWithoutNewerKeys()

--- a/test/test_list_formatting.vader
+++ b/test/test_list_formatting.vader
@@ -53,7 +53,7 @@ Execute(Formatting with codes should work for the loclist):
   \     'text': 'nocode',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
   call remove(g:loclist, 0)
   call AddItem({'text': 'withcode', 'code': 'E123'})
@@ -73,7 +73,7 @@ Execute(Formatting with codes should work for the loclist):
   \     'text': 'E123: withcode',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(Formatting with codes should work for the quickfix list):
   let g:ale_set_loclist = 0
@@ -96,7 +96,7 @@ Execute(Formatting with codes should work for the quickfix list):
   \     'text': 'nocode',
   \   },
   \ ],
-  \ ale#test#GetQflistWithoutModule()
+  \ ale#test#GetQflistWithoutNewerKeys()
 
   call remove(g:loclist, 0)
   call AddItem({'text': 'withcode', 'code': 'E123'})
@@ -116,7 +116,7 @@ Execute(Formatting with codes should work for the quickfix list):
   \     'text': 'E123: withcode',
   \   },
   \ ],
-  \ ale#test#GetQflistWithoutModule()
+  \ ale#test#GetQflistWithoutNewerKeys()
 
 Execute(Formatting with the linter name should work for the loclist):
   let g:ale_loclist_msg_format = '(%linter%) %s'
@@ -138,7 +138,7 @@ Execute(Formatting with the linter name should work for the loclist):
   \     'text': '(some_linter) whatever',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(Formatting with the linter name should work for the quickfix list):
   let g:ale_loclist_msg_format = '(%linter%) %s'
@@ -162,7 +162,7 @@ Execute(Formatting with the linter name should work for the quickfix list):
   \     'text': '(some_linter) whatever',
   \   },
   \ ],
-  \ ale#test#GetQflistWithoutModule()
+  \ ale#test#GetQflistWithoutNewerKeys()
 
 Execute(The buffer loclist format option should take precedence):
   let g:ale_loclist_msg_format = '(%linter%) %s'
@@ -185,4 +185,4 @@ Execute(The buffer loclist format option should take precedence):
   \     'text': 'FOO whatever',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()

--- a/test/test_list_titles.vader
+++ b/test/test_list_titles.vader
@@ -38,7 +38,7 @@ Execute(The loclist titles should be set appropriately):
   \ 'nr': 0,
   \ 'type': 'E',
   \ 'pattern': '',
-  \}], ale#test#GetLoclistWithoutModule()
+  \}], ale#test#GetLoclistWithoutNewerKeys()
 
   if !has('nvim')
     AssertEqual
@@ -68,7 +68,7 @@ Execute(The quickfix titles should be set appropriately):
   \ 'nr': 0,
   \ 'type': 'E',
   \ 'pattern': '',
-  \}], ale#test#GetQflistWithoutModule()
+  \}], ale#test#GetQflistWithoutNewerKeys()
 
   if !has('nvim')
     AssertEqual

--- a/test/test_no_linting_on_write_quit.vader
+++ b/test/test_no_linting_on_write_quit.vader
@@ -60,7 +60,7 @@ Execute(No linting should be done on :wq or :x):
   call ale#events#SaveEvent(bufnr(''))
   call ale#test#FlushJobs()
 
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys())
 
   " Now try doing it again, but where we run the quit event first.
   call setloclist(0, [])
@@ -68,7 +68,7 @@ Execute(No linting should be done on :wq or :x):
   call ale#events#SaveEvent(bufnr(''))
   call ale#test#FlushJobs()
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(No linting should be for :w after :q fails):
   let g:ale_lint_on_save = 1
@@ -83,7 +83,7 @@ Execute(No linting should be for :w after :q fails):
   call ale#events#SaveEvent(bufnr(''))
   call ale#test#FlushJobs()
 
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys())
 
 Execute(No linting should be done on :wq or :x after fixing files):
   let g:ale_lint_on_save = 1
@@ -92,7 +92,7 @@ Execute(No linting should be done on :wq or :x after fixing files):
   call ale#events#SaveEvent(bufnr(''))
   call ale#test#FlushJobs()
 
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys())
 
   " Now try doing it again, but where we run the quit event first.
   call setloclist(0, [])
@@ -100,7 +100,7 @@ Execute(No linting should be done on :wq or :x after fixing files):
   call ale#events#SaveEvent(bufnr(''))
   call ale#test#FlushJobs()
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(Linting should be done after :q fails and fixing files):
   let g:ale_lint_on_save = 1
@@ -115,4 +115,4 @@ Execute(Linting should be done after :q fails and fixing files):
   call ale#events#SaveEvent(bufnr(''))
   call ale#test#FlushJobs()
 
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule())
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys())

--- a/test/test_other_sources.vader
+++ b/test/test_other_sources.vader
@@ -86,11 +86,11 @@ Execute(ShowResults should show results at any time):
   \     'text': 'xyz',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
   call ale#other_source#ShowResults(bufnr(''), 'other-source-linter', [])
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(A regular lint cycle shouldn't clear results from other sources):
   call ale#other_source#ShowResults(bufnr(''), 'other-source-linter', [
@@ -112,7 +112,7 @@ Execute(A regular lint cycle shouldn't clear results from other sources):
   \     'text': 'xyz',
   \   },
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()
 
 Execute(ALEWantResults should be signaled when a buffer is checked):
   augroup VaderTest

--- a/test/test_results_not_cleared_when_opening_loclist.vader
+++ b/test/test_results_not_cleared_when_opening_loclist.vader
@@ -27,4 +27,4 @@ Execute(The loclist shouldn't be cleared when opening the loclist):
   :lopen
   :q
 
-  AssertEqual 1, len(ale#test#GetLoclistWithoutModule()), 'The loclist was cleared'
+  AssertEqual 1, len(ale#test#GetLoclistWithoutNewerKeys()), 'The loclist was cleared'

--- a/test/test_set_list_timers.vader
+++ b/test/test_set_list_timers.vader
@@ -26,4 +26,4 @@ Execute(The SetLists function should work when run in a timer):
   \ 'nr': 0,
   \ 'type': 'E',
   \ 'pattern': '',
-  \}], ale#test#GetLoclistWithoutModule()
+  \}], ale#test#GetLoclistWithoutNewerKeys()

--- a/test/test_setting_loclist_from_another_buffer.vader
+++ b/test/test_setting_loclist_from_another_buffer.vader
@@ -21,6 +21,6 @@ Execute(Errors should be set in the loclist for the original buffer, not the new
   \ g:ale_buffer_info[(g:original_buffer)].loclist,
   \ )
 
-  AssertEqual [], ale#test#GetLoclistWithoutModule()
+  AssertEqual [], ale#test#GetLoclistWithoutNewerKeys()
   AssertEqual 1, len(getloclist(bufwinid(g:original_buffer)))
   AssertEqual 'foo', getloclist(bufwinid(g:original_buffer))[0].text

--- a/test/test_setting_problems_found_in_previous_buffers.vader
+++ b/test/test_setting_problems_found_in_previous_buffers.vader
@@ -95,4 +95,4 @@ Execute(Problems found from previously opened buffers should be set when linting
   \   {'lnum': 2, 'bufnr': bufnr(''), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'E', 'pattern': '', 'text': 'bar'},
   \   {'lnum': 3, 'bufnr': bufnr(''), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'E', 'pattern': '', 'text': 'baz'},
   \ ],
-  \ ale#test#GetLoclistWithoutModule()
+  \ ale#test#GetLoclistWithoutNewerKeys()


### PR DESCRIPTION
For some unknown reason Vader tests fail when run in Neovim 0.6 but work fine on all previous versions. Specifically if fails when using wildcards in the list of tests.

For context the following command fails to run on 0.6 but works fine when using 0.5 and 0.4.4:

```
docker run -a stderr -e VADER_OUTPUT_FILE=/dev/stderr --rm -v "$PWD:/testplugin" -v "$PWD/test:/home" \
   -w /testplugin denseanalysis/ale:4162227ba361156550caebb5608c91a1 /vim-build/bin/neovim-v0.6.0 \
  -u test/vimrc "+Vader! test/*/*.vader"
```

While this commands runs fine on all versions, including 0.6.  Check the wildcards in the list of vader tests to run:

```
docker run -a stderr -e VADER_OUTPUT_FILE=/dev/stderr --rm -v "$PWD:/testplugin" -v "$PWD/test:/home" \
  -w /testplugin denseanalysis/ale:4162227ba361156550caebb5608c91a1 /vim-build/bin/neovim-v0.6.0 \
  -u test/vimrc "+Vader! test/*.vader"
```

Maybe somthing changed in 0.6 that breaks Vader? This needs more investigation.