### PR TITLE
Enable autoimport by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,15 @@ completion manually with `<C-x><C-o>`.
 set omnifunc=ale#completion#OmniFunc
 ```
 
-ALE supports automatic imports from external modules. This behavior is disabled
-by default and can be enabled by setting:
+ALE supports automatic imports from external modules. This behavior is enabled
+by default and can be disabled by setting:
 
 ```vim
-let g:ale_completion_autoimport = 1
+let g:ale_completion_autoimport = 0
 ```
 
-See `:help ale-completion` for more information.
+Note that disabling auto import can result in missing completion items from some
+LSP servers (e.g. eclipselsp). See `:help ale-completion` for more information.
 
 <a name="usage-go-to-definition"></a>
 

--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -16,7 +16,7 @@ onoremap <silent> <Plug>(ale_show_completion_menu) <Nop>
 let g:ale_completion_delay = get(g:, 'ale_completion_delay', 100)
 let g:ale_completion_excluded_words = get(g:, 'ale_completion_excluded_words', [])
 let g:ale_completion_max_suggestions = get(g:, 'ale_completion_max_suggestions', 50)
-let g:ale_completion_autoimport = get(g:, 'ale_completion_autoimport', 0)
+let g:ale_completion_autoimport = get(g:, 'ale_completion_autoimport', 1)
 let g:ale_completion_tsserver_remove_warnings = get(g:, 'ale_completion_tsserver_remove_warnings', 0)
 
 let s:timer_id = -1

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -546,8 +546,10 @@ The |ALEComplete| command can be used to show completion suggestions manually,
 even when |g:ale_completion_enabled| is set to `0`. For manually requesting
 completion information with Deoplete, consult Deoplete's documentation.
 
-ALE by can support automatic imports from external modules. This behavior can
-be enabled by setting the |g:ale_completion_autoimport| variable to `1`.
+ALE supports automatic imports from external modules. This behavior can be
+disabled by setting the |g:ale_completion_autoimport| variable to `0`.
+Disabling automatic imports can drop some or all completion items from
+some LSP servers (e.g. eclipselsp).
 
 You can manually request imports for symbols at the cursor with the
 |ALEImport| command. The word at the cursor must be an exact match for some
@@ -862,11 +864,13 @@ g:ale_completion_tsserver_remove_warnings
 g:ale_completion_autoimport                       *g:ale_completion_autoimport*
 
   Type: Number
-  Default: `0`
+  Default: `1`
 
-  When this option is set to `0`, ALE will not try to automatically import
-  completion results from external modules. It can be enabled by setting it
-  to `1`.
+  When this option is set to `1`, ALE will try to automatically import
+  completion results from external modules. It can be disabled by setting it
+  to `0`. Some LSP servers include auto imports on every completion item so
+  disabling automatic imports may drop some or all completion items returnend
+  by it (e.g. eclipselsp).
 
 
 g:ale_completion_excluded_words               *g:ale_completion_excluded_words*


### PR DESCRIPTION
Based on this discussion https://github.com/dense-analysis/ale/pull/4084#pullrequestreview-897994843 the changes in this PR enable autoimport by default so auto completion works out of the box for more LSP servers (e.g. eclipselsp, javalsp).