### PR TITLE
Sometimes end_lnum and end_col are not present

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -391,8 +391,8 @@ function! s:OnReady(
             \               'character': l:nearest_error.col - 1,
             \           },
             \           'end': {
-            \               'line': l:nearest_error.end_lnum - 1,
-            \               'character': l:nearest_error.end_col,
+            \               'line': get(l:nearest_error, 'end_lnum', 1) - 1,
+            \               'character': get(l:nearest_error, 'end_col', 0)
             \           },
             \       },
             \   },


### PR DESCRIPTION
In some python projects using pyright it seems the end_lnum and end_col keys are not present in the nearest_error dictionary. This PR solves the problem by using get() instead of directly accessing the keys.