### PR TITLE
Improve pylama linter output handling

### DIFF
--- a/ale_linters/python/pylama.vim
+++ b/ale_linters/python/pylama.vim
@@ -110,25 +110,26 @@ function! ale_linters#python#pylama#Handle(buffer, version, lines) abort
 
         for l:error in l:errors
             call add(l:output, {
-                        \   'lnum': l:error['lnum'],
-                        \   'col': l:error['col'],
-                        \   'code': l:error['number'],
-                        \   'type': get(l:pylint_type_to_ale_type, l:error['etype'], 'W'),
-                        \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:error['etype'], ''),
-                        \   'text': printf('%s [%s]', l:error['message'], l:error['source']),
-                        \})
+            \   'lnum': l:error['lnum'],
+            \   'col': l:error['col'],
+            \   'code': l:error['number'],
+            \   'type': get(l:pylint_type_to_ale_type, l:error['etype'], 'W'),
+            \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:error['etype'], ''),
+            \   'text': printf('%s [%s]', l:error['message'], l:error['source']),
+            \})
         endfor
     else
         let l:pattern = '\v^.{-}:([0-9]+):([0-9]+): +%(([A-Z][0-9]+):? +)?(.*)$'
+
         for l:match in ale#util#GetMatches(a:lines, l:pattern)
             call add(l:output, {
-                        \   'lnum': str2nr(l:match[1]),
-                        \   'col': str2nr(l:match[2]),
-                        \   'code': l:match[3],
-                        \   'type': get(l:pylint_type_to_ale_type, l:match[3][0], 'W'),
-                        \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:match[3][0], ''),
-                        \   'text': l:match[4],
-                        \})
+            \   'lnum': str2nr(l:match[1]),
+            \   'col': str2nr(l:match[2]),
+            \   'code': l:match[3],
+            \   'type': get(l:pylint_type_to_ale_type, l:match[3][0], 'W'),
+            \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:match[3][0], ''),
+            \   'text': l:match[4],
+            \})
         endfor
     endif
 

--- a/ale_linters/python/pylama.vim
+++ b/ale_linters/python/pylama.vim
@@ -22,6 +22,22 @@ function! ale_linters#python#pylama#GetExecutable(buffer) abort
     return ale#python#FindExecutable(a:buffer, 'python_pylama', ['pylama'])
 endfunction
 
+function! ale_linters#python#pylama#RunWithVersionCheck(buffer) abort
+    let l:executable = ale_linters#python#pylama#GetExecutable(a:buffer)
+    let l:exec_args = l:executable =~? 'pipenv\|poetry$'
+    \   ? ' run pylama'
+    \   : ''
+
+    let l:command = ale#Escape(l:executable) . l:exec_args . ' --version'
+
+    return ale#semver#RunWithVersionCheck(
+    \   a:buffer,
+    \   l:executable,
+    \   l:command,
+    \   function('ale_linters#python#pylama#GetCommand'),
+    \)
+endfunction
+
 function! ale_linters#python#pylama#GetCwd(buffer) abort
     if ale#Var(a:buffer, 'python_pylama_change_directory')
         " Pylama loads its configuration from the current directory only, and
@@ -35,10 +51,16 @@ function! ale_linters#python#pylama#GetCwd(buffer) abort
     return ''
 endfunction
 
-function! ale_linters#python#pylama#GetCommand(buffer) abort
+function! ale_linters#python#pylama#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#pylama#GetExecutable(a:buffer)
     let l:exec_args = l:executable =~? 'pipenv\|poetry$'
     \   ? ' run pylama'
+    \   : ''
+
+    " json format is added in version 8.1.4
+    " https://github.com/klen/pylama/blob/develop/Changelog
+    let l:format_json_args = ale#semver#GTE(a:version, [8, 1, 4])
+    \   ? ' --format json'
     \   : ''
 
     " Note: Using %t to lint changes would be preferable, but many pylama
@@ -46,16 +68,16 @@ function! ale_linters#python#pylama#GetCommand(buffer) abort
     " import beyond top, etc.).  Neither is ideal.
     return ale#Escape(l:executable) . l:exec_args
     \   . ale#Pad(ale#Var(a:buffer, 'python_pylama_options'))
+    \   . l:format_json_args
     \   . ' %s'
 endfunction
 
