### PR TITLE
Fix unhandled nix versions for linter 'nix'

### DIFF
--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -5,7 +5,7 @@
 function! ale_linters#nix#nix#Command(buffer, output, meta) abort
     let l:version = a:output[0][22:]
 
-    if l:version =~# '^\(2.4\|3\).*'
+    if l:version =~# '^\(2.[4-9]\|3\).*'
         return 'nix-instantiate --log-format internal-json --parse -'
     else
         return 'nix-instantiate --parse -'

--- a/test/handler/test_nix_handler.vader
+++ b/test/handler/test_nix_handler.vader
@@ -49,3 +49,43 @@ Execute(The nix handler should parse message from old nix-instantiate correctly)
   \   'error: syntax error, unexpected IN, at /path/to/filename.nix:23:14',
   \   'error: syntax error, unexpected ''='', expecting '';'', at /path/to/filename.nix:3:12',
   \ ])
+
+Execute(The nix command should not add 'log-format' option for nix version 2.3):
+  AssertEqual
+  \ 'nix-instantiate --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.3.0'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 2.4):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.4.1'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 2.5):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.5.0pre20211206_d1aaa7e'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 2.6):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.6.0pre20211206_ignored'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 2.7):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.7.0pre20211206_ignored'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 2.8):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.8.0pre20211206_ignored'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 2.9):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 2.9.0pre20211206_ignored'], '')
+
+Execute(The nix command should add 'log-format' option for nix version 3.0):
+  AssertEqual
+  \ 'nix-instantiate --log-format internal-json --parse -',
+  \ ale_linters#nix#nix#Command('', ['nix-instantiate (Nix) 3.0.0pre20211206_ignored'], '')


### PR DESCRIPTION
Previously, it would not generate any lint messages for nix 2.5.

Moreover, it would cause this error whenever the nix command is invoked, when paired with a custom `g:ale_command_wrapper`:

    Error detected while processing function <SNR>92_NeoVimCallback[29]..<lambda>27[
    1]..<SNR>90_ExitCallback[28]..ale_linters#nix#nix#Command:
    line    1:
    E684: list index out of range: 0

