### PR TITLE
Add eclipselsp jdt:// support for textDocument/definition

### DIFF
--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -192,4 +192,9 @@ call ale#linter#Define('java', {
 \   'command': function('ale_linters#java#eclipselsp#RunWithVersionCheck'),
 \   'language': 'java',
 \   'project_root': function('ale#java#FindProjectRoot'),
+\   'initialization_options': {
+\     'extendedClientCapabilities': {
+\       'classFileContentsSupport': v:true
+\     }
+\   }
 \})

--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -222,7 +222,7 @@ function! s:OpenJDTLink(root, filename, line, column, options, result) abort
     " disable autocmd when opening buffer
     autocmd! ale_eclipselsp_jdt
     call ale#util#Open(a:filename, a:line, a:column, a:options)
-    autocmd ale_eclipselsp_jdt BufNewFile,BufReadPre jdt://** call ale_linters#java#eclipselsp#OpenJDTLink(expand('<amatch>'))
+    autocmd ale_eclipselsp_jdt BufNewFile,BufReadPre jdt://** call ale_linters#java#eclipselsp#ReadJDTLink(expand('<amatch>'))
 
     if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
         return

--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -185,11 +185,6 @@ function! ale_linters#java#eclipselsp#RunWithVersionCheck(buffer) abort
     \)
 endfunction
 
-augroup ale_eclipselsp_jdt
-    au!
-    au BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
-augroup END
-
 call ale#linter#Define('java', {
 \   'name': 'eclipselsp',
 \   'lsp': 'stdio',

--- a/ale_linters/java/eclipselsp.vim
+++ b/ale_linters/java/eclipselsp.vim
@@ -192,13 +192,6 @@ call ale#linter#Define('java', {
 \   'command': function('ale_linters#java#eclipselsp#RunWithVersionCheck'),
 \   'language': 'java',
 \   'project_root': function('ale#java#FindProjectRoot'),
-\   'uri_handlers': {
-\       'jdt': {
-\           'OpenURILink': function('ale#util#OpenJDTLink'),
-\           'PathFromURI': function('ale#util#JDTToPath'),
-\           'PathToURI': function('ale#util#PathToJDT')
-\       }
-\   },
 \   'initialization_options': {
 \     'extendedClientCapabilities': {
 \       'classFileContentsSupport': v:true

--- a/autoload/ale/code_action.vim
+++ b/autoload/ale/code_action.vim
@@ -300,7 +300,7 @@ function! ale#code_action#BuildChangesList(changes_map) abort
         endfor
 
         call add(l:changes, {
-        \   'fileName': ale#path#FromURI(l:file_name),
+        \   'fileName': ale#util#ToResource(l:file_name),
         \   'textChanges': l:text_changes,
         \})
     endfor

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -94,6 +94,10 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
                     break
                 endif
 
+                if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
+                    break
+                endif
+
                 " Display java file from jar library as part of current project.
                 set filetype=java
 

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -109,7 +109,7 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
                 \   bufnr(''),
                 \   'eclipselsp',
                 \   [0, 'java/classFileContents', {'uri': l:filename}],
-                \       function('s:handle_class_file_contents'))
+                \       function('s:HandleClassFileContents'))
 
                 while s:cb_status isnot# 'complete'
                     sleep 10m

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -109,7 +109,7 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
                 call ale#lsp_linter#SendRequest(
                 \   bufnr(''),
                 \   'eclipselsp',
-                \   [0, 'java/classFileContents', {'uri': l:filename}],
+                \   [0, 'java/classFileContents', {'uri': ale#path#ToURI(l:filename)}],
                 \       function('s:OpenJdtLink', [a:conn_id, l:filename, l:line, l:column, l:options]))
             else
                 call ale#util#Open(l:filename, l:line, l:column, l:options)

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -116,8 +116,11 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
                 endwhile
 
                 let l:contents = s:result['result']
+
                 call setline(1, split(l:contents, '\n'))
-                call ale#util#Open(l:filename, l:line, l:column, l:options)
+                call cursor(l:line, l:column)
+                normal! zz
+
                 setlocal buftype=nofile nomod readonly
             endif
 

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -80,12 +80,12 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
 
             call ale#definition#UpdateTagStack()
 
-            let l:filename = ale#path#FromURI(l:uri)
-            let l:uri_handler = ale#util#GetURIHandler(l:filename)
-            if l:uri_handler isnot# v:null
-                call l:uri_handler.OpenURILink(l:filename, l:line, l:column, l:options, a:conn_id)
-            else
+            let l:uri_handler = ale#uri#GetURIHandler(l:uri)
+            if l:uri_handler is# v:null
+                let l:filename = ale#path#FromFileURI(l:uri)
                 call ale#util#Open(l:filename, l:line, l:column, l:options)
+            else
+                call l:uri_handler.OpenURILink(l:uri, l:line, l:column, l:options, a:conn_id)
             endif
 
             break

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -80,24 +80,11 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
 
             call ale#definition#UpdateTagStack()
 
-            let l:root = a:conn_id[stridx(a:conn_id, ':')+1:]
-            let found_uri_handler = v:false
-            for l:linter in ale#linter#Get(&filetype)
-                if !empty(l:linter.lsp)
-                    if exists('l:linter.uri_handlers') && !empty(l:linter.uri_handlers)
-                        for l:scheme in keys(l:linter.uri_handlers)
-                            if l:uri =~# '^'.l:scheme.'://'
-                                call l:linter.uri_handlers[scheme](l:root, l:line, l:column, l:options, l:uri)
-                                let l:found_uri_handler = v:true
-                                break
-                            endif
-                        endfor
-                    endif
-                endif
-            endfor
-
-            if !found_uri_handler
-                let l:filename = ale#path#FromURI(l:uri)
+            let l:filename = ale#path#FromURI(l:uri)
+            let l:uri_handler = ale#util#GetURIHandler(l:filename)
+            if l:uri_handler isnot# v:null
+                call l:uri_handler.OpenURILink(l:filename, l:line, l:column, l:options, a:conn_id)
+            else
                 call ale#util#Open(l:filename, l:line, l:column, l:options)
             endif
 

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -79,53 +79,40 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
             endif
 
             call ale#definition#UpdateTagStack()
-            call ale#util#Open(l:filename, l:line, l:column, l:options)
 
             if l:filename[:5] is? 'jdt://'
                 let l:found = v:false
-
                 for l:linter in ale#linter#Get('java')
                     if l:linter.name is# 'eclipselsp'
                         let l:found = v:true
                     endif
                 endfor
-
                 if ! l:found
                     break
                 endif
 
-                if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
-                    break
-                endif
-
-                " Display java file from jar library as part of current project.
-                set filetype=java
-
-                let b:ale_lsp_root = a:conn_id[stridx(a:conn_id, ':')+1:]
-                let s:cb_status = 'pending'
-
-                function! s:HandleClassFileContents(result) abort
-                    let s:cb_status = 'complete'
-                    let s:result = a:result
+                function! s:OpenJdtLink(conn_id, uri, line, column, options, result) abort
+                    " Display java file from jar library as part of current project.
+                    let l:contents = a:result['result']
+                    call ale#util#Open(a:uri, a:line, a:column, a:options)
+                    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
+                        return
+                    endif
+                    let b:ale_lsp_root = a:conn_id[stridx(a:conn_id, ':')+1:]
+                    set filetype=java
+                    call setline(1, split(l:contents, '\n'))
+                    call cursor(a:line, a:column)
+                    normal! zz
+                    setlocal buftype=nofile nomod readonly
                 endfunction
 
                 call ale#lsp_linter#SendRequest(
                 \   bufnr(''),
                 \   'eclipselsp',
                 \   [0, 'java/classFileContents', {'uri': l:filename}],
-                \       function('s:HandleClassFileContents'))
-
-                while s:cb_status isnot# 'complete'
-                    sleep 10m
-                endwhile
-
-                let l:contents = s:result['result']
-
-                call setline(1, split(l:contents, '\n'))
-                call cursor(l:line, l:column)
-                normal! zz
-
-                setlocal buftype=nofile nomod readonly
+                \       function('s:OpenJdtLink', [a:conn_id, l:filename, l:line, l:column, l:options]))
+            else
+                call ale#util#Open(l:filename, l:line, l:column, l:options)
             endif
 
             break

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -81,6 +81,7 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
             call ale#definition#UpdateTagStack()
 
             let l:uri_handler = ale#uri#GetURIHandler(l:uri)
+
             if l:uri_handler is# v:null
                 let l:filename = ale#path#FromFileURI(l:uri)
                 call ale#util#Open(l:filename, l:line, l:column, l:options)

--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -160,6 +160,6 @@ function! ale#events#Init() abort
     augroup AleURISchemes
         autocmd!
 
-        autocmd BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
+        autocmd BufNewFile,BufReadPre jdt://** call ale#uri#jdt#ReadJDTLink(expand('<amatch>'))
     augroup END
 endfunction

--- a/autoload/ale/events.vim
+++ b/autoload/ale/events.vim
@@ -156,4 +156,10 @@ function! ale#events#Init() abort
             endif
         endif
     augroup END
+
+    augroup AleURISchemes
+        autocmd!
+
+        autocmd BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
+    augroup END
 endfunction

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -217,15 +217,6 @@ function! ale#linter#PreProcess(filetype, linter) abort
 
             let l:obj.lsp_config = a:linter.lsp_config
         endif
-
-        if has_key(a:linter, 'uri_handlers')
-            let l:obj.uri_handlers = a:linter.uri_handlers
-
-            if type(l:obj.uri_handlers) isnot v:t_dict
-            \&& type(l:obj.uri_handlers) isnot v:t_func
-                throw '`uri_handlers` must be a Dictionary or Function if defined'
-            endif
-        endif
     endif
 
     let l:obj.output_stream = get(a:linter, 'output_stream', 'stdout')

--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -217,6 +217,15 @@ function! ale#linter#PreProcess(filetype, linter) abort
 
             let l:obj.lsp_config = a:linter.lsp_config
         endif
