### PR TITLE
Fix 4083 - do not remove completion items that have additional text e…

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -596,16 +596,6 @@ function! ale#completion#ParseLSPCompletions(response) abort
             continue
         endif
 
-        " Don't use LSP items with additional text edits when autoimport for
-        " completions is turned off.
-        if !empty(get(l:item, 'additionalTextEdits'))
-        \&& !(
-        \   get(l:info, 'additional_edits_only', 0)
-        \   || g:ale_completion_autoimport
-        \)
-            continue
-        endif
-
         let l:doc = get(l:item, 'documentation', '')
 
         if type(l:doc) is v:t_dict && has_key(l:doc, 'value')
@@ -629,6 +619,7 @@ function! ale#completion#ParseLSPCompletions(response) abort
 
         if has_key(l:item, 'additionalTextEdits')
         \ && l:item.additionalTextEdits isnot v:null
+        \ && (get(l:info, 'additional_edits_only', 0) || g:ale_completion_autoimport)
             let l:text_changes = []
 
             for l:edit in l:item.additionalTextEdits

--- a/test/completion/test_lsp_completion_parsing.vader
+++ b/test/completion/test_lsp_completion_parsing.vader
@@ -633,7 +633,17 @@ Execute(Should not handle completion messages with additionalTextEdits when ale_
   let b:ale_completion_info = {'line': 30}
 
   AssertEqual
-  \ [],
+  \ [
+  \   {
+  \     'word': 'next_callback',
+  \     'dup': 0,
+  \     'menu': 'PlayTimeCallback',
+  \     'info': '',
+  \     'kind': 'v',
+  \     'icase': 1,
+  \     'user_data': json_encode({'_ale_completion_item': 1}),
+  \   }
+  \ ],
   \ ale#completion#ParseLSPCompletions({
   \   'id': 226,
   \   'jsonrpc': '2.0',


### PR DESCRIPTION
Do not remove completion items if they have additional text edits and auto-import is off. But still only apply the additional edits if auto-import is on.

Fixes #4083