### PR TITLE
Don't use temp file for clj-kondo

### DIFF
--- a/ale_linters/clojure/clj_kondo.vim
+++ b/ale_linters/clojure/clj_kondo.vim
@@ -8,7 +8,7 @@ function! ale_linters#clojure#clj_kondo#GetCommand(buffer) abort
 
     let l:command = 'clj-kondo'
     \   . ale#Pad(l:options)
-    \   . ' --lint %t'
+    \   . ' --lint %s'
 
     return l:command
 endfunction

--- a/test/linter/test_clj_kondo.vader
+++ b/test/linter/test_clj_kondo.vader
@@ -6,10 +6,10 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'clj-kondo', 'clj-kondo'
-  \   . ' --cache --lint %t'
+  \   . ' --cache --lint %s'
 
 Execute(Extra options should be supported):
   let g:ale_clojure_clj_kondo_options = '--config ./clj-kondo/config.edn'
 
   AssertLinter 'clj-kondo', 'clj-kondo'
-  \   . ' --config ./clj-kondo/config.edn --lint %t'
+  \   . ' --config ./clj-kondo/config.edn --lint %s'


### PR DESCRIPTION
clj-kondo since version 2022.03.04 has a check to for the namespace
declared in the file matching the actual file hierarchy, which now
always fails due to the file hierarchy generated for %t not matching the
file to be linted.  Since clj-kondo only reads the file, use %s instead
of %t to start it.

See: https://github.com/clj-kondo/clj-kondo/issues/1240