-function! ale_linters#python#pylama#Handle(buffer, lines) abort
+function! ale_linters#python#pylama#Handle(buffer, version, lines) abort
     if empty(a:lines)
         return []
     endif
 
     let l:output = ale#python#HandleTraceback(a:lines, 1)
-    let l:pattern = '\v^.{-}:([0-9]+):([0-9]+): +%(([A-Z][0-9]+):? +)?(.*)$'
 
     " First letter of error code is a pylint-compatible message type
     " http://pylint.pycqa.org/en/latest/user_guide/output.html#source-code-analysis-section
@@ -75,16 +97,40 @@ function! ale_linters#python#pylama#Handle(buffer, lines) abort
     \   'D': 'style',
     \}
 
-    for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        call add(l:output, {
-        \   'lnum': str2nr(l:match[1]),
-        \   'col': str2nr(l:match[2]),
-        \   'code': l:match[3],
-        \   'type': get(l:pylint_type_to_ale_type, l:match[3][0], 'W'),
-        \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:match[3][0], ''),
-        \   'text': l:match[4],
-        \})
-    endfor
+    if ale#semver#GTE(a:version, [8, 1, 4])
+        try
+            let l:errors = json_decode(join(a:lines, ''))
+        catch
+            return l:output
+        endtry
+
+        if empty(l:errors)
+            return l:output
+        endif
+
+        for l:error in l:errors
+            call add(l:output, {
+                        \   'lnum': l:error['lnum'],
+                        \   'col': l:error['col'],
+                        \   'code': l:error['number'],
+                        \   'type': get(l:pylint_type_to_ale_type, l:error['etype'], 'W'),
+                        \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:error['etype'], ''),
+                        \   'text': printf('%s [%s]', l:error['message'], l:error['source']),
+                        \})
+        endfor
+    else
+        let l:pattern = '\v^.{-}:([0-9]+):([0-9]+): +%(([A-Z][0-9]+):? +)?(.*)$'
+        for l:match in ale#util#GetMatches(a:lines, l:pattern)
+            call add(l:output, {
+                        \   'lnum': str2nr(l:match[1]),
+                        \   'col': str2nr(l:match[2]),
+                        \   'code': l:match[3],
+                        \   'type': get(l:pylint_type_to_ale_type, l:match[3][0], 'W'),
+                        \   'sub_type': get(l:pylint_type_to_ale_sub_type, l:match[3][0], ''),
+                        \   'text': l:match[4],
+                        \})
+        endfor
+    endif
 
     return l:output
 endfunction
@@ -93,7 +139,15 @@ call ale#linter#Define('python', {
 \   'name': 'pylama',
 \   'executable': function('ale_linters#python#pylama#GetExecutable'),
 \   'cwd': function('ale_linters#python#pylama#GetCwd'),
-\   'command': function('ale_linters#python#pylama#GetCommand'),
-\   'callback': 'ale_linters#python#pylama#Handle',
+\   'command': function('ale_linters#python#pylama#RunWithVersionCheck'),
+\   'callback': {buffer, lines -> ale#semver#RunWithVersionCheck(
+\       buffer,
+\       ale_linters#python#pylama#GetExecutable(buffer),
+\       '%e --version',
+\       {buffer, version -> ale_linters#python#pylama#Handle(
+\           buffer,
+\           l:version,
+\           lines)},
+\   )},
 \   'lint_file': 1,
 \})

--- a/test/handler/test_pylama_handler.vader
+++ b/test/handler/test_pylama_handler.vader
@@ -12,10 +12,13 @@ After:
 
   silent file something_else.py
 
-Execute(The pylama handler should handle no messages):
-  AssertEqual [], ale_linters#python#pylama#Handle(bufnr(''), [])
+Execute(The pylama handler should handle no messages with version older than 8.1.4):
+  AssertEqual [], ale_linters#python#pylama#Handle(bufnr(''), [8, 0, 5], [])
 
-Execute(The pylama handler should handle basic warnings and syntax errors):
+Execute(The pylama handler should handle no messages with version newer or equal than 8.1.4):
+  AssertEqual [], ale_linters#python#pylama#Handle(bufnr(''), [8, 2, 0], [])
+
+Execute(The pylama handler should handle basic warnings and syntax errors with version older than 8.1.4):
   AssertEqual
   \ [
   \   {
@@ -83,7 +86,7 @@ Execute(The pylama handler should handle basic warnings and syntax errors):
   \     'text': 'Invalid string quote ", should be '' [pylint]',
   \   },
   \ ],
