### PR TITLE
Add support for sending ALE's output to Neovim's diagnostics API

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -242,13 +242,15 @@ endfunction
 
 function! ale#engine#SendResultsToNeovimDiagnostics(buffer, loclist)
     if !has('nvim-0.6')
-        " We will warn the user on startup if they set
+        " We will warn the user on startup as well if they try to set
         " g:ale_send_to_neovim_diagnostics outside of a Neovim context.
         return
     endif
 
-    let SendDiagnostics = luaeval("require('diagnostics').sendAleResultsToDiagnostics")
-    call SendDiagnostics(a:buffer, a:loclist)
+    " Keep the Lua surface area really small in the VimL part of ALE,
+    " and just require the diagnostics.lua module on demand.
+    let l:SendDiagnostics = luaeval("require('diagnostics').sendAleResultsToDiagnostics")
+    call l:SendDiagnostics(a:buffer, a:loclist)
 endfunction
 
 function! s:RemapItemTypes(type_map, loclist) abort

--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -240,7 +240,7 @@ function! ale#engine#SetResults(buffer, loclist) abort
     endif
 endfunction
 
-function! ale#engine#SendResultsToNeovimDiagnostics(buffer, loclist)
+function! ale#engine#SendResultsToNeovimDiagnostics(buffer, loclist) abort
     if !has('nvim-0.6')
         " We will warn the user on startup as well if they try to set
         " g:ale_send_to_neovim_diagnostics outside of a Neovim context.
@@ -249,7 +249,7 @@ function! ale#engine#SendResultsToNeovimDiagnostics(buffer, loclist)
 
     " Keep the Lua surface area really small in the VimL part of ALE,
     " and just require the diagnostics.lua module on demand.
-    let l:SendDiagnostics = luaeval("require('diagnostics').sendAleResultsToDiagnostics")
+    let l:SendDiagnostics = luaeval('require("diagnostics").sendAleResultsToDiagnostics')
     call l:SendDiagnostics(a:buffer, a:loclist)
 endfunction
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1938,6 +1938,22 @@ g:ale_root                                                         *g:ale_root*
   LSP linter, it will not run.
 
 
+g:ale_send_to_neovim_diagnostics             *g:ale_send_to_neovim_diagnostics*
+
+  Type: Number
+  Default: 0
+
+  If enabled, this option will disable ALE's standard UI, and instead send
+  all linter output to Neovim's diagnostics API. This allows you to collect
+  errors from nvim-lsp, ALE, and anything else that uses diagnostics all in
+  one place.
+
+  To enable this option, set the value to 1.
+
+  This option requires Neovim 0.6+, as that version introduces the diagnostics
+  API.
+
+
 g:ale_set_balloons                                         *g:ale_set_balloons*
                                                            *b:ale_set_balloons*
 

