### PR TITLE
Fix 4025 - Allow to configure texlab LSP settings

### DIFF
--- a/ale_linters/tex/texlab.vim
+++ b/ale_linters/tex/texlab.vim
@@ -4,6 +4,7 @@
 
 call ale#Set('tex_texlab_executable', 'texlab')
 call ale#Set('tex_texlab_options', '')
+call ale#Set('tex_texlab_config', {})
 
 function! ale_linters#tex#texlab#GetProjectRoot(buffer) abort
     let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
@@ -21,4 +22,5 @@ call ale#linter#Define('tex', {
 \   'executable': {b -> ale#Var(b, 'tex_texlab_executable')},
 \   'command': function('ale_linters#tex#texlab#GetCommand'),
 \   'project_root': function('ale_linters#tex#texlab#GetProjectRoot'),
+\   'lsp_config': {b -> ale#Var(b, 'tex_texlab_config')},
 \})

--- a/doc/ale-tex.txt
+++ b/doc/ale-tex.txt
@@ -77,7 +77,7 @@ g:ale_tex_texlab_options                             *g:ale_tex_texlab_options*
 
 g:ale_tex_texlab_config                               *g:ale_tex_texlab_config*
                                                       *b:ale_tex_texlab_config*
-  Type: |String|
+  Type: |Dictionary|
   Default: `{}`
 
   Dictionary containing LSP configuration settings used to initialize texlab

--- a/doc/ale-tex.txt
+++ b/doc/ale-tex.txt
@@ -73,8 +73,23 @@ g:ale_tex_texlab_options                             *g:ale_tex_texlab_options*
   Type: |String|
   Default: `''`
 
-  This variable can be changed to modify flags given to texlab.
+  This variable can be changed to modify flags given to texlab command.
 
+g:ale_tex_texlab_config                               *g:ale_tex_texlab_config*
+                                                      *b:ale_tex_texlab_config*
+  Type: |String|
+  Default: `{}`
+
+  Dictionary containing LSP configuration settings used to initialize texlab
+  language server. Refer to texlab documentation for possible settings:
+
+    https://github.com/latex-lsp/texlab/blob/master/docs/options.md
+
+  For example to set build onSave initialization setting:
+
+>
+  let g:ale_tex_texlab_config = {"build":{"onSave":v:true}}
+<
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/test/linter/test_texlab.vader
+++ b/test/linter/test_texlab.vader
@@ -28,3 +28,8 @@ Execute(The options should be configurable):
   let b:ale_tex_texlab_options = '-v'
 
   AssertLinter 'texlab', ale#Escape('texlab') . ' ' . b:ale_tex_texlab_options
+
+Execute(Should accpet configuration settings):
+  AssertLSPConfig {}
+  let b:ale_tex_texlab_config = {'build':{'onSave':v:true}}
+  AssertLSPConfig {'build':{'onSave':v:true}}


### PR DESCRIPTION
This PR adds a new configuration `g:ale_tex_texlab_config` that allows to pass initialization settings to texlab LSP.

Closes #4025 