### PR TITLE
Fix 3997 - add language option to uncrustify fixer

### DIFF
--- a/autoload/ale/fixers/uncrustify.vim
+++ b/autoload/ale/fixers/uncrustify.vim
@@ -4,13 +4,30 @@
 call ale#Set('c_uncrustify_executable', 'uncrustify')
 call ale#Set('c_uncrustify_options', '')
 
+let s:languages = {
+\   'c': 'C',
+\   'cpp': 'CPP',
+\   'cs': 'CS',
+\   'objc': 'OC',
+\   'objcpp': 'OC+',
+\   'd': 'D',
+\   'java': 'JAVA',
+\   'vala': 'VALA',
+\   'p': 'PAWN',
+\}
+
+function! ale#fixers#uncrustify#Language(buffer) abort
+    return get(s:languages, &filetype, 'C')
+endfunction
+
 function! ale#fixers#uncrustify#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'c_uncrustify_executable')
     let l:options = ale#Var(a:buffer, 'c_uncrustify_options')
 
     return {
     \   'command': ale#Escape(l:executable)
-    \       . ' --no-backup'
-    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' --no-backup '
+    \       . '-l' . ale#Pad(ale#fixers#uncrustify#Language(a:buffer))
+    \       . ale#Pad(l:options)
     \}
 endfunction

--- a/test/fixers/test_uncrustify_fixer_callback.vader
+++ b/test/fixers/test_uncrustify_fixer_callback.vader
@@ -17,7 +17,7 @@ Execute(The clang-format callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_c_uncrustify_executable)
-  \       . ' --no-backup'
+  \       . ' --no-backup -l C'
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))
 
@@ -28,6 +28,81 @@ Execute(The uncrustify callback should include any additional options):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_c_uncrustify_executable)
-  \     . ' --no-backup --some-option',
+  \     . ' --no-backup -l C --some-option',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+Execute(The uncrustify callback should set proper language):
+  unlet b:ale_c_uncrustify_options
+
+  set filetype=c
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l C',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=cpp
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l CPP',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=cs
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l CS',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=objc
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l OC',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=objcpp
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l OC+',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=d
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l D',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=java
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l JAVA',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=vala
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l VALA',
+  \ },
+  \ ale#fixers#uncrustify#Fix(bufnr(''))
+
+  set filetype=p
+  AssertEqual
+  \ {
+  \   'command': ale#Escape(g:ale_c_uncrustify_executable)
+  \     . ' --no-backup -l PAWN',
   \ },
   \ ale#fixers#uncrustify#Fix(bufnr(''))


### PR DESCRIPTION
Add -l option to uncrustify fixer based on buffer filetype.

Closes #3997