### PR TITLE
Add oelint-adv support

### DIFF
--- a/ale_linters/bitbake/oelint_adv.vim
+++ b/ale_linters/bitbake/oelint_adv.vim
@@ -1,0 +1,47 @@
+" Author: offa
+" Description: oelint-adv for BitBake files
+
+call ale#Set('bitbake_oelint_adv_executable', 'oelint-adv')
+call ale#Set('bitbake_oelint_adv_options', '')
+call ale#Set('bitbake_oelint_adv_config', '.oelint.cfg')
+
+function! ale_linters#bitbake#oelint_adv#Command(buffer) abort
+    let l:config_file = ale#path#FindNearestFile(a:buffer,
+    \    ale#Var(a:buffer, 'bitbake_oelint_adv_config'))
+
+    return ((!empty(l:config_file))
+    \    ? 'OELINT_CONFIG=' . ale#Escape(l:config_file) . ' '
+    \    : '')
+    \    . '%e --quiet '
+    \    . ale#Pad(ale#Var(a:buffer, 'bitbake_oelint_adv_options')) .  '%s'
+endfunction
+
+function! ale_linters#bitbake#oelint_adv#Handle(buffer, lines) abort
+    let l:pattern = '\v^(.+):(.+):(.+):(.+):(.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \    'lnum': str2nr(l:match[2]),
+        \    'type': l:match[3] is# 'error'
+        \          ? 'E' : (l:match[3] is# 'warning' ? 'W' : 'I'),
+        \    'text': StripAnsiCodes(l:match[5]),
+        \    'code': l:match[4]
+        \    })
+    endfor
+
+    return l:output
+endfunction
+
+function! StripAnsiCodes(line) abort
+    return substitute(a:line, '\e\[[0-9;]\+[mK]', '', 'g')
+endfunction
+
+call ale#linter#Define('bitbake', {
+\    'name': 'oelint_adv',
+\    'output_stream': 'both',
+\    'executable': {b -> ale#Var(b, 'bitbake_oelint_adv_executable')},
+\    'cwd': '%s:h',
+\    'command': function('ale_linters#bitbake#oelint_adv#Command'),
+\    'callback': 'ale_linters#bitbake#oelint_adv#Handle',
+\    })

--- a/doc/ale-bitbake.txt
+++ b/doc/ale-bitbake.txt
@@ -1,0 +1,31 @@
+===============================================================================
+ALE BitBake Integration                                   *ale-bitbake-options*
+
+
+===============================================================================
+oelint-adv                                             *ale-bitbake-oelint_adv*
+
+g:ale_bitbake_oelint_adv_executable       *g:ale_bitbake_oelint_adv_executable*
+
+  Type: |String|
+  Default: `'oelint-adv'`
+
+  This variable can be changed to use a different executable for oelint-adv.
+
+g:ale_bitbake_oelint_adv_options             *g:ale_bitbake_oelint_adv_options*
+
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to oelint-adv.
+
+  g:ale_bitbake_oelint_adv_config             *g:ale_bitbake_oelint_adv_config*
+
+  Type: |String|
+  Default: `'.oelint.cfg'`
+
+  This variable can be set to use a different config file.
+
+
+===============================================================================
+vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -52,6 +52,8 @@ Notes:
   * `buildifier`
 * BibTeX
   * `bibclean`
+* BitBake
+  * `oelint-adv`
 * Bourne Shell
   * `shell` (-n flag)
   * `shellcheck`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2721,6 +2721,8 @@ documented in additional help files.
     buildifier............................|ale-bazel-buildifier|
   bib.....................................|ale-bib-options|
     bibclean..............................|ale-bib-bibclean|
+  bitbake.................................|ale-bitbake-options|
+    oelint-adv............................|ale-bitbake-oelint_adv|
   c.......................................|ale-c-options|
     astyle................................|ale-c-astyle|
     cc....................................|ale-c-cc|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -61,6 +61,8 @@ formatting.
   * [buildifier](https://github.com/bazelbuild/buildtools)
 * BibTeX
   * [bibclean](http://ftp.math.utah.edu/pub/bibclean/)
+* BitBake
+  * [oelint-adv](https://github.com/priv-kweihmann/oelint-adv)
 * Bourne Shell
   * shell [-n flag](http://linux.die.net/man/1/sh)
   * [shellcheck](https://www.shellcheck.net/)

--- a/test/handler/test_bitbake_oelint_adv_handler.vader
+++ b/test/handler/test_bitbake_oelint_adv_handler.vader
@@ -1,0 +1,28 @@
+Before:
+  runtime ale_linters/bitbake/oelint_adv.vim
+
+After:
+  Restore
+
+  call ale#linter#Reset()
+
+Execute(The oelint_adv handler should handle warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1234,
+  \     'type': 'I',
+  \     'code': 'oelint.var.suggestedvar.BUGTRACKER',
+  \     'text': 'Variable ''BUGTRACKER'' should be set',
+  \   },
+  \   {
+  \     'lnum': 17,
+  \     'type': 'E',
+  \     'code': 'oelint.var.mandatoryvar.DESCRIPTION',
+  \     'text': 'Variable ''DESCRIPTION'' should be set',
+  \   },
+  \ ],
+  \ ale_linters#bitbake#oelint_adv#Handle(1, [
+  \   '/meta-x/recipes-y/example/example_1.0.bb:1234:info:oelint.var.suggestedvar.BUGTRACKER:Variable ''BUGTRACKER'' should be set',
+  \   '[31mexample2_1.1.bb:17:error:oelint.var.mandatoryvar.DESCRIPTION:Variable ''DESCRIPTION'' should be set[0m',
+  \ ])

--- a/test/linter/test_bitbake.vader
+++ b/test/linter/test_bitbake.vader
@@ -1,0 +1,13 @@
+Before:
+    call ale#assert#SetUpLinterTest('bitbake', 'oelint_adv')
+
+After:
+    call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+    AssertLinter 'oelint-adv', ale#Escape('oelint-adv') . ' --quiet %s'
+
+Execute(The executable should be configurable):
+    let b:ale_bitbake_oelint_adv_executable = 'xyz'
+
+    AssertLinter 'xyz', ale#Escape('xyz') . ' --quiet %s'


### PR DESCRIPTION
Adds support for [oelint-adv](https://github.com/priv-kweihmann/oelint-adv), a Yocto / OpenEmbedded BitBake recipe linter.
