### PR TITLE
Add import menu for ALEImport for multiple matches

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -370,32 +370,31 @@ function! ale#completion#Show(result) abort
         return
     endif
 
-    " Replace completion options shortly before opening the menu.
-    if l:source is# 'ale-automatic' || l:source is# 'ale-manual'
-        call s:ReplaceCompletionOptions(l:source)
-
-        call timer_start(0, function('s:OpenCompletionMenu'))
-    endif
-
-    if l:source is# 'ale-callback'
-        call b:CompleteCallback(b:ale_completion_result)
-    endif
-
-    if l:source is# 'ale-import'
+    if l:source is# 'ale-import' && len(b:ale_completion_result) == 1
         call ale#completion#HandleUserData(b:ale_completion_result[0])
 
         let l:text_changed = '' . g:ale_lint_on_text_changed
 
         " Check the buffer again right away, if linting is enabled.
         if g:ale_enabled
-        \&& (
-        \   l:text_changed is# '1'
-        \   || l:text_changed is# 'always'
-        \   || l:text_changed is# 'normal'
-        \   || l:text_changed is# 'insert'
-        \)
+                    \&& (
+                    \   l:text_changed is# '1'
+                    \   || l:text_changed is# 'always'
+                    \   || l:text_changed is# 'normal'
+                    \   || l:text_changed is# 'insert'
+                    \)
             call ale#Queue(0, '')
         endif
+    elseif l:source is# 'ale-automatic' || l:source is# 'ale-manual' || l:source is# 'ale-import'
+        if l:source is# 'ale-import'
+            call feedkeys('ea', 'n')
+        endif
+
+        " Replace completion options shortly before opening the menu.
+        call s:ReplaceCompletionOptions(l:source)
+        call timer_start(0, function('s:OpenCompletionMenu'))
+    elseif l:source is# 'ale-callback'
+        call b:CompleteCallback(b:ale_completion_result)
     endif
 endfunction
 


### PR DESCRIPTION
This is one possible solution. Its a menu via echo. Perhaps temporary if another type of menu is preferred.

This PR is for the second out of the two commits on this branch, #74c0760.

For me, without the first commit, ALEImport does not even work (see PR #4105). Thus, dealing with PR #4105 first might be best.

This simply displays a menu if there are multiple names to import matching the selected name. In other words, this is a possible solution for issue #4085.

I am not sure if its worth it to write a test for `ale#util#Prompt` since it gets input from the user. I could rewrite it to make it more testable if you like.