### PR TITLE
Fix end line number when it exceeds the file

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -347,6 +347,12 @@ function! ale#engine#FixLocList(buffer, linter_name, from_other_source, loclist)
 
         if has_key(l:old_item, 'end_lnum')
             let l:item.end_lnum = str2nr(l:old_item.end_lnum)
+
+            " When the error ends after the end of the file, put it at the
+            " end. This is only done for the current buffer.
+            if l:item.bufnr == a:buffer && l:item.end_lnum > l:last_line_number
+                let l:item.end_lnum = l:last_line_number
+            endif
         endif
 
         if has_key(l:old_item, 'sub_type')

--- a/test/test_loclist_corrections.vader
+++ b/test/test_loclist_corrections.vader
@@ -124,6 +124,7 @@ Execute(FixLocList should set items with lines beyond the end to the last line):
   \     'text': 'a',
   \     'lnum': 10,
   \     'col': 0,
+  \     'end_lnum': 10,
   \     'bufnr': bufnr('%'),
   \     'vcol': 0,
   \     'type': 'E',
@@ -135,7 +136,7 @@ Execute(FixLocList should set items with lines beyond the end to the last line):
   \   bufnr('%'),
   \   'foobar',
   \   0,
-  \   [{'text': 'a', 'lnum': 11}],
+  \   [{'text': 'a', 'lnum': 11, 'end_lnum': 12}],
   \ )
 
 Execute(FixLocList should move line 0 to line 1):
@@ -223,9 +224,9 @@ Execute(FixLocList should pass on end_lnum values):
   \ [
   \   {
   \     'text': 'a',
-  \     'lnum': 10,
+  \     'lnum': 7,
   \     'col': 10,
-  \     'end_lnum': 13,
+  \     'end_lnum': 10,
   \     'end_col': 12,
   \     'bufnr': bufnr('%'),
   \     'vcol': 0,
@@ -235,9 +236,9 @@ Execute(FixLocList should pass on end_lnum values):
   \   },
   \   {
   \     'text': 'a',
-  \     'lnum': 10,
+  \     'lnum': 7,
   \     'col': 11,
-  \     'end_lnum': 13,
+  \     'end_lnum': 10,
   \     'end_col': 12,
   \     'bufnr': bufnr('%'),
   \     'vcol': 0,
@@ -251,8 +252,8 @@ Execute(FixLocList should pass on end_lnum values):
   \   'foobar',
   \   0,
   \   [
-  \     {'text': 'a', 'lnum': '010', 'col': '010', 'end_col': '012', 'end_lnum': '013'},
-  \     {'text': 'a', 'lnum': '010', 'col': '011', 'end_col': 12, 'end_lnum': 13},
+  \     {'text': 'a', 'lnum': '07', 'col': '010', 'end_col': '012', 'end_lnum': '010'},
+  \     {'text': 'a', 'lnum': '07', 'col': '011', 'end_col': 12, 'end_lnum': 10},
   \   ],
   \ )
 


### PR DESCRIPTION
If the end of the error exceeds the file, set it to the last line, similarly as it is done with the beginning of the error.

This issue was noticed by vim getting killed because of out of memory. The reason was that rust-analyzer delivered a very large number for the end line of an error (4294967295) due to an underflow bug (rust-analyzer/rust-analyzer#11866). Ale fixed the beginning of the error to line 1 and then tried to generate a list of the lines to highlight (https://github.com/dense-analysis/ale/blob/v3.2.0/autoload/ale/highlight.vim#L80). This list is very large, actually so large that vim was automatically killed because it ran out of memory.

While I don't think Ale should add workarounds for all bugs in language servers, I do think that this fix is reasonable generic and can help to mitigate future memory usage issues with error ranges larger than the current file.