### PR TITLE
Add buf linter and fixer

### DIFF
--- a/ale_linters/proto/buf_lint.vim
+++ b/ale_linters/proto/buf_lint.vim
@@ -13,7 +13,8 @@ function! ale_linters#proto#buf_lint#GetCommand(buffer) abort
 endfunction
 
 call ale#linter#Define('proto', {
-\   'name': 'buf-lint',
+\   'name': 'buf_lint',
+\   'aliases': ['buf-lint'],
 \   'lint_file': 1,
 \   'output_stream': 'stdout',
 \   'executable': {b -> ale#Var(b, 'proto_buf_lint_executable')},

--- a/ale_linters/proto/buf_lint.vim
+++ b/ale_linters/proto/buf_lint.vim
@@ -1,0 +1,22 @@
+" Author: Alex McKinney <alexmckinney01@gmail.com>
+" Description: Run buf lint.
+
+call ale#Set('proto_buf_lint_executable', 'buf')
+call ale#Set('proto_buf_lint_config', '')
+
+function! ale_linters#proto#buf_lint#GetCommand(buffer) abort
+    let l:config = ale#Var(a:buffer, 'proto_buf_lint_config')
+
+    return '%e lint'
+    \ . (!empty(l:config) ? ' --config=' . ale#Escape(l:config) : '')
+    \ . ' %s#include_package_files=true'
+endfunction
+
+call ale#linter#Define('proto', {
+\   'name': 'buf-lint',
+\   'lint_file': 1,
+\   'output_stream': 'stdout',
+\   'executable': {b -> ale#Var(b, 'proto_buf_lint_executable')},
+\   'command': function('ale_linters#proto#buf_lint#GetCommand'),
+\   'callback': 'ale#handlers#unix#HandleAsError',
+\})

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -37,6 +37,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['python'],
 \       'description': 'Fix PEP8 issues with black.',
 \   },
+\   'buf-format': {
+\       'function': 'ale#fixers#buf_format#Fix',
+\       'suggested_filetypes': ['proto'],
+\       'description': 'Fix .proto files with buf format.',
+\   },
 \   'buildifier': {
 \       'function': 'ale#fixers#buildifier#Fix',
 \       'suggested_filetypes': ['bzl'],

--- a/autoload/ale/fixers/buf_format.vim
+++ b/autoload/ale/fixers/buf_format.vim
@@ -1,0 +1,12 @@
+" Author: Alex McKinney <alexmckinney01@gmail.com>
+" Description: Run buf format.
+
+call ale#Set('proto_buf_format_executable', 'buf')
+
+function! ale#fixers#buf_format#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'proto_buf_format_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' format %t',
+    \}
+endfunction

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -13,8 +13,22 @@ To enable `.proto` file linting, update |g:ale_linters| as appropriate:
 To enable `.proto` file fixing, update |g:ale_fixers| as appropriate:
 >
   " Enable linter for .proto files
-  let b:ale_fixers = {'proto': ['protolint']}
+  let b:ale_fixers = {'proto': ['buf-format', 'protolint']}
 <
+===============================================================================
+buf-format                                                *ale-proto-buf-format*
+
+  The formatter uses `buf`, a fully-featured Protobuf compiler that doesn't depend
+  on `protoc`. Make sure the `buf` binary is available in the system path, or
+  set ale_proto_buf_format_executable.
+
+g:ale_proto_buf_format_executable           *g:ale_proto_buf_format_executable*
+
+  Type: |String|
+  Default: 'buf'
+
+  This variable can be changed to modify the executable used for buf.
+
 ===============================================================================
 buf-lint                                                    *ale-proto-buf-lint*
 

--- a/doc/ale-proto.txt
+++ b/doc/ale-proto.txt
@@ -8,13 +8,37 @@ Integration Information
 To enable `.proto` file linting, update |g:ale_linters| as appropriate:
 >
   " Enable linter for .proto files
-  let g:ale_linters = {'proto': ['protoc-gen-lint', 'protolint']}
+  let g:ale_linters = {'proto': ['buf-lint', 'protoc-gen-lint', 'protolint']}
 
 To enable `.proto` file fixing, update |g:ale_fixers| as appropriate:
 >
   " Enable linter for .proto files
   let b:ale_fixers = {'proto': ['protolint']}
 <
+===============================================================================
+buf-lint                                                    *ale-proto-buf-lint*
+
+  The linter uses `buf`, a fully-featured Protobuf compiler that doesn't depend
+  on `protoc`. Make sure the `buf` binary is available in the system path, or
+  set ale_proto_buf_lint_executable.
+
+g:ale_proto_buf_lint_executable               *g:ale_proto_buf_lint_executable*
+
+  Type: |String|
+  Default: 'buf'
+
+  This variable can be changed to modify the executable used for buf.
+
+g:ale_proto_buf_lint_config                       *g:ale_proto_buf_lint_config*
+
+  Type: |String|
+  Default: `''`
+
+  A path to a buf configuration file.
+
+  The path to the configuration file can be an absolute path or a relative
+  path. ALE will search for the relative path in parent directories.
+
 ===============================================================================
 protoc-gen-lint                                      *ale-proto-protoc-gen-lint*
 

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -430,6 +430,7 @@ Notes:
 * Prolog
   * `swipl`
 * proto
+  * `buf-format`!!
   * `buf-lint`!!
   * `protoc-gen-lint`!!
   * `protolint`!!

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -430,6 +430,7 @@ Notes:
 * Prolog
   * `swipl`
 * proto
