### PR TITLE
Add CMake linter cmake-lint

### DIFF
--- a/ale_linters/cmake/cmake_lint.vim
+++ b/ale_linters/cmake/cmake_lint.vim
@@ -1,0 +1,41 @@
+" Author: Carl Smedstad <carl.smedstad at protonmail dot com>
+" Description: cmake-lint for cmake files
+
+let g:ale_cmake_cmake_lint_executable =
+\   get(g:, 'ale_cmake_cmake_lint_executable', 'cmake-lint')
+
+let g:ale_cmake_cmake_lint_options =
+\   get(g:, 'ale_cmake_cmake_lint_options', '')
+
+function! ale_linters#cmake#cmake_lint#Executable(buffer) abort
+    return ale#Var(a:buffer, 'cmake_cmake_lint_executable')
+endfunction
+
+function! ale_linters#cmake#cmake_lint#Command(buffer) abort
+    return ale_linters#cmake#cmake_lint#Executable(a:buffer)
+    \   . ' ' . ale#Var(a:buffer, 'cmake_cmake_lint_options') . ' %t'
+endfunction
+
+function! ale_linters#cmake#cmake_lint#Handle(buffer, lines) abort
+    let l:pattern = '\v^[^:]+:(\d+),?(\d+)?:\s\[([A-Z]\d+)\]\s(.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'type': 'W',
+        \   'code': l:match[3],
+        \   'text': l:match[4],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('cmake', {
+\   'name': 'cmake_lint',
+\   'executable': function('ale_linters#cmake#cmake_lint#Executable'),
+\   'command': function('ale_linters#cmake#cmake_lint#Command'),
+\   'callback': 'ale_linters#cmake#cmake_lint#Handle',
+\})

--- a/ale_linters/cmake/cmake_lint.vim
+++ b/ale_linters/cmake/cmake_lint.vim
@@ -12,8 +12,10 @@ function! ale_linters#cmake#cmake_lint#Executable(buffer) abort
 endfunction
 
 function! ale_linters#cmake#cmake_lint#Command(buffer) abort
-    return ale_linters#cmake#cmake_lint#Executable(a:buffer)
-    \   . ' ' . ale#Var(a:buffer, 'cmake_cmake_lint_options') . ' %t'
+    let l:executable = ale_linters#cmake#cmake_lint#Executable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'cmake_cmake_lint_options')
+
+    return ale#Escape(l:executable) . ' ' . l:options . ' %t'
 endfunction
 
 function! ale_linters#cmake#cmake_lint#Handle(buffer, lines) abort

--- a/doc/ale-cmake.txt
+++ b/doc/ale-cmake.txt
@@ -22,6 +22,25 @@ g:ale_cmake_cmakelint_options                   *g:ale_cmake_cmakelint_options*
 
 
 ===============================================================================
+cmake-lint                                                *ale-cmake-cmake-lint*
+
+g:ale_cmake_cmake_lint_executable            *g:ale_cmake_cmake_lint_executable*
+                                             *b:ale_cmake_cmake_lint_executable*
+  Type: |String|
+  Default: `'cmake-lint'`
+
+  This variable can be set to change the path the cmake-lint.
+
+
+g:ale_cmake_cmake_lint_options                  *g:ale_cmake_cmake_lint_options*
+                                                *b:ale_cmake_cmake_lint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to cmake-lint.
+
+
+===============================================================================
 cmake-format                                            *ale-cmake-cmakeformat*
 
 g:ale_cmake_cmakeformat_executable         *g:ale_cmake_cmakeformat_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -105,6 +105,7 @@ Notes:
   * `cfn-python-lint`
 * CMake
   * `cmake-format`
+  * `cmake-lint`
   * `cmakelint`
 * CoffeeScript
   * `coffee`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2752,6 +2752,7 @@ documented in additional help files.
     cfn-python-lint.......................|ale-cloudformation-cfn-python-lint|
   cmake...................................|ale-cmake-options|
     cmakelint.............................|ale-cmake-cmakelint|
+    cmake-lint............................|ale-cmake-cmake-lint|
     cmake-format..........................|ale-cmake-cmakeformat|
   cpp.....................................|ale-cpp-options|
     astyle................................|ale-cpp-astyle|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -114,6 +114,7 @@ formatting.
   * [cfn-python-lint](https://github.com/awslabs/cfn-python-lint)
 * CMake
   * [cmake-format](https://github.com/cheshirekow/cmake_format)
+  * [cmake-lint](https://github.com/cheshirekow/cmake_format)
   * [cmakelint](https://github.com/richq/cmake-lint)
 * CoffeeScript
   * [coffee](http://coffeescript.org/)

--- a/test/handler/test_cmake_lint_handler.vader
+++ b/test/handler/test_cmake_lint_handler.vader
@@ -1,0 +1,30 @@
+Before:
+  runtime ale_linters/cmake/cmake_lint.vim
+
+After:
+  Restore
+
+  call ale#linter#Reset()
+
+Execute(The cmake_lint handler should handle basic warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 126,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'code': 'C0301',
+  \     'text': 'Line too long (136/80)',
+  \   },
+  \   {
+  \     'lnum': 139,
+  \     'col': 4,
+  \     'type': 'W',
+  \     'code': 'C0113',
+  \     'text': 'Missing COMMENT in statement which allows it',
+  \   },
+  \ ],
+  \ ale_linters#cmake#cmake_lint#Handle(1, [
+  \   'CMakeLists.txt:126: [C0301] Line too long (136/80)',
+  \   'CMakeLists.txt:139,04: [C0113] Missing COMMENT in statement which allows it',
+  \ ])

--- a/test/linter/test_cmake_cmake_lint.vader
+++ b/test/linter/test_cmake_cmake_lint.vader
@@ -1,0 +1,13 @@
+Before:
+  call ale#assert#SetUpLinterTest('cmake', 'cmake_lint')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'cmake-lint', ale#Escape('cmake-lint') . '  %t'
+
+Execute(The executable should be configurable):
+  let g:ale_cmake_cmake_lint_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar') . '  %t'


### PR DESCRIPTION
Add support for the CMake linter cmake-lint provided by https://github.com/cheshirekow/cmake_format.

A bit unsure about the naming due to the conflict with the other linter for CMake.

Resolves #3396.