+
+        if has_key(a:linter, 'uri_handlers')
+            let l:obj.uri_handlers = a:linter.uri_handlers
+
+            if type(l:obj.uri_handlers) isnot v:t_dict
+            \&& type(l:obj.uri_handlers) isnot v:t_func
+                throw '`uri_handlers` must be a Dictionary or Function if defined'
+            endif
+        endif
     endif
 
     let l:obj.output_stream = get(a:linter, 'output_stream', 'stdout')

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -35,7 +35,7 @@ function! ale#lsp#message#Initialize(root_path, options, capabilities) abort
     \   'rootPath': a:root_path,
     \   'capabilities': a:capabilities,
     \   'initializationOptions': a:options,
-    \   'rootUri': ale#path#ToURI(a:root_path),
+    \   'rootUri': ale#util#ToURI(a:root_path),
     \}]
 endfunction
 
@@ -56,7 +56,7 @@ function! ale#lsp#message#DidOpen(buffer, language_id) abort
 
     return [1, 'textDocument/didOpen', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \       'languageId': a:language_id,
     \       'version': ale#lsp#message#GetNextVersionID(),
     \       'text': join(l:lines, "\n") . "\n",
@@ -70,7 +70,7 @@ function! ale#lsp#message#DidChange(buffer) abort
     " For changes, we simply send the full text of the document to the server.
     return [1, 'textDocument/didChange', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \       'version': ale#lsp#message#GetNextVersionID(),
     \   },
     \   'contentChanges': [{'text': join(l:lines, "\n") . "\n"}]
@@ -80,7 +80,7 @@ endfunction
 function! ale#lsp#message#DidSave(buffer, includeText) abort
     let l:response = [1, 'textDocument/didSave', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \}]
 
@@ -95,7 +95,7 @@ endfunction
 function! ale#lsp#message#DidClose(buffer) abort
     return [1, 'textDocument/didClose', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \}]
 endfunction
