### PR TITLE
Document the use of author rewriting tools

### DIFF
--- a/doc/ale-development.txt
+++ b/doc/ale-development.txt
@@ -14,6 +14,7 @@ CONTENTS                                             *ale-development-contents*
     4.1. Writing Linter Tests.............|ale-development-linter-tests|
     4.2. Writing Fixer Tests..............|ale-development-fixer-tests|
     4.3. Running Tests in a Windows VM....|ale-development-windows-tests|
+  5. Contributing.........................|ale-development-contributing|
 
 ===============================================================================
 1. Introduction                                  *ale-development-introduction*
@@ -443,6 +444,24 @@ It will probably take several minutes for all of the tests to run. Be patient.
 You can run a specific test by passing the filename as an argument to the
 batch file, for example: `run-tests test/test_c_flag_parsing.vader` . This will
 give you results much more quickly.
+
+===============================================================================
+5. Contributing                                  *ale-development-contributing*
+
+All integration of new code into ALE is done through GitHub pull requests.
+Using that tool streamlines the process and minimizes the time and effort
+required to e.g. ensure test suites are run for every change.
+
+As for any project hosted by GitHub, the choice of platform demands every
+contributor to take care to setup an account and configure it accordingly.
+
+Due to details of our process, a difference to many other GitHub hosted
+projects is that contributors who wish to keep the author fields for their
+commits unaltered need to configure a public email address in their account
+and profile settings. See: https://docs.github.com/en/account-and-profile/
+
+Unless configuring GitHub to expose contact details, commits will be rewritten
+to appear by `USERNAME <RANDOM_NUMBER+USERNAME@users.noreply.github.com>` .
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
As a new contributor to ALE, it felt great to be able to help getting issues #1397, #1968 and #3160 closed.

Overall it was good to get #4050 and #4087 merged too, but I must say it was surprising to have those commits attributed to a non-descriptive random alias plus (less surprising) one of ALE's most valued maintainers, rather than the identifying details I used when pushing the commits.

Please consider merging something like this suggested sub-chapter, making future contributors informed about the specific quirks of ALE's merge process.

Adapting the process so that these phrasings became irrelevant would of course be my preference, but that's unlikely reasonable after weighing up all interests.