+  * `buf-lint`!!
   * `protoc-gen-lint`!!
   * `protolint`!!
 * Pug

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3058,6 +3058,7 @@ documented in additional help files.
   prolog..................................|ale-prolog-options|
     swipl.................................|ale-prolog-swipl|
   proto...................................|ale-proto-options|
+    buf-format............................|ale-proto-buf-format|
     buf-lint..............................|ale-proto-buf-lint|
     protoc-gen-lint.......................|ale-proto-protoc-gen-lint|
     protolint.............................|ale-proto-protolint|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3058,6 +3058,7 @@ documented in additional help files.
   prolog..................................|ale-prolog-options|
     swipl.................................|ale-prolog-swipl|
   proto...................................|ale-proto-options|
+    buf-lint..............................|ale-proto-buf-lint|
     protoc-gen-lint.......................|ale-proto-protoc-gen-lint|
     protolint.............................|ale-proto-protolint|
   pug.....................................|ale-pug-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -439,6 +439,7 @@ formatting.
 * Prolog
   * [swipl](https://github.com/SWI-Prolog/swipl-devel)
 * proto
+  * [buf-format](https://github.com/bufbuild/buf) :floppy_disk:
   * [buf-lint](https://github.com/bufbuild/buf) :floppy_disk:
   * [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) :floppy_disk:
   * [protolint](https://github.com/yoheimuta/protolint) :floppy_disk:

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -439,6 +439,7 @@ formatting.
 * Prolog
   * [swipl](https://github.com/SWI-Prolog/swipl-devel)
 * proto
+  * [buf-lint](https://github.com/bufbuild/buf) :floppy_disk:
   * [protoc-gen-lint](https://github.com/ckaznocha/protoc-gen-lint) :floppy_disk:
   * [protolint](https://github.com/yoheimuta/protolint) :floppy_disk:
 * Pug

--- a/test/fixers/test_buf_format_fixer_callback.vader
+++ b/test/fixers/test_buf_format_fixer_callback.vader
@@ -1,0 +1,21 @@
+Before:
+  Save g:ale_proto_buf_format_executable
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_proto_buf_format_executable = 'xxxinvalid'
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The buf-format callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/proto/testfile.proto')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid') . ' format  %t',
+  \ },
+  \ ale#fixers#buf_format#Fix(bufnr(''))

--- a/test/fixers/test_buf_format_fixer_callback.vader
+++ b/test/fixers/test_buf_format_fixer_callback.vader
@@ -16,6 +16,6 @@ Execute(The buf-format callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'command': ale#Escape('xxxinvalid') . ' format  %t',
+  \   'command': ale#Escape('xxxinvalid') . ' format %t',
   \ },
   \ ale#fixers#buf_format#Fix(bufnr(''))

--- a/test/linter/test_buf_lint.vader
+++ b/test/linter/test_buf_lint.vader
@@ -1,0 +1,22 @@
+Before:
+  call ale#assert#SetUpLinterTest('proto', 'buf-lint')
+  call ale#test#SetFilename('test.proto')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'buf-lint',
+  \ ale#Escape('buf')
+  \ . ' lint'
+  \ . ' %s#include_package_files=true'
+
+Execute(The callback should include any additional options):
+  let b:ale_proto_buf_lint_executable = '/tmp/buf'
+  let b:ale_proto_buf_lint_config = '/tmp/buf.yaml'
+
+  AssertLinter '/tmp/buf',
+  \ ale#Escape('/tmp/buf')
+  \ . ' lint'
+  \ . ' --config=' . ale#Escape('/tmp/buf.yaml')
+  \ . ' %s#include_package_files=true'

--- a/test/linter/test_buf_lint.vader
+++ b/test/linter/test_buf_lint.vader
@@ -1,12 +1,12 @@
 Before:
-  call ale#assert#SetUpLinterTest('proto', 'buf-lint')
+  call ale#assert#SetUpLinterTest('proto', 'buf_lint')
   call ale#test#SetFilename('test.proto')
 
 After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'buf-lint',
+  AssertLinter 'buf',
   \ ale#Escape('buf')
   \ . ' lint'
   \ . ' %s#include_package_files=true'

--- a/test/test-files/proto/testfile.proto
+++ b/test/test-files/proto/testfile.proto
@@ -1,0 +1,1 @@
+syntax = "proto3";

--- a/test/test-files/proto/testfile.proto
+++ b/test/test-files/proto/testfile.proto
@@ -1,1 +1,0 @@
-syntax = "proto3";


### PR DESCRIPTION
This adds the `buf lint` command as a linter and the `buf format` command as a fixer. The `buf lint` linter was previously published from our own [vim-buf](https://github.com/bufbuild/vim-buf) repository [here](https://github.com/bufbuild/vim-buf/blob/main/ale_linters/proto/buf_lint.vim), whereas the `buf format` fixer is completely new. We'd like both of them to exist in `ale` now that `buf` has a stable `v1` release.

I've included a description and test for each (pattern matching from what previously exists, e.g. `clang-format`, `dartfmt`, and `gofmt`). I've also verified that both work locally by pointing `vim-plug` to my local copy of `ale`.

I've used the following `.vimrc` configuration to test locally against `.proto` files:

```vim
let g:ale_linters = {
\   'proto': ['buf-lint'],
\}
let g:ale_lint_on_text_changed = 'never'
let g:ale_linters_explicit = 1

let g:ale_fixers = {
\   'proto': ['buf-format'],
\}
let g:ale_fix_on_save = 1
```