@@ -106,7 +106,7 @@ let s:COMPLETION_TRIGGER_CHARACTER = 2
 function! ale#lsp#message#Completion(buffer, line, column, trigger_character) abort
     let l:message = [0, 'textDocument/completion', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
@@ -124,7 +124,7 @@ endfunction
 function! ale#lsp#message#Definition(buffer, line, column) abort
     return [0, 'textDocument/definition', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
@@ -133,7 +133,7 @@ endfunction
 function! ale#lsp#message#TypeDefinition(buffer, line, column) abort
     return [0, 'textDocument/typeDefinition', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
@@ -142,7 +142,7 @@ endfunction
 function! ale#lsp#message#References(buffer, line, column) abort
     return [0, 'textDocument/references', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \   'context': {'includeDeclaration': v:false},
@@ -158,7 +158,7 @@ endfunction
 function! ale#lsp#message#Hover(buffer, line, column) abort
     return [0, 'textDocument/hover', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \}]
@@ -173,7 +173,7 @@ endfunction
 function! ale#lsp#message#Rename(buffer, line, column, new_name) abort
     return [0, 'textDocument/rename', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'position': {'line': a:line - 1, 'character': a:column - 1},
     \   'newName': a:new_name,
@@ -183,7 +183,7 @@ endfunction
 function! ale#lsp#message#CodeAction(buffer, line, column, end_line, end_column, diagnostics) abort
     return [0, 'textDocument/codeAction', {
     \   'textDocument': {
-    \       'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
     \   },
     \   'range': {
     \       'start': {'line': a:line - 1, 'character': a:column - 1},

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -59,7 +59,7 @@ function! ale#lsp#response#ReadDiagnostics(response) abort
         \ && l:diagnostic.relatedInformation isnot v:null
             let l:related = deepcopy(l:diagnostic.relatedInformation)
             call map(l:related, {key, val ->
-            \   ale#path#FromURI(val.location.uri) .
+            \   ale#util#ToResource(val.location.uri) .
             \   ':' . (val.location.range.start.line + 1) .
             \   ':' . (val.location.range.start.character + 1) .
             \   ":\n\t" . val.message

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -8,12 +8,24 @@ if !has_key(s:, 'lsp_linter_map')
     let s:lsp_linter_map = {}
 endif
 
-function! ale#lsp_linter#GetLinterMap() abort
+" A Dictionary to track one-shot handlers for custom LSP requests
+let s:custom_handlers_map = get(s:, 'custom_handlers_map', {})
+
+" Clear LSP linter data for the linting engine.
+function! ale#lsp_linter#ClearLSPData() abort
+    let s:lsp_linter_map = {}
+    let s:custom_handlers_map = {}
+endfunction
+
+" Only for internal use.
+function! ale#lsp_linter#GetLSPLinterMap() abort
     return s:lsp_linter_map
 endfunction
 
-" A Dictionary to track one-shot handlers for custom LSP requests
-let s:custom_handlers_map = get(s:, 'custom_handlers_map', {})
+" Just for tests.
+function! ale#lsp_linter#SetLSPLinterMap(replacement_map) abort
+    let s:lsp_linter_map = a:replacement_map
+endfunction
 
 " Check if diagnostics for a particular linter should be ignored.
 function! s:ShouldIgnore(buffer, linter_name) abort
@@ -479,17 +491,6 @@ endfunction
 
 function! ale#lsp_linter#CheckWithLSP(buffer, linter) abort
     return ale#lsp_linter#StartLSP(a:buffer, a:linter, function('s:CheckWithLSP'))
-endfunction
-
-" Clear LSP linter data for the linting engine.
-function! ale#lsp_linter#ClearLSPData() abort
-    let s:lsp_linter_map = {}
-    let s:custom_handlers_map = {}
-endfunction
-
-" Just for tests.
-function! ale#lsp_linter#SetLSPLinterMap(replacement_map) abort
-    let s:lsp_linter_map = a:replacement_map
 endfunction
 
 function! s:HandleLSPResponseToCustomRequests(conn_id, response) abort

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -8,7 +8,7 @@ if !has_key(s:, 'lsp_linter_map')
     let s:lsp_linter_map = {}
 endif
 
-function! ale#lsp_linter#GetLinterMap()
+function! ale#lsp_linter#GetLinterMap() abort
     return s:lsp_linter_map
 endfunction
 

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -49,7 +49,7 @@ endfunction
 
 function! s:HandleLSPDiagnostics(conn_id, response) abort
     let l:linter_name = s:lsp_linter_map[a:conn_id]
-    let l:filename = ale#path#FromURI(a:response.params.uri)
+    let l:filename = ale#util#ToResource(a:response.params.uri)
     let l:escaped_name = escape(
     \   fnameescape(l:filename),
     \   has('win32') ? '^' : '^,}]'

--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -8,6 +8,10 @@ if !has_key(s:, 'lsp_linter_map')
     let s:lsp_linter_map = {}
 endif
 
+function! ale#lsp_linter#GetLinterMap()
+    return s:lsp_linter_map
+endfunction
+
 " A Dictionary to track one-shot handlers for custom LSP requests
 let s:custom_handlers_map = get(s:, 'custom_handlers_map', {})
 

--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -219,6 +219,10 @@ endfunction
 " relatives paths will not be prefixed with the protocol.
 " For Windows paths, the `:` in C:\ etc. will not be percent-encoded.
 function! ale#path#ToURI(path) abort
+    if a:path[:5] is? 'jdt://'
+        return a:path
+    endif
+
     let l:has_drive_letter = a:path[1:2] is# ':\'
 
     return substitute(
@@ -232,6 +236,14 @@ function! ale#path#ToURI(path) abort
 endfunction
 
 function! ale#path#FromURI(uri) abort
+    if a:uri[:5] is? 'jdt://'
+        let l:uri_parts = split(a:uri, '=')
+        let l:uri_parts[1] = substitute(l:uri_parts[1], '/', '%2F', 'g')
+        let l:uri = l:uri_parts[0] . '=' . l:uri_parts[1]
+
+        return l:uri
+    endif
+
     if a:uri[:6] is? 'file://'
         let l:encoded_path = a:uri[7:]
     elseif a:uri[:4] is? 'file:'

--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -219,12 +219,6 @@ endfunction
 " relatives paths will not be prefixed with the protocol.
 " For Windows paths, the `:` in C:\ etc. will not be percent-encoded.
 function! ale#path#ToURI(path) abort
-    if a:path[:5] is? 'jdt://'
-        let l:path = substitute(a:path, '%3f', '?', 'g')
-
-        return l:path
-    endif
-
     let l:has_drive_letter = a:path[1:2] is# ':\'
 
     return substitute(
@@ -238,23 +232,6 @@ function! ale#path#ToURI(path) abort
 endfunction
 
 function! ale#path#FromURI(uri) abort
-    if a:uri[:5] is? 'jdt://'
-        let l:uri = ale#uri#Decode(a:uri)
-
-        let l:scheme = a:uri[:5]
-        let l:auth_path = a:uri[6:stridx(a:uri, '?')-1]
-        let l:query = a:uri[stridx(a:uri, '?')+1:]
-
-        " do not allow ["*:<>?|] in authority and path sections
-        let l:auth_path = substitute(l:auth_path, '\(["*:<>?|]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
-        " do not allow ["*:<>|?\/] in query section
-        let l:query = substitute(l:query, '\(["*:<>?|\\/]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
-
-        let l:uri = l:scheme . l:auth_path . '%3f' . l:query
-
-        return l:uri
-    endif
-
     if a:uri[:6] is? 'file://'
         let l:encoded_path = a:uri[7:]
     elseif a:uri[:4] is? 'file:'

--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -219,6 +219,12 @@ endfunction
 " relatives paths will not be prefixed with the protocol.
 " For Windows paths, the `:` in C:\ etc. will not be percent-encoded.
 function! ale#path#ToURI(path) abort
+    let l:uri_handler = ale#util#GetURIHandler(a:path)
+    if l:uri_handler isnot# v:null
+        let l:uri = l:uri_handler.PathToURI(a:path)
+        return l:uri
+    endif
+
     let l:has_drive_letter = a:path[1:2] is# ':\'
 
     return substitute(
@@ -232,6 +238,12 @@ function! ale#path#ToURI(path) abort
 endfunction
 
 function! ale#path#FromURI(uri) abort
+    let l:uri_handler = ale#util#GetURIHandler(a:uri)
+    if l:uri_handler isnot# v:null
+        let l:path = l:uri_handler.PathFromURI(a:uri)
+        return l:path
+    endif
+
     if a:uri[:6] is? 'file://'
         let l:encoded_path = a:uri[7:]
     elseif a:uri[:4] is? 'file:'

--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -218,13 +218,7 @@ endfunction
 " Convert a filesystem path to a file:// URI
 " relatives paths will not be prefixed with the protocol.
 " For Windows paths, the `:` in C:\ etc. will not be percent-encoded.
-function! ale#path#ToURI(path) abort
-    let l:uri_handler = ale#util#GetURIHandler(a:path)
-    if l:uri_handler isnot# v:null
-        let l:uri = l:uri_handler.PathToURI(a:path)
-        return l:uri
-    endif
-
+function! ale#path#ToFileURI(path) abort
     let l:has_drive_letter = a:path[1:2] is# ':\'
 
     return substitute(
@@ -237,13 +231,7 @@ function! ale#path#ToURI(path) abort
     \)
 endfunction
 
-function! ale#path#FromURI(uri) abort
-    let l:uri_handler = ale#util#GetURIHandler(a:uri)
-    if l:uri_handler isnot# v:null
-        let l:path = l:uri_handler.PathFromURI(a:uri)
-        return l:path
-    endif
-
+function! ale#path#FromFileURI(uri) abort
     if a:uri[:6] is? 'file://'
         let l:encoded_path = a:uri[7:]
     elseif a:uri[:4] is? 'file:'

--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -245,7 +245,7 @@ function! ale#path#FromURI(uri) abort
         let l:auth_path = a:uri[6:stridx(a:uri, '?')-1]
         let l:query = a:uri[stridx(a:uri, '?')+1:]
 
-        " not allow ["*:<>?|] in authority and path sections
+        " do not allow ["*:<>?|] in authority and path sections
         let l:auth_path = substitute(l:auth_path, '\(["*:<>?|]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
         " do not allow ["*:<>|?\/] in query section
         let l:query = substitute(l:query, '\(["*:<>?|\\/]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -54,7 +54,7 @@ function! ale#references#HandleLSPResponse(conn_id, response) abort
         if type(l:result) is v:t_list
             for l:response_item in l:result
                 call add(l:item_list, {
-                \ 'filename': ale#path#FromURI(l:response_item.uri),
+                \ 'filename': ale#util#ToResource(l:response_item.uri),
                 \ 'line': l:response_item.range.start.line + 1,
                 \ 'column': l:response_item.range.start.character + 1,
                 \})

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -66,7 +66,7 @@ endfunction
 function! ale#references#FormatLSPResponseItem(response_item, options) abort
     if get(a:options, 'open_in') is# 'quickfix'
         return {
-        \ 'filename': ale#util#ToResource(l:response_item.uri),
+        \ 'filename': ale#util#ToResource(a:response_item.uri),
         \ 'lnum': a:response_item.range.start.line + 1,
         \ 'col': a:response_item.range.start.character + 1,
         \}

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -72,7 +72,7 @@ function! ale#references#FormatLSPResponseItem(response_item, options) abort
         \}
     else
         return {
-        \ 'filename': ale#util#ToResource(l:response_item.uri),
+        \ 'filename': ale#util#ToResource(a:response_item.uri),
         \ 'line': a:response_item.range.start.line + 1,
         \ 'column': a:response_item.range.start.character + 1,
         \}

--- a/autoload/ale/symbol.vim
+++ b/autoload/ale/symbol.vim
@@ -41,7 +41,7 @@ function! ale#symbol#HandleLSPResponse(conn_id, response) abort
                 let l:location = l:response_item.location
 
                 call add(l:item_list, {
-                \ 'filename': ale#path#FromURI(l:location.uri),
+                \ 'filename': ale#util#ToResource(l:location.uri),
                 \ 'line': l:location.range.start.line + 1,
                 \ 'column': l:location.range.start.character + 1,
                 \ 'match': l:response_item.name,

--- a/autoload/ale/uri.vim
+++ b/autoload/ale/uri.vim
@@ -25,3 +25,18 @@ function! ale#uri#Decode(value) abort
     \   'g'
     \)
 endfunction
+
+let s:uri_handlers = {
+\   'jdt': {
+\       'OpenURILink': function('ale#uri#jdt#OpenJDTLink'),
+\   }
+\}
+
+function! ale#uri#GetURIHandler(uri) abort
+    for l:scheme in keys(s:uri_handlers)
+        if a:uri =~# '^'.l:scheme.'://'
+            return s:uri_handlers[scheme]
+        endif
+    endfor
+    return v:null
+endfunction

--- a/autoload/ale/uri.vim
+++ b/autoload/ale/uri.vim
@@ -38,5 +38,6 @@ function! ale#uri#GetURIHandler(uri) abort
             return s:uri_handlers[scheme]
         endif
     endfor
+
     return v:null
 endfunction

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -9,7 +9,7 @@ function! s:OpenJDTLink(root, uri, line, column, options, result) abort
 
     let l:contents = a:result['result']
 
-    if type(l:contents) ==# type(v:null)
+    if type(l:contents) is# type(v:null)
         echoerr 'File content not found'
     endif
 

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -84,7 +84,7 @@ function! ale#uri#jdt#ReadJDTLink(encoded_uri) abort
     let l:linter_map = ale#lsp_linter#GetLSPLinterMap()
 
     for l:conn_id in keys(l:linter_map)
-        if l:linter_map[l:conn_id] ==# 'eclipselsp'
+        if l:linter_map[l:conn_id] is# 'eclipselsp'
             let l:root = l:conn_id[stridx(l:conn_id, ':')+1:]
         endif
     endfor

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -49,12 +49,11 @@ function! ale#uri#jdt#OpenJDTLink(encoded_uri, line, column, options, conn_id) a
     let l:root = a:conn_id[stridx(a:conn_id, ':')+1:]
     let l:uri = a:encoded_uri
     call ale#lsp_linter#SendRequest(
-                \   bufnr(''),
-                \   'eclipselsp',
-                \   [0, 'java/classFileContents', {
-                \       'uri': ale#util#ToURI(l:uri)
-                \   }],
-                \   function('s:OpenJDTLink', [l:root, l:uri, a:line, a:column, a:options]))
+    \   bufnr(''),
+    \   'eclipselsp',
+    \   [0, 'java/classFileContents', {'uri': ale#util#ToURI(l:uri)}],
+    \   function('s:OpenJDTLink', [l:root, l:uri, a:line, a:column, a:options])
+    \)
 endfunction
 
 function! s:ReadClassFileContents(uri, result) abort

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -80,11 +80,13 @@ function! ale#uri#jdt#ReadJDTLink(encoded_uri) abort
     endif
 
     let l:linter_map = ale#lsp_linter#GetLSPLinterMap()
+
     for l:conn_id in keys(l:linter_map)
         if l:linter_map[l:conn_id] ==# 'eclipselsp'
             let l:root = l:conn_id[stridx(l:conn_id, ':')+1:]
         endif
     endfor
+
     if l:root is# v:null
         throw 'eclipselsp not running'
     endif

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -3,7 +3,7 @@
 
 function! s:OpenJDTLink(root, uri, line, column, options, result) abort
     if has_key(a:result, 'error')
-        echoerr a:result.error.message
+        execute 'echoerr a:result.error.message'
         return
     endif
 

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -97,10 +97,9 @@ function! ale#uri#jdt#ReadJDTLink(encoded_uri) abort
     set filetype=java
 
     call ale#lsp_linter#SendRequest(
-                \   bufnr(''),
-                \   'eclipselsp',
-                \   [0, 'java/classFileContents', {
-                \       'uri': ale#util#ToURI(l:uri)
-                \   }],
-                \   function('s:ReadClassFileContents', [l:uri]))
+    \   bufnr(''),
+    \   'eclipselsp',
+    \   [0, 'java/classFileContents', {'uri': ale#util#ToURI(l:uri)}],
+    \   function('s:ReadClassFileContents', [l:uri])
+    \)
 endfunction

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -11,7 +11,7 @@ function! s:OpenJDTLink(root, uri, line, column, options, result) abort
     let l:contents = a:result['result']
 
     if type(l:contents) is# type(v:null)
-        echoerr 'File content not found'
+        execute 'echoerr ''File content not found'''
     endif
 
     " disable autocmd when opening buffer

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -4,6 +4,7 @@
 function! s:OpenJDTLink(root, uri, line, column, options, result) abort
     if has_key(a:result, 'error')
         execute 'echoerr a:result.error.message'
+
         return
     endif
 

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -59,6 +59,7 @@ endfunction
 function! s:ReadClassFileContents(uri, result) abort
     if has_key(a:result, 'error')
         echoerr a:result.error.message
+
         return
     endif
 

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -58,7 +58,7 @@ endfunction
 
 function! s:ReadClassFileContents(uri, result) abort
     if has_key(a:result, 'error')
-        echoerr a:result.error.message
+        execute 'echoerr a:result.error.message'
 
         return
     endif

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -66,7 +66,7 @@ function! s:ReadClassFileContents(uri, result) abort
 
     let l:contents = a:result['result']
 
-    if type(l:contents) ==# type(v:null)
+    if type(l:contents) is# type(v:null)
         execute 'echoerr ''File content not found'''
     endif
 

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -1,0 +1,101 @@
+" Author: yoshi1123 <yoshi1@tutanota.com>
+" Description: Functions for working with jdt:// URIs.
+
+function! s:OpenJDTLink(root, filename, line, column, options, result) abort
+    if has_key(a:result, 'error')
+        echoerr a:result.error.message
+        return
+    endif
+
+    let l:contents = a:result['result']
+    if type(l:contents) ==# type(v:null)
+        echoerr 'File content not found'
+    endif
+
+    " disable autocmd when opening buffer
+    autocmd! AleURISchemes
+    call ale#util#Open(a:filename, a:line, a:column, a:options)
+    autocmd AleURISchemes BufNewFile,BufReadPre jdt://** call ale#uri#jdt#ReadJDTLink(expand('<amatch>'))
+
+    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
+        return
+    endif
+
+    let b:ale_lsp_root = a:root
+    set filetype=java
+
+    call setline(1, split(l:contents, '\n'))
+    call cursor(a:line, a:column)
+    normal! zz
+
+    setlocal buftype=nofile nomodified nomodifiable readonly
+endfunction
+
+" Load new buffer with jdt:// contents and jump to line and column.
+function! ale#uri#jdt#OpenJDTLink(encoded_uri, line, column, options, conn_id) abort
+    let l:found_eclipselsp = v:false
+    for l:linter in ale#linter#Get('java')
+        if l:linter.name is# 'eclipselsp'
+            let l:found_eclipselsp = v:true
+        endif
+    endfor
+    if !l:found_eclipselsp
+        throw 'eclipselsp not running'
+    endif
+
+    let l:root = a:conn_id[stridx(a:conn_id, ':')+1:]
+    let l:filename = a:encoded_uri
+    call ale#lsp_linter#SendRequest(
+                \   bufnr(''),
+                \   'eclipselsp',
+                \   [0, 'java/classFileContents', {
+                \       'uri': ale#util#ToURI(l:filename)
+                \   }],
+                \   function('s:OpenJDTLink', [l:root, l:filename, a:line, a:column, a:options]))
+endfunction
+
+function! s:ReadClassFileContents(filename, result) abort
+    if has_key(a:result, 'error')
+        echoerr a:result.error.message
+        return
+    endif
+
+    let l:contents = a:result['result']
+
+    if type(l:contents) ==# type(v:null)
+        echoerr 'File content not found'
+    endif
+
+    call setline(1, split(l:contents, '\n'))
+
+    setlocal buftype=nofile nomodified nomodifiable readonly
+endfunction
+
+" Read jdt:// contents, as part of current project, into current buffer.
+function! ale#uri#jdt#ReadJDTLink(encoded_uri) abort
+    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
+        return
+    endif
+
+    let l:linter_map = ale#lsp_linter#GetLSPLinterMap()
+    for l:conn_id in keys(l:linter_map)
+        if l:linter_map[l:conn_id] ==# 'eclipselsp'
+            let l:root = l:conn_id[stridx(l:conn_id, ':')+1:]
+        endif
+    endfor
+    if l:root is# v:null
+        throw 'eclipselsp not running'
+    endif
+
+    let l:filename = a:encoded_uri
+    let b:ale_lsp_root = l:root
+    set filetype=java
+
+    call ale#lsp_linter#SendRequest(
+                \   bufnr(''),
+                \   'eclipselsp',
+                \   [0, 'java/classFileContents', {
+                \       'uri': ale#util#ToURI(l:filename)
+                \   }],
+                \   function('s:ReadClassFileContents', [l:filename]))
+endfunction

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -35,11 +35,13 @@ endfunction
 " Load new buffer with jdt:// contents and jump to line and column.
 function! ale#uri#jdt#OpenJDTLink(encoded_uri, line, column, options, conn_id) abort
     let l:found_eclipselsp = v:false
+
     for l:linter in ale#linter#Get('java')
         if l:linter.name is# 'eclipselsp'
             let l:found_eclipselsp = v:true
         endif
     endfor
+
     if !l:found_eclipselsp
         throw 'eclipselsp not running'
     endif

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -66,7 +66,7 @@ function! s:ReadClassFileContents(uri, result) abort
     let l:contents = a:result['result']
 
     if type(l:contents) ==# type(v:null)
-        echoerr 'File content not found'
+        execute 'echoerr ''File content not found'''
     endif
 
     call setline(1, split(l:contents, '\n'))

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -8,6 +8,7 @@ function! s:OpenJDTLink(root, uri, line, column, options, result) abort
     endif
 
     let l:contents = a:result['result']
+
     if type(l:contents) ==# type(v:null)
         echoerr 'File content not found'
     endif

--- a/autoload/ale/uri/jdt.vim
+++ b/autoload/ale/uri/jdt.vim
@@ -1,7 +1,7 @@
 " Author: yoshi1123 <yoshi1@tutanota.com>
 " Description: Functions for working with jdt:// URIs.
 
-function! s:OpenJDTLink(root, filename, line, column, options, result) abort
+function! s:OpenJDTLink(root, uri, line, column, options, result) abort
     if has_key(a:result, 'error')
         echoerr a:result.error.message
         return
@@ -14,7 +14,7 @@ function! s:OpenJDTLink(root, filename, line, column, options, result) abort
 
     " disable autocmd when opening buffer
     autocmd! AleURISchemes
-    call ale#util#Open(a:filename, a:line, a:column, a:options)
+    call ale#util#Open(a:uri, a:line, a:column, a:options)
     autocmd AleURISchemes BufNewFile,BufReadPre jdt://** call ale#uri#jdt#ReadJDTLink(expand('<amatch>'))
 
     if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
@@ -44,17 +44,17 @@ function! ale#uri#jdt#OpenJDTLink(encoded_uri, line, column, options, conn_id) a
     endif
 
     let l:root = a:conn_id[stridx(a:conn_id, ':')+1:]
-    let l:filename = a:encoded_uri
+    let l:uri = a:encoded_uri
     call ale#lsp_linter#SendRequest(
                 \   bufnr(''),
                 \   'eclipselsp',
                 \   [0, 'java/classFileContents', {
-                \       'uri': ale#util#ToURI(l:filename)
+                \       'uri': ale#util#ToURI(l:uri)
                 \   }],
-                \   function('s:OpenJDTLink', [l:root, l:filename, a:line, a:column, a:options]))
+                \   function('s:OpenJDTLink', [l:root, l:uri, a:line, a:column, a:options]))
 endfunction
 
-function! s:ReadClassFileContents(filename, result) abort
+function! s:ReadClassFileContents(uri, result) abort
     if has_key(a:result, 'error')
         echoerr a:result.error.message
         return
@@ -87,7 +87,7 @@ function! ale#uri#jdt#ReadJDTLink(encoded_uri) abort
         throw 'eclipselsp not running'
     endif
 
-    let l:filename = a:encoded_uri
+    let l:uri = a:encoded_uri
     let b:ale_lsp_root = l:root
     set filetype=java
 
@@ -95,7 +95,7 @@ function! ale#uri#jdt#ReadJDTLink(encoded_uri) abort
                 \   bufnr(''),
                 \   'eclipselsp',
                 \   [0, 'java/classFileContents', {
-                \       'uri': ale#util#ToURI(l:filename)
+                \       'uri': ale#util#ToURI(l:uri)
                 \   }],
-                \   function('s:ReadClassFileContents', [l:filename]))
+                \   function('s:ReadClassFileContents', [l:uri]))
 endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -560,6 +560,7 @@ endfunction
 
 function! ale#util#ToResource(uri) abort
     let l:uri_handler = ale#uri#GetURIHandler(a:uri)
+
     if l:uri_handler is# v:null
         " resource is a filesystem path
         let l:resource = ale#path#FromFileURI(a:uri)
@@ -567,5 +568,6 @@ function! ale#util#ToResource(uri) abort
         " resource is a URI
         let l:resource = a:uri
     endif
+
     return l:resource
 endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -543,3 +543,18 @@ endfunction
 function! ale#util#GetBufferContents(buffer) abort
     return join(getbufline(a:buffer, 1, '$'), '\n') . '\n'
 endfunction
+
+function! ale#util#GetURIHandler(uri)
+    for l:linter in ale#linter#Get(&filetype)
+        if !empty(l:linter.lsp)
+            if exists('l:linter.uri_handlers') && !empty(l:linter.uri_handlers)
+                for l:scheme in keys(l:linter.uri_handlers)
+                    if a:uri =~# '^'.l:scheme.'://'
+                        return l:linter.uri_handlers[scheme]
+                    endif
+                endfor
+            endif
+        endif
+    endfor
+    return v:null
+endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -544,141 +544,26 @@ function! ale#util#GetBufferContents(buffer) abort
     return join(getbufline(a:buffer, 1, '$'), '\n') . '\n'
 endfunction
 
-let s:uri_handlers = {
-\   'jdt': {
-\       'OpenURILink': function('ale#util#OpenJDTLink'),
-\       'PathFromURI': function('ale#util#JDTToPath'),
-\       'PathToURI': function('ale#util#PathToJDT')
-\   }
-\}
-
-function! ale#util#GetURIHandler(uri) abort
-    for l:scheme in keys(s:uri_handlers)
-        if a:uri =~# '^'.l:scheme.'://'
-            return s:uri_handlers[scheme]
-        endif
-    endfor
-    return v:null
-endfunction
-
-function! ale#util#JDTToPath(uri) abort
-    let l:uri = ale#uri#Decode(a:uri)
-
-    let l:scheme = a:uri[:5]
-    let l:auth_path = a:uri[6:stridx(a:uri, '?')-1]
-    let l:query = a:uri[stridx(a:uri, '?')+1:]
-
-    " do not allow ["*:<>?|] in authority and path sections
-    let l:auth_path = substitute(l:auth_path, '\(["*:<>?|]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
-    " do not allow ["*:<>|?\/] in query section
-    let l:query = substitute(l:query, '\(["*:<>?|\\/]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
-
-    let l:path = l:scheme . l:auth_path . '%3f' . l:query
-
-    return l:path
-endfunction
-
-function! ale#util#PathToJDT(path) abort
-    let l:uri = substitute(a:path, '%3f', '?', 'g')
-
+function! ale#util#ToURI(resource) abort
+    let l:uri_handler = ale#uri#GetURIHandler(a:resource)
+    if l:uri_handler is# v:null
+        " resource is a filesystem path
+        let l:uri = ale#path#ToFileURI(a:resource)
+    else
+        " resource is a URI
+        let l:uri = a:resource
+    endif
     return l:uri
 endfunction
 
-function! s:OpenJDTLink(root, filename, line, column, options, result) abort
-    if has_key(a:result, 'error')
-        echoerr a:result.error.message
-        return
+function! ale#util#ToResource(uri) abort
+    let l:uri_handler = ale#uri#GetURIHandler(a:uri)
+    if l:uri_handler is# v:null
+        " resource is a filesystem path
+        let l:resource = ale#path#FromFileURI(a:uri)
+    else
+        " resource is a URI
+        let l:resource = a:uri
     endif
-
-    let l:contents = a:result['result']
-    if type(l:contents) ==# type(v:null)
-        echoerr 'File content not found'
-    endif
-
-    " disable autocmd when opening buffer
-    autocmd! AleURISchemes
-    call ale#util#Open(a:filename, a:line, a:column, a:options)
-    autocmd AleURISchemes BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
-
-    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
-        return
-    endif
-
-    let b:ale_lsp_root = a:root
-    set filetype=java
-
-    call setline(1, split(l:contents, '\n'))
-    call cursor(a:line, a:column)
-    normal! zz
-
-    setlocal buftype=nofile nomodified nomodifiable readonly
-endfunction
-
-" Load new buffer with jdt:// contents and jump to line and column.
-function! ale#util#OpenJDTLink(encoded_uri, line, column, options, conn_id) abort
-    let l:found_eclipselsp = v:false
-    for l:linter in ale#linter#Get('java')
-        if l:linter.name is# 'eclipselsp'
-            let l:found_eclipselsp = v:true
-        endif
-    endfor
-    if !l:found_eclipselsp
-        throw 'eclipselsp not running'
-    endif
-
-    let l:root = a:conn_id[stridx(a:conn_id, ':')+1:]
-    let l:filename = a:encoded_uri
-    call ale#lsp_linter#SendRequest(
-                \   bufnr(''),
-                \   'eclipselsp',
-                \   [0, 'java/classFileContents', {
-                \       'uri': ale#path#ToURI(l:filename)
-                \   }],
-                \   function('s:OpenJDTLink', [l:root, l:filename, a:line, a:column, a:options]))
-endfunction
-
-function! s:ReadClassFileContents(filename, result) abort
-    if has_key(a:result, 'error')
-        echoerr a:result.error.message
-        return
-    endif
-
-    let l:contents = a:result['result']
-
-    if type(l:contents) ==# type(v:null)
-        echoerr 'File content not found'
-    endif
-
-    call setline(1, split(l:contents, '\n'))
-
-    setlocal buftype=nofile nomodified nomodifiable readonly
-endfunction
-
-" Read jdt:// contents, as part of current project, into current buffer.
-function! ale#util#ReadJDTLink(encoded_uri) abort
-    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
-        return
-    endif
-
-    let l:linter_map = ale#lsp_linter#GetLSPLinterMap()
-    for l:conn_id in keys(l:linter_map)
-        if l:linter_map[l:conn_id] ==# 'eclipselsp'
-            let l:root = l:conn_id[stridx(l:conn_id, ':')+1:]
-        endif
-    endfor
-    if l:root is# v:null
-        throw 'eclipselsp not running'
-    endif
-
-    let l:filename = a:encoded_uri
-    let b:ale_lsp_root = l:root
-    set filetype=java
-
-    call ale#lsp_linter#SendRequest(
-                \   bufnr(''),
-                \   'eclipselsp',
-                \   [0, 'java/classFileContents', {
-                \       'uri': ale#path#ToURI(l:filename)
-                \   }],
-                \   function('s:ReadClassFileContents', [l:filename]))
+    return l:resource
 endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -594,9 +594,9 @@ function! s:OpenJDTLink(root, filename, line, column, options, result) abort
     endif
 
     " disable autocmd when opening buffer
-    autocmd! ale_eclipselsp_jdt
+    autocmd! AleURISchemes
     call ale#util#Open(a:filename, a:line, a:column, a:options)
-    autocmd ale_eclipselsp_jdt BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
+    autocmd AleURISchemes BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
 
     if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
         return

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -546,6 +546,7 @@ endfunction
 
 function! ale#util#ToURI(resource) abort
     let l:uri_handler = ale#uri#GetURIHandler(a:resource)
+
     if l:uri_handler is# v:null
         " resource is a filesystem path
         let l:uri = ale#path#ToFileURI(a:resource)
@@ -553,6 +554,7 @@ function! ale#util#ToURI(resource) abort
         " resource is a URI
         let l:uri = a:resource
     endif
+
     return l:uri
 endfunction
 

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -558,3 +558,125 @@ function! ale#util#GetURIHandler(uri)
     endfor
     return v:null
 endfunction
+
+function! ale#util#JDTToPath(uri) abort
+    let l:uri = ale#uri#Decode(a:uri)
+
+    let l:scheme = a:uri[:5]
+    let l:auth_path = a:uri[6:stridx(a:uri, '?')-1]
+    let l:query = a:uri[stridx(a:uri, '?')+1:]
+
+    " do not allow ["*:<>?|] in authority and path sections
+    let l:auth_path = substitute(l:auth_path, '\(["*:<>?|]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
+    " do not allow ["*:<>|?\/] in query section
+    let l:query = substitute(l:query, '\(["*:<>?|\\/]\)', '\=printf("%%%x", char2nr(submatch(1)))', 'g')
+
+    let l:path = l:scheme . l:auth_path . '%3f' . l:query
+
+    return l:path
+endfunction
+
+function! ale#util#PathToJDT(path) abort
+    let l:uri = substitute(a:path, '%3f', '?', 'g')
+
+    return l:uri
+endfunction
+
+function! s:OpenJDTLink(root, filename, line, column, options, result) abort
+    if has_key(a:result, 'error')
+        echoerr a:result.error.message
+        return
+    endif
+
+    let l:contents = a:result['result']
+    if type(l:contents) ==# type(v:null)
+        echoerr 'File content not found'
+    endif
+
+    " disable autocmd when opening buffer
+    autocmd! ale_eclipselsp_jdt
+    call ale#util#Open(a:filename, a:line, a:column, a:options)
+    autocmd ale_eclipselsp_jdt BufNewFile,BufReadPre jdt://** call ale#util#ReadJDTLink(expand('<amatch>'))
+
+    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
+        return
+    endif
+
+    let b:ale_lsp_root = a:root
+    set filetype=java
+
+    call setline(1, split(l:contents, '\n'))
+    call cursor(a:line, a:column)
+    normal! zz
+
+    setlocal buftype=nofile nomodified nomodifiable readonly
+endfunction
+
+" Load new buffer with jdt:// contents and jump to line and column.
+function! ale#util#OpenJDTLink(encoded_uri, line, column, options, conn_id) abort
+    let l:found_eclipselsp = v:false
+    for l:linter in ale#linter#Get('java')
+        if l:linter.name is# 'eclipselsp'
+            let l:found_eclipselsp = v:true
+        endif
+    endfor
+    if !l:found_eclipselsp
+        throw 'eclipselsp not running'
+    endif
+
+    let l:root = a:conn_id[stridx(a:conn_id, ':')+1:]
+    let l:filename = a:encoded_uri
+    call ale#lsp_linter#SendRequest(
+                \   bufnr(''),
+                \   'eclipselsp',
+                \   [0, 'java/classFileContents', {
+                \       'uri': ale#path#ToURI(l:filename)
+                \   }],
+                \   function('s:OpenJDTLink', [l:root, l:filename, a:line, a:column, a:options]))
+endfunction
+
+function! s:ReadClassFileContents(filename, result) abort
+    if has_key(a:result, 'error')
+        echoerr a:result.error.message
+        return
+    endif
+
+    let l:contents = a:result['result']
+
+    if type(l:contents) ==# type(v:null)
+        echoerr 'File content not found'
+    endif
+
+    call setline(1, split(l:contents, '\n'))
+
+    setlocal buftype=nofile nomodified nomodifiable readonly
+endfunction
+
+" Read jdt:// contents, as part of current project, into current buffer.
+function! ale#util#ReadJDTLink(encoded_uri) abort
+    if !empty(getbufvar(bufnr(''), 'ale_lsp_root', ''))
+        return
+    endif
+
+    let l:linter_map = ale#lsp_linter#GetLinterMap()
+    for l:conn_id in keys(l:linter_map)
+        if l:linter_map[l:conn_id] ==# 'eclipselsp'
+            let l:root = l:conn_id[stridx(l:conn_id, ':')+1:]
+        endif
+    endfor
+    if l:root is# v:null
+        throw 'eclipselsp not running'
+    endif
+
+    let l:filename = a:encoded_uri
+    let b:ale_lsp_root = l:root
+    set filetype=java
+
+    call ale#lsp_linter#SendRequest(
+                \   bufnr(''),
+                \   'eclipselsp',
+                \   [0, 'java/classFileContents', {
+                \       'uri': ale#path#ToURI(l:filename)
+                \   }],
+                \   function('s:ReadClassFileContents', [l:filename]))
+endfunction

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -544,16 +544,18 @@ function! ale#util#GetBufferContents(buffer) abort
     return join(getbufline(a:buffer, 1, '$'), '\n') . '\n'
 endfunction
 
+let s:uri_handlers = {
+\   'jdt': {
+\       'OpenURILink': function('ale#util#OpenJDTLink'),
+\       'PathFromURI': function('ale#util#JDTToPath'),
+\       'PathToURI': function('ale#util#PathToJDT')
+\   }
+\}
+
 function! ale#util#GetURIHandler(uri)
-    for l:linter in ale#linter#Get(&filetype)
-        if !empty(l:linter.lsp)
-            if exists('l:linter.uri_handlers') && !empty(l:linter.uri_handlers)
-                for l:scheme in keys(l:linter.uri_handlers)
-                    if a:uri =~# '^'.l:scheme.'://'
-                        return l:linter.uri_handlers[scheme]
-                    endif
-                endfor
-            endif
+    for l:scheme in keys(s:uri_handlers)
+        if a:uri =~# '^'.l:scheme.'://'
+            return s:uri_handlers[scheme]
         endif
     endfor
     return v:null

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -660,7 +660,7 @@ function! ale#util#ReadJDTLink(encoded_uri) abort
         return
     endif
 
-    let l:linter_map = ale#lsp_linter#GetLinterMap()
+    let l:linter_map = ale#lsp_linter#GetLSPLinterMap()
     for l:conn_id in keys(l:linter_map)
         if l:linter_map[l:conn_id] ==# 'eclipselsp'
             let l:root = l:conn_id[stridx(l:conn_id, ':')+1:]

--- a/autoload/ale/util.vim
+++ b/autoload/ale/util.vim
@@ -552,7 +552,7 @@ let s:uri_handlers = {
 \   }
 \}
 