--- a/lua/diagnostics.lua
+++ b/lua/diagnostics.lua
@@ -1,0 +1,46 @@
+local module = {}
+
+local ale_type_to_diagnostic_severity = {
+  E = vim.diagnostic.severity.ERROR,
+  W = vim.diagnostic.severity.WARN,
+  I = vim.diagnostic.severity.INFO
+}
+
+module.sendAleResultsToDiagnostics = function(buffer, loclist)
+  diagnostics = {}
+
+  -- Convert all the ALE loclist items to the shape that Neovim's diagnostic
+  -- API is expecting.
+  for _, location in ipairs(loclist) do
+    table.insert(
+      diagnostics,
+      -- All line numbers from ALE are 1-indexed, but all line numbers
+      -- in the diagnostics API are 0-indexed, so we have to subtract 1
+      -- to make this work.
+      {
+        lnum = location.lnum - 1,
+        -- Ending line number, or if we don't have one, just make it the same
+        -- as the starting line number
+        end_lnum = (location.end_lnum or location.lnum) - 1,
+        -- Which column does the error start on?
+        col = (location.col or 1) - 1,
+        -- end_col does *not* appear to need 1 subtracted, so we don't.
+        end_col = location.end_col,
+        -- Which severity: error, warning, or info?
+        severity = ale_type_to_diagnostic_severity[location.type] or "E",
+        -- The error message
+        message = location.text,
+        -- e.g. "rubocop"
+        source = location.linter_name,
+      }
+    )
+  end
+
+  vim.diagnostic.set(
+    vim.api.nvim_create_namespace('ale'),
+    buffer,
+    diagnostics
+  )
+end
+
+return module

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -191,6 +191,7 @@ let g:ale_popup_menu_enabled = get(g:, 'ale_popup_menu_enabled', has('gui_runnin
 let g:ale_send_to_neovim_diagnostics = get(g:, 'ale_send_to_neovim_diagnostics', 0)
 
 if g:ale_send_to_neovim_diagnostics && !has('nvim-0.6')
+    " no-custom-checks
     echoerr("Cannot set g:ale_send_to_neovim_diagnostics to 1 unless you are running Neovim 0.6+.")
 endif
 

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -192,7 +192,7 @@ let g:ale_send_to_neovim_diagnostics = get(g:, 'ale_send_to_neovim_diagnostics',
 
 if g:ale_send_to_neovim_diagnostics && !has('nvim-0.6')
     " no-custom-checks
-    echoerr("Cannot set g:ale_send_to_neovim_diagnostics to 1 unless you are running Neovim 0.6+.")
+    echoerr('Cannot set g:ale_send_to_neovim_diagnostics to 1 unless you are running Neovim 0.6+.')
 endif
 
 if g:ale_set_balloons is 1 || g:ale_set_balloons is# 'hover'

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -186,6 +186,14 @@ let g:ale_deno_executable = get(g:, 'ale_deno_executable', 'deno')
 " If 1, enable a popup menu for commands.
 let g:ale_popup_menu_enabled = get(g:, 'ale_popup_menu_enabled', has('gui_running'))
 
+" If 1, disables ALE's built in error display. Instead, all errors are piped
+" to Neovim's diagnostics API.
+let g:ale_send_to_neovim_diagnostics = get(g:, 'ale_send_to_neovim_diagnostics', 0)
+
+if g:ale_send_to_neovim_diagnostics && !has('nvim-0.6')
+    echoerr("Cannot set g:ale_send_to_neovim_diagnostics to 1 unless you are running Neovim 0.6+.")
+endif
+
 if g:ale_set_balloons is 1 || g:ale_set_balloons is# 'hover'
     call ale#balloon#Enable()
 endif


### PR DESCRIPTION
Hi @w0rp,

Here is a PR for the changes we discussed in #4005.

## Changes

* `g:ale_send_to_neovim_diagnostics = 0 | 1` as a configuration option
* When `g:ale_send_to_neovim_diagnostics` is enabled, we send ALE output to Neovim diagnostics
* A version check for Neovim 0.6+. We print an error if the config is set to `1` and the user is on an unsupported Vim version
* Documentation

## TODOs

- [ ] Fix off by 1 issue reported by @daliusd below
- [ ] Maybe good idea to add a test test_linting_sets_signs.vader or test_sign_placement.vader that tests ALE signs are disabled when neovim diagnostics are enabled.
- [ ] Also maybe add a test to test_cursor_warnings.vader that tests cursor messages is not echoed when neovim diagnostics are enabled.
- [ ] Figure out if it's OK to disable loclist/quickfix like we do currently
- [ ] Fix issue with `g:ale_virtualtext_cursor` reported below

## Screenshots

**Error on startup if you're not running Neovim 0.6+**
![image](https://user-images.githubusercontent.com/59429/161328074-6edddd53-7a28-4a59-a74f-944bf50ba489.png)

**ALE in the diagnostics API**
![image](https://user-images.githubusercontent.com/59429/161328107-bb835a6a-6d60-4bb5-b8df-603e3ee8618c.png)

**ALE in trouble.nvim's fix list**
![image](https://user-images.githubusercontent.com/59429/161328141-395ce93b-76c0-4ccd-a0a6-61704b70b6c0.png)

## Testing

