### PR TITLE
Append one more absolute pattern.

### DIFF
--- a/autoload/ale/path.vim
+++ b/autoload/ale/path.vim
@@ -119,8 +119,8 @@ function! ale#path#IsAbsolute(filename) abort
         return 1
     endif
 
-    " Check for /foo and C:\foo, etc.
-    return a:filename[:0] is# '/' || a:filename[1:2] is# ':\'
+    " Check for /foo, C:\foo and C:/foo, etc.
+    return a:filename[:0] is# '/' || a:filename[1:2] is# ':\' || a:filename[1:2] is# ':/'
 endfunction
 
 let s:temp_dir = ale#path#Simplify(fnamemodify(ale#util#Tempname(), ':h:h'))


### PR DESCRIPTION
I'm on windows and all the file paths in compile_commands.json generated by cmake are begin with `F:/`.


> Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!
> 
> Seriously, read `:help ale-dev` and write tests.

Seems no test for function ale#path#IsAbsolute in repo.