-function! ale#util#GetURIHandler(uri)
+function! ale#util#GetURIHandler(uri) abort
     for l:scheme in keys(s:uri_handlers)
         if a:uri =~# '^'.l:scheme.'://'
             return s:uri_handlers[scheme]

--- a/test/completion/test_ale_import_command.vader
+++ b/test/completion/test_ale_import_command.vader
@@ -368,7 +368,7 @@ Execute(ALEImport should request imports correctly for language servers):
   AssertEqual
   \ [
   \   [0, 'textDocument/completion', {
-  \     'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \     'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \     'position': {'character': 6, 'line': 1}
   \   }],
   \ ],
@@ -514,7 +514,7 @@ Execute(ALEImport should tell the user when no completions were found from a lan
   AssertEqual
   \ [
   \   [0, 'textDocument/completion', {
-  \     'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \     'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \     'position': {'character': 6, 'line': 1}
   \   }],
   \ ],

--- a/test/completion/test_lsp_completion_messages.vader
+++ b/test/completion/test_lsp_completion_messages.vader
@@ -233,13 +233,13 @@ Execute(The right message should be sent for the initial LSP request):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/completion', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
@@ -294,13 +294,13 @@ Execute(Two completion requests shouldn't be sent in a row):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/completion', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],

--- a/test/lsp/test_closing_documents.vader
+++ b/test/lsp/test_closing_documents.vader
@@ -63,7 +63,7 @@ Execute(A message should be sent if the document was opened):
   \ [
   \   ['command:/foo', 1, 'textDocument/didOpen', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 1,
   \       'languageId': 'lang',
   \       'text': "\n",
@@ -71,7 +71,7 @@ Execute(A message should be sent if the document was opened):
   \   }],
   \   ['command:/foo', 1, 'textDocument/didClose', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \     },
   \   }],
   \ ],
