### PR TITLE
clangtidy supports build_dir and cpp_clangtidy_options at the same time

### DIFF
--- a/ale_linters/cpp/clangtidy.vim
+++ b/ale_linters/cpp/clangtidy.vim
@@ -16,20 +16,17 @@ call ale#Set('c_build_dir', '')
 function! ale_linters#cpp#clangtidy#GetCommand(buffer, output) abort
     let l:checks = join(ale#Var(a:buffer, 'cpp_clangtidy_checks'), ',')
     let l:build_dir = ale#c#GetBuildDirectory(a:buffer)
-    let l:options = ''
 
-    " Get the extra options if we couldn't find a build directory.
-    if empty(l:build_dir)
-        let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
-        let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
-        let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
+    " Get the extra options
+    let l:options = ale#Var(a:buffer, 'cpp_clangtidy_options')
+    let l:cflags = ale#c#GetCFlags(a:buffer, a:output)
+    let l:options .= !empty(l:options) ? ale#Pad(l:cflags) : l:cflags
 
-        " Tell clang-tidy a .h header with a C++ filetype in Vim is a C++ file
-        " only when compile-commands.json file is not there. Adding these
-        " flags makes clang-tidy completely ignore compile commmands.
-        if expand('#' . a:buffer) =~# '\.h$'
-            let l:options .= !empty(l:options) ? ' -x c++' : '-x c++'
-        endif
+    " Tell clang-tidy a .h header with a C++ filetype in Vim is a C++ file
+    " only when compile-commands.json file is not there. Adding these
+    " flags makes clang-tidy completely ignore compile commmands.
+    if expand('#' . a:buffer) =~# '\.h$'
+        let l:options .= !empty(l:options) ? ' -x c++' : '-x c++'
     endif
 
     " Get the options to pass directly to clang-tidy

--- a/test/linter/test_c_import_paths.vader
+++ b/test/linter/test_c_import_paths.vader
@@ -149,6 +149,7 @@ Execute(The C++ ClangTidy handler should include json folders for projects with 
   \ ale#Escape('clang-tidy')
   \   . ' %s '
   \   . '-p ' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/c/json_project/build'))
+  \   . ' -- -I' . ale#Escape(ale#path#Simplify(g:dir . '/../test-files/c/json_project/include'))
 
 Execute(The C++ ClangTidy handler should include 'include' directories for projects with a Makefile):
   call ale#assert#SetUpLinterTest('cpp', 'clangtidy')

--- a/test/linter/test_clang_tidy.vader
+++ b/test/linter/test_clang_tidy.vader
@@ -47,7 +47,7 @@ Execute(The build directory should be configurable):
   \   . ' -checks=' . ale#Escape('*') . ' %s'
   \   . ' -p ' . ale#Escape('/foo/bar')
 
-Execute(The build directory setting should override the options):
+Execute(The build directory setting should coexist with the options):
   let b:ale_cpp_clangtidy_checks = ['*']
   let b:ale_c_build_dir = '/foo/bar'
   let b:ale_cpp_clangtidy_options = '-Wall'
@@ -55,7 +55,7 @@ Execute(The build directory setting should override the options):
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy')
   \   . ' -checks=' . ale#Escape('*') . ' %s'
-  \   . ' -p ' . ale#Escape('/foo/bar')
+  \   . ' -p ' . ale#Escape('/foo/bar') . ' -- -Wall'
 
 Execute(The build directory should be used for header files):
   call ale#test#SetFilename('test.h')

--- a/test/linter/test_clang_tidy.vader
+++ b/test/linter/test_clang_tidy.vader
@@ -67,14 +67,14 @@ Execute(The build directory should be used for header files):
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy')
   \   . ' -checks=' . ale#Escape('*') . ' %s'
-  \   . ' -p ' . ale#Escape('/foo/bar')
+  \   . ' -p ' . ale#Escape('/foo/bar') . ' -- -Wall -x c++'
 
   call ale#test#SetFilename('test.hpp')
 
   AssertLinter 'clang-tidy',
   \ ale#Escape('clang-tidy')
   \   . ' -checks=' . ale#Escape('*') . ' %s'
-  \   . ' -p ' . ale#Escape('/foo/bar')
+  \   . ' -p ' . ale#Escape('/foo/bar') . ' -- -Wall'
 
 Execute(The executable should be configurable):
   let b:ale_cpp_clangtidy_checks = ['*']


### PR DESCRIPTION
Fixed https://github.com/dense-analysis/ale/issues/3118

## Manual test steps:
1. In the C++ project folder, create the `compile_commands.json`
2. In the C++ project folder, create the file `.vimrc` with content
```
let g:ale_cpp_clangtidy_options = ...
```
3. In `~/.vimrc` file, enable exrc feature
```
set exrc
set secure
```
4. In `~/.vim/ftplugin/cpp.vim`, enable linter and add buffer option
```
let b:ale_linters = ['clangtidy']
let b:ale_cpp_clangtidy_options = get(g:, 'ale_cpp_clangtidy_options', '') . ' -x c++'
```
5. Open any c++ header file or implementation file in the project, verify the configurations in `compile_commands.json`, `g:ale_cpp_clangtidy_options` and `b:ale_cpp_clangtidy_options` all take effect in `:ALEInfo`