-  \ ale_linters#python#pylama#Handle(bufnr(''), [
+  \ ale_linters#python#pylama#Handle(bufnr(''), [8, 0, 5], [
   \   'No config file found, using default configuration',
   \   'index.py:8:1: W0611 ''foo'' imported but unused [pyflakes]',
   \   'index.py:8:0: E0401 Unable to import ''foo'' [pylint]',
@@ -95,7 +98,79 @@ Execute(The pylama handler should handle basic warnings and syntax errors):
   \   'index.py:20:0: C4001 Invalid string quote ", should be '' [pylint]',
   \ ])
 
-Execute(The pylama handler should handle tracebacks with parsable messages):
+Execute(The pylama handler should handle basic warnings and syntax errors with version newer than 8.1.4):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 8,
+  \     'col': 1,
+  \     'code': 'W0611',
+  \     'type': 'W',
+  \     'sub_type': '',
+  \     'text': '''foo'' imported but unused [pyflakes]',
+  \   },
+  \   {
+  \     'lnum': 8,
+  \     'col': 0,
+  \     'code': 'E0401',
+  \     'type': 'E',
+  \     'sub_type': '',
+  \     'text': 'Unable to import ''foo'' [pylint]',
+  \   },
+  \   {
+  \     'lnum': 10,
+  \     'col': 1,
+  \     'code': 'E302',
+  \     'type': 'E',
+  \     'sub_type': '',
+  \     'text': 'expected 2 blank lines, found 1 [pycodestyle]',
+  \   },
+  \   {
+  \     'lnum': 11,
+  \     'col': 1,
+  \     'code': 'D401',
+  \     'type': 'W',
+  \     'sub_type': 'style',
+  \     'text': 'First line should be in imperative mood (''Get'', not ''Gets'') [pydocstyle]',
+  \   },
+  \   {
+  \     'lnum': 15,
+  \     'col': 81,
+  \     'code': 'E501',
+  \     'type': 'E',
+  \     'sub_type': '',
+  \     'text': 'line too long (96 > 80 characters) [pycodestyle]',
+  \   },
+  \   {
+  \     'lnum': 16,
+  \     'col': 1,
+  \     'code': 'D203',
+  \     'type': 'W',
+  \     'sub_type': 'style',
+  \     'text': '1 blank line required before class docstring (found 0) [pydocstyle]',
+  \   },
+  \   {
+  \     'lnum': 18,
+  \     'col': 1,
+  \     'code': 'D107',
+  \     'type': 'W',
+  \     'sub_type': 'style',
+  \     'text': 'Missing docstring in __init__ [pydocstyle]',
+  \   },
+  \   {
+  \     'lnum': 20,
+  \     'col': 0,
+  \     'code': 'C4001',
+  \     'type': 'W',
+  \     'sub_type': 'style',
+  \     'text': 'Invalid string quote ", should be '' [pylint]',
+  \   },
+  \ ],
+  \ ale_linters#python#pylama#Handle(bufnr(''), [8, 2, 0], [
+  \ '[{"source":"pyflakes","col":1,"lnum":8,"etype":"W","message":"''foo'' imported but unused","filename":"index.py","number":"W0611"},{"source":"pylint","col":0,"lnum":8,"etype":"E","message":"Unable to import ''foo''","filename":"index.py","number":"E0401"},{"source":"pycodestyle","col":1,"lnum":10,"etype":"E","message":"expected 2 blank lines, found 1","filename":"index.py","number":"E302"},{"source":"pydocstyle","col":1,"lnum":11,"etype":"D","message":"First line should be in imperative mood (''Get'', not ''Gets'')","filename":"index.py","number":"D401"},{"source":"pycodestyle","col":81,"lnum":15,"etype":"E","message":"line too long (96 > 80 characters)","filename":"index.py","number":"E501"},{"source":"pydocstyle","col":1,"lnum":16,"etype":"D","message":"1 blank line required before class docstring (found 0)","filename":"index.py","number":"D203"},{"source":"pydocstyle","col":1,"lnum":18,"etype":"D","message":"Missing docstring in __init__","filename":"index.py","number":"D107"},{"source":"pylint","col":0,"lnum":20,"etype":"C","message":"Invalid string quote \", should be ''","filename":"index.py","number":"C4001"}]',
+  \ ])
+
+Execute(The pylama handler should handle tracebacks with parsable messages with version older than 8.1.4):
   AssertEqual
   \ [
   \   {
@@ -135,7 +210,7 @@ Execute(The pylama handler should handle tracebacks with parsable messages):
   \     'text': 'line too long (96 > 80 characters) [pycodestyle]',
   \   },
   \ ],
-  \ ale_linters#python#pylama#Handle(bufnr(''), [
+  \ ale_linters#python#pylama#Handle(bufnr(''), [8, 0, 5], [
   \   'Traceback (most recent call last):',
   \   '  File "/usr/local/lib/python2.7/site-packages/pylama/core.py", line 66, in run',
   \   '    path, code=code, ignore=ignore, select=select, params=lparams)',
@@ -158,7 +233,7 @@ Execute(The pylama handler should handle tracebacks with parsable messages):
 " Note: This is probably a bug, since all pylama plugins produce codes, but
 " should be handled for compatibility.
 " Note: The pylama isort plugin is distributed in the isort package.
-Execute(The pylama handler should handle messages without codes):
+Execute(The pylama handler should handle messages without codes with version older than 8.1.4):
   AssertEqual
   \ [
   \   {
@@ -170,13 +245,13 @@ Execute(The pylama handler should handle messages without codes):
   \     'text': 'Incorrectly sorted imports. [isort]'
   \   },
   \ ],
-  \ ale_linters#python#pylama#Handle(bufnr(''), [
+  \ ale_linters#python#pylama#Handle(bufnr(''), [8, 0, 5], [
   \   'index.py:0:0: Incorrectly sorted imports. [isort]',
   \ ])
 
 " Note: This is a pylama bug, but should be handled for compatibility.
 " See https://github.com/klen/pylama/pull/146
-Execute(The pylama handler should handle message codes followed by a colon):
+Execute(The pylama handler should handle message codes followed by a colon with version older than 8.1.4):
   AssertEqual
   \ [
   \   {
@@ -188,6 +263,6 @@ Execute(The pylama handler should handle message codes followed by a colon):
   \     'text': 'Found commented out code: # needs_sphinx = ''1.0'' [eradicate]',
   \   },
   \ ],
-  \ ale_linters#python#pylama#Handle(bufnr(''), [
+  \ ale_linters#python#pylama#Handle(bufnr(''), [8, 0, 5], [
   \   'index.py:31:1: E800: Found commented out code: # needs_sphinx = ''1.0'' [eradicate]',
   \ ])


### PR DESCRIPTION
The current pattern for matching pylama output is:

    '\v^.{-}:([0-9]+):([0-9]+): +%(([A-Z][0-9]+):? +)?(.*)$'

By default, pylama output format looks like:

    samples/pylama.py:99:101 E501 line too long (189 > 100 characters) [pycodestyle]
    samples/pylama.py:104:101 E501 line too long (189 > 100 characters) [pycodestyle]
    samples/pylama.py:11:9  f-string is missing placeholders [pyflakes]
    samples/pylama.py:12:101 E501 line too long (150 > 100 characters) [pycodestyle]

Notice the there is no `:` in the first part of the output. It looks
like the linter expects pylama to a non-default `--format` option, or
pylama changed the default format at some point. pylama support
`--format json` that will produce following output:

    {
      "source": "pycodestyle",
      "col": 101,
      "lnum": 99,
      "etype": "E",
      "message": "line too long (189 > 100 characters)",
      "filename": "samples/pylama.py",
      "number": "E501"
    },
    {
      "source": "pycodestyle",
      "col": 101,
      "lnum": 104,
      "etype": "E",
      "message": "line too long (189 > 100 characters)",
      "filename": "samples/pylama.py",
      "number": "E501"
    },
    {
      "source": "pyflakes",
      "col": 9,
      "lnum": 11,
      "etype": "E",
      "message": "f-string is missing placeholders",
      "filename": "samples/pylama.py",
      "number": ""
    },
    {
      "source": "pycodestyle",
      "col": 101,
      "lnum": 12,
      "etype": "E",
      "message": "line too long (150 > 100 characters)",
      "filename": "samples/pylama.py",
      "number": "E501"
    }

This commit introduces following changes:

* forces pylama command to always use `--format json`. Not sure if this
  will cause any issues.

* use `json_decode` instead of regex to parse the errors