### PR TITLE
Make it possible to override awk --lint option

### DIFF
--- a/ale_linters/awk/gawk.vim
+++ b/ale_linters/awk/gawk.vim
@@ -9,8 +9,9 @@ function! ale_linters#awk#gawk#GetCommand(buffer) abort
     " gawk from attempting to execute the body of the script
     " it is linting.
     return '%e --source ' . ale#Escape('BEGIN { exit } END { exit 1 }')
+    \   . ' --lint'
     \   .  ale#Pad(ale#Var(a:buffer, 'awk_gawk_options'))
-    \   . ' -f %t --lint /dev/null'
+    \   . ' -f %t /dev/null'
 endfunction
 
 call ale#linter#Define('awk', {

--- a/test/linter/test_gawk.vader
+++ b/test/linter/test_gawk.vader
@@ -7,19 +7,19 @@ After:
 Execute(The default command should be correct):
   AssertLinter 'gawk',
   \ ale#Escape('gawk') . ' --source ' . ale#Escape('BEGIN { exit } END { exit 1 }')
-  \   . ' -f %t --lint /dev/null'
+  \   . ' --lint -f %t /dev/null'
 
 Execute(The executable should be configurable):
   let b:ale_awk_gawk_executable = '/other/gawk'
 
   AssertLinter '/other/gawk',
   \ ale#Escape('/other/gawk') . ' --source ' . ale#Escape('BEGIN { exit } END { exit 1 }')
-  \   . ' -f %t --lint /dev/null'
+  \   . ' --lint -f %t /dev/null'
 
 Execute(The options should be configurable):
   let b:ale_awk_gawk_executable = 'gawk'
-  let b:ale_awk_gawk_options = '--something'
+  let b:ale_awk_gawk_options = '--lint=no-ext'
 
   AssertLinter 'gawk',
   \ ale#Escape('gawk') . ' --source ' . ale#Escape('BEGIN { exit } END { exit 1 }')
-  \   . ' --something -f %t --lint /dev/null'
+  \   . ' --lint --lint=no-ext -f %t /dev/null'


### PR DESCRIPTION
Currently, it's not possible to override the awk `--lint` option with
```viml
let g:ale_awk_gawk_options = '--lint=no-ext'
```
altough this could be useful for those who only use gawk and don't want to get these lint errors:
> FEATURE X is a gawk extension

The idea is to move the default `--lint` option before the `awk_gawk_options` in the gawk.vim code to give the custom `--lint=...` option a higher precedence.

Updated & ran the tests.