@@ -106,7 +106,7 @@ Execute(Re-opening and closing the documents should work):
   \ [
   \   ['command:/foo', 1, 'textDocument/didOpen', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 2,
   \       'languageId': 'lang',
   \       'text': "\n",
@@ -114,12 +114,12 @@ Execute(Re-opening and closing the documents should work):
   \   }],
   \   ['command:/foo', 1, 'textDocument/didClose', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \     },
   \   }],
   \   ['command:/foo', 1, 'textDocument/didOpen', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 1,
   \       'languageId': 'lang',
   \       'text': "\n",
@@ -127,7 +127,7 @@ Execute(Re-opening and closing the documents should work):
   \   }],
   \   ['command:/foo', 1, 'textDocument/didClose', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \     },
   \   }],
   \ ],
@@ -148,7 +148,7 @@ Execute(Messages for closing documents should be sent to each server):
   \ [
   \   ['command:/foo', 1, 'textDocument/didOpen', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 2,
   \       'languageId': 'lang',
   \       'text': "\n",
@@ -156,7 +156,7 @@ Execute(Messages for closing documents should be sent to each server):
   \   }],
   \   ['command:/bar', 1, 'textDocument/didOpen', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 1,
   \       'languageId': 'lang',
   \       'text': "\n",
@@ -164,12 +164,12 @@ Execute(Messages for closing documents should be sent to each server):
   \   }],
   \   ['command:/bar', 1, 'textDocument/didClose', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \     },
   \   }],
   \   ['command:/foo', 1, 'textDocument/didClose', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \     },
   \   }],
   \ ],

