### PR TITLE
add support for checkov for linting terraform files

### DIFF
--- a/ale_linters/terraform/checkov.vim
+++ b/ale_linters/terraform/checkov.vim
@@ -1,0 +1,52 @@
+" Author: Thyme-87 <thyme-87@posteo.me>
+" Description: use checkov for providing warnings via ale
+
+call ale#Set('terraform_checkov_executable', 'checkov')
+call ale#Set('terraform_checkov_options', '-o json --quiet')
+
+function! ale_linters#terraform#checkov#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'terraform_checkov_executable')
+endfunction
+
+function! ale_linters#terraform#checkov#GetCommand(buffer) abort
+    return '%e ' . '-f %t ' . ale#Var(a:buffer, 'terraform_checkov_options')
+endfunction
+
+function! ale_linters#terraform#checkov#Handle(buffer, lines) abort
+    let l:output = []
+
+    try
+        let l:results = get(ale#util#FuzzyJSONDecode(a:lines, {}), 'results', [])
+    catch
+        return []
+    endtry
+
+    "if no problems are found by checkov, it will provide some statistics
+    "as the JSON format is different then, l:results will then be an empty list
+    "handle this by returning an empty list in this case
+    if empty(l:results)
+        return []
+    endif
+
+    for l:violation in l:results['failed_checks']
+        call add(l:output, {
+        \   'filename': l:violation['file_path'],
+        \   'lnum': l:violation['file_line_range'][0],
+        \   'end_lnum': l:violation['file_line_range'][1],
+        \   'text': l:violation['check_name'] . ' [' . l:violation['check_id'] . ']',
+        \   'detail': l:violation['check_id'] . ': ' . l:violation['check_name'] . "\n" .
+        \             'For more information, see: '. l:violation['guideline'],
+        \   'type': 'W',
+        \   })
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('terraform', {
+\   'name': 'checkov',
+\   'output_stream': 'stdout',
+\   'executable': function('ale_linters#terraform#checkov#GetExecutable'),
+\   'command': function('ale_linters#terraform#checkov#GetCommand'),
+\   'callback': 'ale_linters#terraform#checkov#Handle',
+\})

--- a/ale_linters/terraform/checkov.vim
+++ b/ale_linters/terraform/checkov.vim
@@ -2,14 +2,14 @@
 " Description: use checkov for providing warnings via ale
 
 call ale#Set('terraform_checkov_executable', 'checkov')
-call ale#Set('terraform_checkov_options', '-o json --quiet')
+call ale#Set('terraform_checkov_options', '')
 
 function! ale_linters#terraform#checkov#GetExecutable(buffer) abort
     return ale#Var(a:buffer, 'terraform_checkov_executable')
 endfunction
 
 function! ale_linters#terraform#checkov#GetCommand(buffer) abort
-    return '%e ' . '-f %t ' . ale#Var(a:buffer, 'terraform_checkov_options')
+    return '%e ' . '-f %t -o json --quiet ' . ale#Var(a:buffer, 'terraform_checkov_options')
 endfunction
 
 function! ale_linters#terraform#checkov#Handle(buffer, lines) abort

--- a/ale_linters/terraform/checkov.vim
+++ b/ale_linters/terraform/checkov.vim
@@ -15,20 +15,9 @@ endfunction
 function! ale_linters#terraform#checkov#Handle(buffer, lines) abort
     let l:output = []
 
-    try
-        let l:results = get(ale#util#FuzzyJSONDecode(a:lines, {}), 'results', [])
-    catch
-        return []
-    endtry
+    let l:results = get(get(ale#util#FuzzyJSONDecode(a:lines, {}), 'results', []), 'failed_checks', [])
 
-    "if no problems are found by checkov, it will provide some statistics
-    "as the JSON format is different then, l:results will then be an empty list
-    "handle this by returning an empty list in this case
-    if empty(l:results)
-        return []
-    endif
-
-    for l:violation in l:results['failed_checks']
+    for l:violation in l:results
         call add(l:output, {
         \   'filename': l:violation['file_path'],
         \   'lnum': l:violation['file_line_range'][0],

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -560,6 +560,7 @@ Notes:
 * Tcl
   * `nagelfar`!!
 * Terraform
+  * `checkov`
   * `terraform`
   * `terraform-fmt-fixer`
   * `terraform-ls`

--- a/doc/ale-terraform.txt
+++ b/doc/ale-terraform.txt
@@ -3,6 +3,25 @@ ALE Terraform Integration                               *ale-terraform-options*
 
 
 ===============================================================================
+checkov                                                 *ale-terraform-checkov*
+
+g:ale_terraform_checkov_executable         *g:ale_terraform_checkov_executable*
+                                           *b:ale_terraform_checkov_executable*
+
+  Type: |String|
+  Default: `'checkov'`
+
+  This variable can be changed to use a different executable for checkov.
+
+
+g:ale_terraform_checkov_options               *g:ale_terraform_checkov_options*
+                                              *b:ale_terraform_checkov_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to set additional options for checkov.
+
+===============================================================================
 terraform-fmt-fixer                                   *ale-terraform-fmt-fixer*
 
 g:ale_terraform_fmt_executable                 *g:ale_terraform_fmt_executable*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3112,6 +3112,7 @@ documented in additional help files.
   tcl.....................................|ale-tcl-options|
     nagelfar..............................|ale-tcl-nagelfar|
   terraform...............................|ale-terraform-options|
+    checkov...............................|ale-terraform-checkov|
     terraform-fmt-fixer...................|ale-terraform-fmt-fixer|
     terraform.............................|ale-terraform-terraform|
     terraform-ls..........................|ale-terraform-terraform-ls|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -569,6 +569,7 @@ formatting.
 * Tcl
   * [nagelfar](http://nagelfar.sourceforge.net) :floppy_disk:
 * Terraform
+  * [checkov](https://github.com/bridgecrewio/checkov)
   * [terraform](https://github.com/hashicorp/terraform)
   * [terraform-fmt-fixer](https://github.com/hashicorp/terraform)
   * [terraform-ls](https://github.com/hashicorp/terraform-ls)

--- a/test/handler/test_checkov_handler.vader
+++ b/test/handler/test_checkov_handler.vader
@@ -1,0 +1,66 @@
+Before:
+  runtime ale_linters/terraform/checkov.vim
+  call ale#test#SetFilename('main.tf')
+
+After:
+  call ale#linter#Reset()
+
+Execute(The JSON output of checkov should be handled correctly):
+  AssertEqual
+  \ [
+  \   {
+  \         'filename': '/main.tf',
+  \         'lnum': 22,
+  \         'end_lnum': 27,
+  \         'text': 'Enable VPC Flow Logs and Intranode Visibility [CKV_GCP_61]',
+  \         'detail': "CKV_GCP_61: Enable VPC Flow Logs and Intranode Visibility\n" .
+  \                   'For more information, see: https://docs.bridgecrew.io/docs/enable-vpc-flow-logs-and-intranode-visibility',
+  \         'type': 'W',
+  \   }
+  \ ],
+  \ ale_linters#terraform#checkov#Handle(bufnr(''), [
+  \'{',
+  \'    "check_type": "terraform",',
+  \'    "results": {',
+  \'        "failed_checks": [',
+  \'            {',
+  \'                "check_id": "CKV_GCP_61",',
+  \'                "bc_check_id": "BC_GCP_KUBERNETES_18",',
+  \'                "check_name": "Enable VPC Flow Logs and Intranode Visibility",',
+  \'                "check_result": {',
+  \'                    "result": "FAILED",',
+  \'                    "evaluated_keys": [',
+  \'                        "enable_intranode_visibility"',
+  \'                    ]',
+  \'                },',
+  \'                "file_path": "/main.tf",',
+  \'                "repo_file_path": "/main.tf",',
+  \'                "file_line_range": [',
+  \'                    22,',
+  \'                    27',
+  \'                ],',
+  \'                "resource": "google_container_cluster.cluster-name",',
+  \'                "evaluations": null,',
+  \'                "check_class": "checkov.terraform.checks.resource.gcp.GKEEnableVPCFlowLogs",',
+  \'                "entity_tags": null,',
+  \'                "resource_address": null,',
+  \'                "guideline": "https://docs.bridgecrew.io/docs/enable-vpc-flow-logs-and-intranode-visibility"',
+  \'            }',
+  \'        ]',
+  \'    }',
+  \'}'
+  \ ])
+
+Execute(Handle output for no findings correctly):
+  AssertEqual
+  \ [],
+  \ ale_linters#terraform#checkov#Handle(bufnr(''), [
+  \'{',
+  \'    "passed": 0,',
+  \'    "failed": 0,',
+  \'    "skipped": 0,',
+  \'    "parsing_errors": 0,',
+  \'    "resource_count": 0,',
+  \'    "checkov_version": "2.0.632"',
+  \'}'
+  \])

--- a/test/linter/test_checkov.vader
+++ b/test/linter/test_checkov.vader
@@ -1,0 +1,14 @@
+Before:
+  call ale#assert#SetUpLinterTest('terraform', 'checkov')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be direct):
+  AssertLinter 'checkov',
+  \ ale#Escape('checkov') . ' -f %t -o json --quiet'
+
+Execute(It should be possible to override the default command):
+  let b:ale_terraform_checkov_executable = '/bin/other/checkov'
+  AssertLinter '/bin/other/checkov',
+  \ ale#Escape('/bin/other/checkov') . ' -f %t -o json --quiet'

--- a/test/linter/test_checkov.vader
+++ b/test/linter/test_checkov.vader
@@ -6,9 +6,9 @@ After:
 
 Execute(The default command should be direct):
   AssertLinter 'checkov',
-  \ ale#Escape('checkov') . ' -f %t -o json --quiet'
+  \ ale#Escape('checkov') . ' -f %t -o json --quiet '
 
 Execute(It should be possible to override the default command):
   let b:ale_terraform_checkov_executable = '/bin/other/checkov'
   AssertLinter '/bin/other/checkov',
-  \ ale#Escape('/bin/other/checkov') . ' -f %t -o json --quiet'
+  \ ale#Escape('/bin/other/checkov') . ' -f %t -o json --quiet '


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Display rule violations from [checkov](https://github.com/bridgecrewio/checkov) via `ale`. Motivated by [checkov2vim](https://github.com/mhristof/checkov2vim) which I did not manage to set up correctly on my machine.

I provided the most basic tests (derived from the tests for the `terraform` linter and `ansible_lint`) and I do hope that this is sufficient.

Please let me know if I missed anything.