### PR TITLE
Set default value for insertTextFormat

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -581,7 +581,7 @@ function! ale#completion#ParseLSPCompletions(response) abort
             continue
         endif
 
-        if get(l:item, 'insertTextFormat') is s:LSP_INSERT_TEXT_FORMAT_PLAIN
+        if get(l:item, 'insertTextFormat', s:LSP_INSERT_TEXT_FORMAT_PLAIN) is s:LSP_INSERT_TEXT_FORMAT_PLAIN
         \&& type(get(l:item, 'textEdit')) is v:t_dict
             let l:text = l:item.textEdit.newText
         elseif type(get(l:item, 'insertText')) is v:t_string


### PR DESCRIPTION
As per the spec (https://microsoft.github.io/language-server-protocol/specification#textDocument_completion), `insertTextFormat` should default to `InsertTextFormat.PlainText` when ommited.

Unfortunately, I'm not very familiar with viml develpment and couldn't run the `./run-tests` script (I keep getting an error that the image is not known, even with `--build-image`), so I ended up not writing any tests nor checking if the current tests pass...