--- a/test/lsp/test_did_save_event.vader
+++ b/test/lsp/test_did_save_event.vader
@@ -94,7 +94,7 @@ Execute(Server should be notified on save):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],
@@ -118,14 +118,14 @@ Execute(Server should be notified on save with didSave is supported by server):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],
   \   }],
   \   [1, 'textDocument/didSave', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \     },
   \   }],
   \ ],
@@ -138,7 +138,7 @@ Execute(Server should be notified on change):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \       'uri': ale#path#ToURI(expand('%:p')),
+  \       'uri': ale#path#ToFileURI(expand('%:p')),
   \       'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}],

--- a/test/lsp/test_engine_lsp_response_handling.vader
+++ b/test/lsp/test_engine_lsp_response_handling.vader
@@ -314,7 +314,7 @@ Execute(LSP diagnostics responses should be handled correctly):
   \ 'jsonrpc':'2.0',
   \ 'method':'textDocument/publishDiagnostics',
   \ 'params': {
-  \     'uri': ale#path#ToURI(expand('%:p')),
+  \     'uri': ale#path#ToFileURI(expand('%:p')),
   \     'diagnostics': [
   \        {
   \          'range': {
@@ -403,7 +403,7 @@ Execute(LSP errors should mark linters no longer active):
   call ale#lsp_linter#HandleLSPResponse(1, {
   \ 'method': 'textDocument/publishDiagnostics',
   \ 'params': {
-  \   'uri': ale#path#ToURI(g:dir . '/filename.py'),
+  \   'uri': ale#path#ToFileURI(g:dir . '/filename.py'),
   \   'diagnostics': [],
   \ },
   \})

--- a/test/lsp/test_lsp_client_messages.vader
+++ b/test/lsp/test_lsp_client_messages.vader
@@ -44,7 +44,7 @@ Execute(ale#lsp#message#DidOpen() should return correct messages):
   \   'textDocument/didOpen',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \         'languageId': 'typescript',
   \         'version': 12,
   \         'text': "foo()\nbar()\nbaz()\n",
@@ -62,7 +62,7 @@ Execute(ale#lsp#message#DidChange() should return correct messages):
   \   'textDocument/didChange',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \         'version': 34,
   \     },
   \     'contentChanges': [{'text': "foo()\nbar()\nbaz()\n"}],
@@ -84,7 +84,7 @@ Execute(ale#lsp#message#DidSave() should return correct messages):
   \   'textDocument/didSave',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \   }
   \ ],
@@ -97,7 +97,7 @@ Execute(ale#lsp#message#DidSave() should return correct message with includeText
   \   'textDocument/didSave',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \         'version': 1,
   \     },
   \     'text': ale#util#GetBufferContents(bufnr('')),
@@ -112,7 +112,7 @@ Execute(ale#lsp#message#DidClose() should return correct messages):
   \   'textDocument/didClose',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \   }
   \ ],
@@ -125,7 +125,7 @@ Execute(ale#lsp#message#Completion() should return correct messages):
   \   'textDocument/completion',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \     'position': {'line': 11, 'character': 33},
   \   }
@@ -139,7 +139,7 @@ Execute(ale#lsp#message#Completion() should return correct messages with a trigg
   \   'textDocument/completion',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \     'position': {'line': 11, 'character': 33},
   \     'context': {'triggerKind': 2, 'triggerCharacter': '.'},
@@ -154,7 +154,7 @@ Execute(ale#lsp#message#Definition() should return correct messages):
   \   'textDocument/definition',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \     'position': {'line': 11, 'character': 33},
   \   }
@@ -168,7 +168,7 @@ Execute(ale#lsp#message#TypeDefinition() should return correct messages):
   \   'textDocument/typeDefinition',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \     'position': {'line': 11, 'character': 33},
   \   }
@@ -182,7 +182,7 @@ Execute(ale#lsp#message#References() should return correct messages):
   \   'textDocument/references',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \     'position': {'line': 11, 'character': 33},
   \     'context': {'includeDeclaration': v:false},
@@ -208,7 +208,7 @@ Execute(ale#lsp#message#Hover() should return correct messages):
   \   'textDocument/hover',
   \   {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(g:dir . '/foo/bar.ts'),
+  \         'uri': ale#path#ToFileURI(g:dir . '/foo/bar.ts'),
   \     },
   \     'position': {'line': 11, 'character': 33},
   \   }

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -138,7 +138,7 @@ Before:
       \     'id': 1,
       \     'params': {
       \       'initializationOptions': {},
-      \       'rootUri': ale#path#ToURI(a:root),
+      \       'rootUri': ale#path#ToFileURI(a:root),
       \       'rootPath': a:root,
       \       'processId': getpid(),
       \       'capabilities': {
@@ -253,7 +253,7 @@ Before:
       \     'jsonrpc': '2.0',
       \     'params': {
       \       'textDocument': {
-      \         'uri': ale#path#ToURI(expand('#' . a:buffer . ':p')),
+      \         'uri': ale#path#ToFileURI(expand('#' . a:buffer . ':p')),
       \         'version': ale#lsp#message#GetNextVersionID() - 1,
       \         'languageId': a:language,
       \         'text': "\n",

--- a/test/test_codefix.vader
+++ b/test/test_codefix.vader
@@ -511,7 +511,7 @@ Execute(LSP code action requests should be sent):
   \       'diagnostics': [{'range': {'end': {'character': 6, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'code': 2304, 'message': 'oops'}]
   \     },
   \     'range': {'end': {'character': 5, 'line': 1}, 'start': {'character': 4, 'line': 1}},
-  \     'textDocument': {'uri': ale#path#ToURI(expand('%:p'))}
+  \     'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))}
   \   }]
   \ ],
   \ g:message_list[-1:]
@@ -543,7 +543,7 @@ Execute(LSP code action requests should be sent only for error with code):
   \       'diagnostics': [{'range': {'end': {'character': 6, 'line': 1}, 'start': {'character': 4, 'line': 1}}, 'code': 2304, 'message': 'oops'}]
   \     },
   \     'range': {'end': {'character': 5, 'line': 1}, 'start': {'character': 4, 'line': 1}},
-  \     'textDocument': {'uri': ale#path#ToURI(expand('%:p'))}
+  \     'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))}
   \   }]
   \ ],
   \ g:message_list[-1:]

--- a/test/test_find_references.vader
+++ b/test/test_find_references.vader
@@ -357,13 +357,13 @@ Execute(LSP reference responses should be handled):
   \   'id': 3,
   \   'result': [
   \     {
-  \       'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \       'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \       'range': {
   \         'start': {'line': 2, 'character': 7},
   \       },
   \     },
   \     {
-  \       'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/other_file')),
+  \       'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/other_file')),
   \       'range': {
   \         'start': {'line': 7, 'character': 15},
   \       },
@@ -396,13 +396,13 @@ Execute(LSP reference responses should be put to quickfix):
   \   'id': 3,
   \   'result': [
   \     {
-  \       'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \       'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \       'range': {
   \         'start': {'line': 2, 'character': 7},
   \       },
   \     },
   \     {
-  \       'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/other_file')),
+  \       'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/other_file')),
   \       'range': {
   \         'start': {'line': 7, 'character': 15},
   \       },
