### PR TITLE
remove --vanilla option

### DIFF
--- a/autoload/ale/fixers/styler.vim
+++ b/autoload/ale/fixers/styler.vim
@@ -6,7 +6,7 @@ call ale#Set('r_styler_options', 'tidyverse_style()')
 
 function! ale#fixers#styler#Fix(buffer) abort
     return {
-    \   'command': 'Rscript --vanilla -e '
+    \   'command': 'Rscript -e '
     \       . '"suppressPackageStartupMessages(library(styler));'
     \       . 'style_file(commandArgs(TRUE), transformers = '
     \       . ale#Var(a:buffer, 'r_styler_options') . ')"'

--- a/autoload/ale/fixers/styler.vim
+++ b/autoload/ale/fixers/styler.vim
@@ -6,7 +6,7 @@ call ale#Set('r_styler_options', 'tidyverse_style()')
 
 function! ale#fixers#styler#Fix(buffer) abort
     return {
-    \   'command': 'Rscript -e '
+    \   'command': 'Rscript --no-save --no-restore --no-site-file --no-init-file -e '
     \       . '"suppressPackageStartupMessages(library(styler));'
     \       . 'style_file(commandArgs(TRUE), transformers = '
     \       . ale#Var(a:buffer, 'r_styler_options') . ')"'


### PR DESCRIPTION
With "--vanilla" option the Rscript does not read ~/.Renviron. In my case this file stores R_LIBS_USER variable which points to a user-installed R libraries (not system-wide).
My styler package is installed to my home directoy - and I think many people use install.packages(...) to his home directory (not only the default .libPaths()).
See a Q&A here: https://stackoverflow.com/questions/37970555/controversy-of-r-libs-user-path

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
