### PR TITLE
Treat ale_open_list integer value as a threshold

### DIFF
--- a/autoload/ale/list.vim
+++ b/autoload/ale/list.vim
@@ -36,12 +36,22 @@ function! ale#list#IsQuickfixOpen() abort
 endfunction
 
 " Check if we should open the list, based on the save event being fired, and
-" that setting being on, or the setting just being set to `1`.
-function! s:ShouldOpen(buffer) abort
+" that setting being on, or that the error count is at least as high as the
+" setting when set to an integer value.
+function! s:ShouldOpen(buffer, loclist_len) abort
     let l:val = ale#Var(a:buffer, 'open_list')
     let l:saved = getbufvar(a:buffer, 'ale_save_event_fired', 0)
 
-    return l:val is 1 || (l:val is# 'on_save' && l:saved)
+    return l:val > 0 ? a:loclist_len >= l:val : l:val is# 'on_save' && l:saved
+endfunction
+
+" Check if we should close the list, based on the save event being fired, and
+" that setting being on, or the setting just being set to an integer value.
+function! s:ShouldClose(buffer) abort
+    let l:val = ale#Var(a:buffer, 'open_list')
+    let l:saved = getbufvar(a:buffer, 'ale_save_event_fired', 0)
+
+    return !((l:val >= 1) || (l:val is# 'on_save' && l:saved))
 endfunction
 
 function! s:Deduplicate(list) abort
@@ -122,9 +132,9 @@ function! s:SetListsImpl(timer_id, buffer, loclist) abort
 
     " Open a window to show the problems if we need to.
     "
-    " We'll check if the current buffer's List is not empty here, so the
-    " window will only be opened if the current buffer has problems.
-    if s:ShouldOpen(a:buffer) && !empty(a:loclist)
+    " ShouldOpen() checks if the current buffer has enough problems to be
+    " opened.
+    if s:ShouldOpen(a:buffer, len(a:loclist))
         let l:winnr = winnr()
         let l:mode = mode()
 
@@ -213,7 +223,7 @@ function! ale#list#SetLists(buffer, loclist) abort
 endfunction
 
 function! s:CloseWindowIfNeeded(buffer) abort
-    if ale#Var(a:buffer, 'keep_list_window_open') || !s:ShouldOpen(a:buffer)
+    if ale#Var(a:buffer, 'keep_list_window_open') || s:ShouldClose(a:buffer)
         return
     endif
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1793,6 +1793,9 @@ g:ale_open_list                                               *g:ale_open_list*
   loclist (|lopen|) or for the quickfix list instead if |g:ale_set_quickfix|
   is `1`. (|copen|)
 
+  When set to any higher numberical value, ALE will only open the window when
+  the number of warnings or errors are at least that many.
+
   When set to `'on_save'`, ALE will only open the loclist after buffers have
   been saved. The list will be opened some time after buffers are saved and
   any linter for a buffer returns results.

--- a/test/test_list_opening.vader
+++ b/test/test_list_opening.vader
@@ -97,6 +97,34 @@ Execute(The quickfix window should open for just the loclist):
   call ale#list#SetLists(bufnr('%'), [])
   Assert !ale#list#IsQuickfixOpen()
 
+Execute(The quickfix window should open on the correct threshold):
+  " The window should open for a value lower than number of entries.
+  let g:ale_open_list = len(g:loclist) - 1
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+  Assert ale#list#IsQuickfixOpen()
+
+  " Clear the list to be ready for a new value.
+  call ale#list#SetLists(bufnr('%'), [])
+  Assert !ale#list#IsQuickfixOpen()
+
+  " It should also open for a value equal to the number of entries.
+  let g:ale_open_list = len(g:loclist)
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+  Assert ale#list#IsQuickfixOpen()
+
+  " Clear the list again, preparing for a final value.
+  call ale#list#SetLists(bufnr('%'), [])
+  Assert !ale#list#IsQuickfixOpen()
+
+  " Window should not open for values higher than number of loclist entries.
+  let g:ale_open_list = len(g:loclist) + 1
+  call ale#list#SetLists(bufnr('%'), g:loclist)
+  Assert !ale#list#IsQuickfixOpen()
+
+  " Clear the list just to clean up.
+  call ale#list#SetLists(bufnr('%'), [])
+  Assert !ale#list#IsQuickfixOpen()
+
 Execute(The quickfix window height should be correct for the loclist):
   let g:ale_open_list = 1
   let g:ale_list_window_size = 7


### PR DESCRIPTION
Setting `ale_open_list = 1` is great when having multiple lints to address. Yet it is annoying as %#"¤ to use that setting when writing new code, as the window tends to open way too frequently.

This change makes this already numeric option possible to set to higher values, and doing so leads to only opening a list window if the number of warnings or errors equals to or exceeds the value. A typical useful value could be `ale_open_list = 2` which allows for typing a word to completion without getting a split buffer. One can imagine other thresholds being attractive for other use cases.

No change to functionality is intended when `ale_open_list` is set to the previously allowed values `0`, `1` and `on_save`.