@@ -453,13 +453,13 @@ Execute(LSP reference requests should be sent):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/references', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   'context': {'includeDeclaration': v:false},
   \   }],

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -327,7 +327,7 @@ Execute(Other files should be jumped to for LSP definition responses):
   \ {
   \   'id': 3,
   \   'result': {
-  \     'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \     'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \     'range': {
   \       'start': {'line': 2, 'character': 7},
   \     },
@@ -350,7 +350,7 @@ Execute(Newer LocationLink items should be supported):
   \ {
   \   'id': 3,
   \   'result': {
-  \     'targetUri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \     'targetUri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \     'targetRange': {
   \       'start': {'line': 2, 'character': 7},
   \     },
@@ -373,7 +373,7 @@ Execute(Locations inside the same file should be jumped to without using :edit):
   \ {
   \   'id': 3,
   \   'result': {
-  \     'uri': ale#path#ToURI(ale#path#Simplify(expand('%:p'))),
+  \     'uri': ale#path#ToFileURI(ale#path#Simplify(expand('%:p'))),
   \     'range': {
   \       'start': {'line': 2, 'character': 7},
   \     },
@@ -395,7 +395,7 @@ Execute(Other files should be jumped to in tabs for LSP definition responses):
   \ {
   \   'id': 3,
   \   'result': {
-  \     'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \     'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \     'range': {
   \       'start': {'line': 2, 'character': 7},
   \     },
@@ -419,13 +419,13 @@ Execute(Definition responses with lists should be handled):
   \   'id': 3,
   \   'result': [
   \     {
-  \       'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \       'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \       'range': {
   \         'start': {'line': 2, 'character': 7},
   \       },
   \     },
   \     {
-  \       'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/other_file')),
+  \       'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/other_file')),
   \       'range': {
   \         'start': {'line': 20, 'character': 3},
   \       },
@@ -470,13 +470,13 @@ Execute(LSP definition requests should be sent):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/definition', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
@@ -506,13 +506,13 @@ Execute(LSP type definition requests should be sent):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/typeDefinition', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
@@ -542,13 +542,13 @@ Execute(LSP tab definition requests should be sent):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/definition', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],
@@ -578,13 +578,13 @@ Execute(LSP tab type definition requests should be sent):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/typeDefinition', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   }],
   \ ],

--- a/test/test_ignoring_linters.vader
+++ b/test/test_ignoring_linters.vader
@@ -271,7 +271,7 @@ Execute(Buffer ignore lists should be applied for LSP linters):
   \ 'jsonrpc': '2.0',
   \ 'method': 'textDocument/publishDiagnostics',
   \ 'params': {
-  \   'uri': ale#path#ToURI(expand('%:p')),
+  \   'uri': ale#path#ToFileURI(expand('%:p')),
   \   'diagnostics': [
   \     {
   \       'severity': 1,
@@ -366,7 +366,7 @@ Execute(ale_disable_lsp should be applied for LSP linters):
   \ 'jsonrpc': '2.0',
   \ 'method': 'textDocument/publishDiagnostics',
   \ 'params': {
-  \   'uri': ale#path#ToURI(expand('%:p')),
+  \   'uri': ale#path#ToFileURI(expand('%:p')),
   \   'diagnostics': [
   \     {
   \       'severity': 1,

--- a/test/test_path_uri.vader
+++ b/test/test_path_uri.vader
@@ -1,73 +1,73 @@
 Before:
   scriptencoding utf-8
 
-Execute(ale#path#ToURI should work for Windows paths):
-  AssertEqual 'file:///C:/foo/bar/baz.tst', ale#path#ToURI('C:\foo\bar\baz.tst')
-  AssertEqual 'foo/bar/baz.tst', ale#path#ToURI('foo\bar\baz.tst')
+Execute(ale#path#ToFileURI should work for Windows paths):
+  AssertEqual 'file:///C:/foo/bar/baz.tst', ale#path#ToFileURI('C:\foo\bar\baz.tst')
+  AssertEqual 'foo/bar/baz.tst', ale#path#ToFileURI('foo\bar\baz.tst')
 
-Execute(ale#path#FromURI should work for Unix paths):
-  AssertEqual '/foo/bar/baz.tst', ale#path#FromURI('file:///foo/bar/baz.tst')
-  AssertEqual '/foo/bar/baz.tst', ale#path#FromURI('file:/foo/bar/baz.tst')
-  AssertEqual '/foo/bar/baz.tst', ale#path#FromURI('FILE:///foo/bar/baz.tst')
-  AssertEqual '/foo/bar/baz.tst', ale#path#FromURI('FILE:/foo/bar/baz.tst')
+Execute(ale#path#FromFileURI should work for Unix paths):
+  AssertEqual '/foo/bar/baz.tst', ale#path#FromFileURI('file:///foo/bar/baz.tst')
+  AssertEqual '/foo/bar/baz.tst', ale#path#FromFileURI('file:/foo/bar/baz.tst')
+  AssertEqual '/foo/bar/baz.tst', ale#path#FromFileURI('FILE:///foo/bar/baz.tst')
+  AssertEqual '/foo/bar/baz.tst', ale#path#FromFileURI('FILE:/foo/bar/baz.tst')
 
-Execute(ale#path#FromURI should work for Windows paths):
+Execute(ale#path#FromFileURI should work for Windows paths):
   if has('win32')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('file:///C:/foo/bar/baz.tst')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('file:/C:/foo/bar/baz.tst')
-    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromURI('file:///c:/foo/bar/baz.tst')
-    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromURI('file:/c:/foo/bar/baz.tst')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('FILE:///C:/foo/bar/baz.tst')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('FILE:/C:/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('file:///C:/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('file:/C:/foo/bar/baz.tst')
+    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromFileURI('file:///c:/foo/bar/baz.tst')
+    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromFileURI('file:/c:/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('FILE:///C:/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('FILE:/C:/foo/bar/baz.tst')
   else
-    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromURI('file:///C:/foo/bar/baz.tst')
-    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromURI('file:/C:/foo/bar/baz.tst')
-    AssertEqual '/c:/foo/bar/baz.tst', ale#path#FromURI('file:///c:/foo/bar/baz.tst')
-    AssertEqual '/c:/foo/bar/baz.tst', ale#path#FromURI('file:/c:/foo/bar/baz.tst')
-    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromURI('FILE:///C:/foo/bar/baz.tst')
-    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromURI('FILE:/C:/foo/bar/baz.tst')
+    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromFileURI('file:///C:/foo/bar/baz.tst')
+    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromFileURI('file:/C:/foo/bar/baz.tst')
+    AssertEqual '/c:/foo/bar/baz.tst', ale#path#FromFileURI('file:///c:/foo/bar/baz.tst')
+    AssertEqual '/c:/foo/bar/baz.tst', ale#path#FromFileURI('file:/c:/foo/bar/baz.tst')
+    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromFileURI('FILE:///C:/foo/bar/baz.tst')
+    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromFileURI('FILE:/C:/foo/bar/baz.tst')
   endif
 
-Execute(ale#path#FromURI parse Windows paths with a pipe):
+Execute(ale#path#FromFileURI parse Windows paths with a pipe):
   if has('win32')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('file:///C|/foo/bar/baz.tst')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('file:/C|/foo/bar/baz.tst')
-    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromURI('file:///c|/foo/bar/baz.tst')
-    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromURI('file:/c|/foo/bar/baz.tst')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('FILE:///C|/foo/bar/baz.tst')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('FILE:/C|/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('file:///C|/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('file:/C|/foo/bar/baz.tst')
+    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromFileURI('file:///c|/foo/bar/baz.tst')
+    AssertEqual 'c:\foo\bar\baz.tst', ale#path#FromFileURI('file:/c|/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('FILE:///C|/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('FILE:/C|/foo/bar/baz.tst')
   else
-    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromURI('file:///C|/foo/bar/baz.tst')
-    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromURI('file:/C|/foo/bar/baz.tst')
-    AssertEqual '/c|/foo/bar/baz.tst', ale#path#FromURI('file:///c|/foo/bar/baz.tst')
-    AssertEqual '/c|/foo/bar/baz.tst', ale#path#FromURI('file:/c|/foo/bar/baz.tst')
-    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromURI('FILE:///C|/foo/bar/baz.tst')
-    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromURI('FILE:/C|/foo/bar/baz.tst')
+    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromFileURI('file:///C|/foo/bar/baz.tst')
+    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromFileURI('file:/C|/foo/bar/baz.tst')
+    AssertEqual '/c|/foo/bar/baz.tst', ale#path#FromFileURI('file:///c|/foo/bar/baz.tst')
+    AssertEqual '/c|/foo/bar/baz.tst', ale#path#FromFileURI('file:/c|/foo/bar/baz.tst')
+    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromFileURI('FILE:///C|/foo/bar/baz.tst')
+    AssertEqual '/C|/foo/bar/baz.tst', ale#path#FromFileURI('FILE:/C|/foo/bar/baz.tst')
   endif
 
-Execute(ale#path#FromURI should handle the colon for the drive letter being encoded):
+Execute(ale#path#FromFileURI should handle the colon for the drive letter being encoded):
   " These URIs shouldn't be created, but we'll handle them anyway.
   if has('win32')
-    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromURI('file:///C%3A/foo/bar/baz.tst')
+    AssertEqual 'C:\foo\bar\baz.tst', ale#path#FromFileURI('file:///C%3A/foo/bar/baz.tst')
   else
-    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromURI('file:///C%3A/foo/bar/baz.tst')
+    AssertEqual '/C:/foo/bar/baz.tst', ale#path#FromFileURI('file:///C%3A/foo/bar/baz.tst')
   endif
 
-Execute(ale#path#ToURI should work for Unix paths):
-  AssertEqual 'file:///foo/bar/baz.tst', ale#path#ToURI('/foo/bar/baz.tst')
-  AssertEqual 'foo/bar/baz.tst', ale#path#ToURI('foo/bar/baz.tst')
+Execute(ale#path#ToFileURI should work for Unix paths):
+  AssertEqual 'file:///foo/bar/baz.tst', ale#path#ToFileURI('/foo/bar/baz.tst')
+  AssertEqual 'foo/bar/baz.tst', ale#path#ToFileURI('foo/bar/baz.tst')
 
-Execute(ale#path#ToURI should keep safe characters):
-  AssertEqual '//a-zA-Z0-9$-_.!*''(),', ale#path#ToURI('\/a-zA-Z0-9$-_.!*''(),')
+Execute(ale#path#ToFileURI should keep safe characters):
+  AssertEqual '//a-zA-Z0-9$-_.!*''(),', ale#path#ToFileURI('\/a-zA-Z0-9$-_.!*''(),')
 
-Execute(ale#path#ToURI should percent encode unsafe characters):
-  AssertEqual '%20%2b%3a%3f%26%3d', ale#path#ToURI(' +:?&=')
+Execute(ale#path#ToFileURI should percent encode unsafe characters):
+  AssertEqual '%20%2b%3a%3f%26%3d', ale#path#ToFileURI(' +:?&=')
 
-Execute(ale#path#FromURI should decode percent encodings):
-  AssertEqual ' +:?&=', ale#path#FromURI('%20%2b%3a%3f%26%3d')
+Execute(ale#path#FromFileURI should decode percent encodings):
+  AssertEqual ' +:?&=', ale#path#FromFileURI('%20%2b%3a%3f%26%3d')
 
-Execute(ale#path#ToURI should handle UTF-8):
-  AssertEqual 'file:///T%c3%a9l%c3%a9chargement', ale#path#ToURI('/Téléchargement')
+Execute(ale#path#ToFileURI should handle UTF-8):
+  AssertEqual 'file:///T%c3%a9l%c3%a9chargement', ale#path#ToFileURI('/Téléchargement')
 
-Execute(ale#path#FromURI should handle UTF-8):
-  AssertEqual '/Téléchargement', ale#path#FromURI('file:///T%C3%A9l%C3%A9chargement')
+Execute(ale#path#FromFileURI should handle UTF-8):
+  AssertEqual '/Téléchargement', ale#path#FromFileURI('file:///T%C3%A9l%C3%A9chargement')

--- a/test/test_path_uri_jdt.vader
+++ b/test/test_path_uri_jdt.vader
@@ -1,5 +1,8 @@
-Execute(ale#path#FromURI should percent escape '/' in the query for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2F%5C%2Ffoo%5C%2Fbar%5C%2Fbaz.jar%3Cpackage.name(Type.class', ale#path#FromURI('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/%5C/foo%5C/bar%5C/baz.jar%3Cpackage.name(Type.class')
+Execute(ale#path#FromURI should percent escape ["*:<>|?\/], for ntfs, in the query for jdt://):
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#path#FromURI('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
 
-Execute(ale#path#ToURI should not escape anything for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2F%5C%2Ffoo%5C%2Fbar%5C%2Fbaz.jar<package.name(Type.class', ale#path#FromURI('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/%5C/foo%5C/bar%5C/baz.jar<package.name(Type.class')
+Execute(ale#path#FromURI should percent escape ["*:<>|?], for ntfs, in the auth/path?query for jdt://):
+  AssertEqual 'jdt://foo/ba%22%2a%3a%3c%3e\%7cr/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#path#FromURI('jdt://foo/ba"*:<>\|r/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
+
+Execute(ale#path#ToURI should only percent unescape [?], for ntfs, for jdt://):
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#path#ToURI('jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class')

--- a/test/test_path_uri_jdt.vader
+++ b/test/test_path_uri_jdt.vader
@@ -1,8 +1,0 @@
-Execute(ale#path#FromURI should percent escape ["*:<>|?\/], for ntfs, in the query for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#util#JDTToPath('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
-
-Execute(ale#path#FromURI should percent escape ["*:<>|?], for ntfs, in the auth/path?query for jdt://):
-  AssertEqual 'jdt://foo/ba%22%2a%3a%3c%3e\%7cr/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#util#JDTToPath('jdt://foo/ba"*:<>\|r/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
-
-Execute(ale#path#ToURI should only percent unescape [?], for ntfs, for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#util#PathToJDT('jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class')

--- a/test/test_path_uri_jdt.vader
+++ b/test/test_path_uri_jdt.vader
@@ -1,8 +1,8 @@
 Execute(ale#path#FromURI should percent escape ["*:<>|?\/], for ntfs, in the query for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale_linters#java#eclipselsp#JDTToPath('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#util#JDTToPath('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
 
 Execute(ale#path#FromURI should percent escape ["*:<>|?], for ntfs, in the auth/path?query for jdt://):
-  AssertEqual 'jdt://foo/ba%22%2a%3a%3c%3e\%7cr/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale_linters#java#eclipselsp#JDTToPath('jdt://foo/ba"*:<>\|r/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
+  AssertEqual 'jdt://foo/ba%22%2a%3a%3c%3e\%7cr/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#util#JDTToPath('jdt://foo/ba"*:<>\|r/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
 
 Execute(ale#path#ToURI should only percent unescape [?], for ntfs, for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale_linters#java#eclipselsp#PathToJDT('jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class')
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#util#PathToJDT('jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class')

--- a/test/test_path_uri_jdt.vader
+++ b/test/test_path_uri_jdt.vader
@@ -1,8 +1,8 @@
 Execute(ale#path#FromURI should percent escape ["*:<>|?\/], for ntfs, in the query for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#path#FromURI('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale_linters#java#eclipselsp#JDTToPath('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
 
 Execute(ale#path#FromURI should percent escape ["*:<>|?], for ntfs, in the auth/path?query for jdt://):
-  AssertEqual 'jdt://foo/ba%22%2a%3a%3c%3e\%7cr/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#path#FromURI('jdt://foo/ba"*:<>\|r/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
+  AssertEqual 'jdt://foo/ba%22%2a%3a%3c%3e\%7cr/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale_linters#java#eclipselsp#JDTToPath('jdt://foo/ba"*:<>\|r/baz.jar/package.name.Type.class?=proj/\/foo\/ba"*:<>\|r\/baz.jar<package.name(Type.class')
 
 Execute(ale#path#ToURI should only percent unescape [?], for ntfs, for jdt://):
-  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale#path#ToURI('jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class')
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class', ale_linters#java#eclipselsp#PathToJDT('jdt://foo/bar/baz.jar/package.name.Type.class%3f=proj%2f%5c%2ffoo%5c%2fba%22%2a%3a%3c%3e%5c%7cr%5c%2fbaz.jar%3cpackage.name(Type.class')

--- a/test/test_path_uri_jdt.vader
+++ b/test/test_path_uri_jdt.vader
@@ -1,0 +1,5 @@
+Execute(ale#path#FromURI should percent escape '/' in the query for jdt://):
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2F%5C%2Ffoo%5C%2Fbar%5C%2Fbaz.jar%3Cpackage.name(Type.class', ale#path#FromURI('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/%5C/foo%5C/bar%5C/baz.jar%3Cpackage.name(Type.class')
+
+Execute(ale#path#ToURI should not escape anything for jdt://):
+  AssertEqual 'jdt://foo/bar/baz.jar/package.name.Type.class?=proj%2F%5C%2Ffoo%5C%2Fbar%5C%2Fbaz.jar<package.name(Type.class', ale#path#FromURI('jdt://foo/bar/baz.jar/package.name.Type.class?=proj/%5C/foo%5C/bar%5C/baz.jar<package.name(Type.class')

--- a/test/test_rename.vader
+++ b/test/test_rename.vader
@@ -487,13 +487,13 @@ Execute(LSP rename requests should be sent):
   \ [
   \   [1, 'textDocument/didChange', {
   \     'textDocument': {
-  \         'uri': ale#path#ToURI(expand('%:p')),
+  \         'uri': ale#path#ToFileURI(expand('%:p')),
   \         'version': g:ale_lsp_next_version_id - 1,
   \     },
   \     'contentChanges': [{'text': join(getline(1, '$'), "\n") . "\n"}]
   \   }],
   \   [0, 'textDocument/rename', {
-  \   'textDocument': {'uri': ale#path#ToURI(expand('%:p'))},
+  \   'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
   \   'position': {'line': 0, 'character': 2},
   \   'newName': 'a-new-name',
   \   }],

--- a/test/test_symbol_search.vader
+++ b/test/test_symbol_search.vader
@@ -94,7 +94,7 @@ Execute(LSP symbol responses should be handled):
   \     {
   \       'name': 'foo',
   \       'location': {
-  \         'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
+  \         'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/completion_dummy_file')),
   \         'range': {
   \           'start': {'line': 2, 'character': 7},
   \         },
@@ -103,7 +103,7 @@ Execute(LSP symbol responses should be handled):
   \     {
   \       'name': 'foobar',
   \       'location': {
-  \         'uri': ale#path#ToURI(ale#path#Simplify(g:dir . '/other_file')),
+  \         'uri': ale#path#ToFileURI(ale#path#Simplify(g:dir . '/other_file')),
   \         'range': {
   \           'start': {'line': 7, 'character': 15},
   \         },


### PR DESCRIPTION
This adds jdt:// support in eclipselsp. I referred to #[https://github.com/neoclide/coc.nvim/issues/112](https://github.com/neoclide/coc.nvim/issues/112).

The tests are at `test/test_path_uri_jdt.vader`.

Let me know if there are changes needed.