### PR TITLE
Investigating fixing ALEImport

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -911,7 +911,8 @@ function! ale#completion#Import() abort
     endif
 
     let [l:line, l:column] = getpos('.')[1:2]
-    let l:column = searchpos('\V' . escape(l:word, '/\'), 'bn', l:line)[1]
+    let l:column = searchpos('\V' . escape(l:word, '/\'), 'bnc', l:line)[1]
+    let l:column = l:column + len(l:word) - 1
 
     if l:column isnot 0
         let l:started = ale#completion#GetCompletions('ale-import', {

--- a/test/completion/test_ale_import_command.vader
+++ b/test/completion/test_ale_import_command.vader
@@ -187,7 +187,7 @@ Execute(ALEImport should request imports correctly for tsserver):
   \   'conn_id': 0,
   \   'request_id': 0,
   \   'source': 'ale-import',
-  \   'column': 11,
+  \   'column': 21,
   \   'line': 2,
   \   'line_length': 21,
   \   'prefix': 'missingword',
@@ -206,7 +206,7 @@ Execute(ALEImport should request imports correctly for tsserver):
   \   'conn_id': 347,
   \   'request_id': 1,
   \   'source': 'ale-import',
-  \   'column': 11,
+  \   'column': 21,
   \   'line': 2,
   \   'line_length': 21,
   \   'prefix': 'missingword',
@@ -229,14 +229,14 @@ Execute(ALEImport should request imports correctly for tsserver):
   \   [0, 'ts@completions', {
   \     'file': expand('%:p'),
   \     'includeExternalModuleExports': 1,
-  \     'offset': 11,
+  \     'offset': 21,
   \     'line': 2,
   \     'prefix': 'missingword',
   \   }],
   \   [0, 'ts@completionEntryDetails', {
   \     'file': expand('%:p'),
   \     'entryNames': [{'name': 'missingword'}],
-  \     'offset': 11,
+  \     'offset': 21,
   \     'line': 2,
   \   }]
   \ ],
@@ -282,7 +282,7 @@ Execute(ALEImport should tell the user when no completions were found from tsser
   \   'conn_id': 0,
   \   'request_id': 0,
   \   'source': 'ale-import',
-  \   'column': 11,
+  \   'column': 21,
   \   'line': 2,
   \   'line_length': 21,
   \   'prefix': 'missingword',
@@ -301,7 +301,7 @@ Execute(ALEImport should tell the user when no completions were found from tsser
   \   'conn_id': 347,
   \   'request_id': 1,
   \   'source': 'ale-import',
-  \   'column': 11,
+  \   'column': 21,
   \   'line': 2,
   \   'line_length': 21,
   \   'prefix': 'missingword',
@@ -336,7 +336,7 @@ Execute(ALEImport should request imports correctly for language servers):
   \   'conn_id': 0,
   \   'request_id': 0,
   \   'source': 'ale-import',
-  \   'column': 7,
+  \   'column': 17,
   \   'line': 2,
   \   'line_length': 17,
   \   'prefix': 'missingword',
@@ -355,7 +355,7 @@ Execute(ALEImport should request imports correctly for language servers):
   \   'conn_id': 347,
   \   'request_id': 1,
   \   'source': 'ale-import',
-  \   'column': 7,
+  \   'column': 17,
   \   'line': 2,
   \   'line_length': 17,
   \   'prefix': 'missingword',
@@ -369,7 +369,7 @@ Execute(ALEImport should request imports correctly for language servers):
   \ [
   \   [0, 'textDocument/completion', {
   \     'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
-  \     'position': {'character': 6, 'line': 1}
+  \     'position': {'character': 16, 'line': 1}
   \   }],
   \ ],
   \ g:sent_message_list
@@ -482,7 +482,7 @@ Execute(ALEImport should tell the user when no completions were found from a lan
   \   'conn_id': 0,
   \   'request_id': 0,
   \   'source': 'ale-import',
-  \   'column': 7,
+  \   'column': 17,
   \   'line': 2,
   \   'line_length': 17,
   \   'prefix': 'missingword',
@@ -501,7 +501,7 @@ Execute(ALEImport should tell the user when no completions were found from a lan
   \   'conn_id': 347,
   \   'request_id': 1,
   \   'source': 'ale-import',
-  \   'column': 7,
+  \   'column': 17,
   \   'line': 2,
   \   'line_length': 17,
   \   'prefix': 'missingword',
@@ -515,7 +515,7 @@ Execute(ALEImport should tell the user when no completions were found from a lan
   \ [
   \   [0, 'textDocument/completion', {
   \     'textDocument': {'uri': ale#path#ToFileURI(expand('%:p'))},
-  \     'position': {'character': 6, 'line': 1}
+  \     'position': {'character': 16, 'line': 1}
   \   }],
   \ ],
   \ g:sent_message_list


### PR DESCRIPTION
Perhaps this might help fix ALEImport.

ALEImport currently does not work for me with eclipselsp. It seems to use the first character position of \<cword> to complete (in the position parameter of the textDocument/complete request message), which results in many completion items. When using the last character of \<cword> it seems to return only completion items that match \<cword>, instead of many words, perhaps all references in the source.

If using the first character matches all words in the source, then it will only be guaranteed to work (taking a long time) if the response has `{"isIncomplete": false}`. For example if the LSP response were to include all the words in the completion item list, and so it is incomplete, like this,
```
{"jsonrpc":"2.0","id":4,"result":{"isIncomplete":true, ...}
```
then there is a good chance \<cword> is not found in the results.

I have not looked at this extensively, but if what I have said above is true, then this would be a bug that this PR fixes. This PR seems to fix ALEImport for me.

---

Also, this might be a bug in the current version, which this patch would also fix:

If the cursor is on the first character of a word to import, it will not work, if using the current approach, one would have to use the "c" flag in searchpos (line 914 in `autoload/ale/completion.vim`):
```
let l:column = searchpos('\V' . escape(l:word, '/\'), 'bnc', l:line)[1]
```
instead of the current:
```
let l:column = searchpos('\V' . escape(l:word, '/\'), 'bn', l:line)[1]
```
Or use another method, such as what is in this PR.

---

Perhaps this is related to issue #4028.