### PR TITLE
Fix 4141 - Stop press enter prompt on long diagnostic messages

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -11,9 +11,9 @@ let g:ale_echo_msg_format = get(g:, 'ale_echo_msg_format', '%code: %%s')
 let s:cursor_timer = -1
 
 " A wrapper for echon so we can test messages we echo in Vader tests.
-function! ale#cursor#Echon(message) abort
+function! ale#cursor#Echom(message) abort
     " no-custom-checks
-    echon a:message
+    exec "norm! :echom a:message\n"
 endfunction
 
 function! ale#cursor#TruncatedEcho(original_message) abort
@@ -36,14 +36,7 @@ function! ale#cursor#TruncatedEcho(original_message) abort
         silent! setlocal shortmess+=T
 
         try
-            " echon will not display the message if it exceeds the width of
-            " the window
-            if &columns < strdisplaywidth(l:message)
-                " Truncate message longer than window width with trailing '...'
-                let l:message = l:message[:&columns - 5] . '...'
-            endif
-
-            call ale#cursor#Echon(l:message)
+            call ale#cursor#Echom(l:message)
         catch /^Vim\%((\a\+)\)\=:E523/
             " Fallback into manual truncate (#1987)
             let l:winwidth = winwidth(0)

--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -231,7 +231,11 @@ function! ale#hover#HandleLSPResponse(conn_id, response) abort
             \&& (l:set_balloons is 1 || l:set_balloons is# 'hover')
                 call balloon_show(join(l:lines, "\n"))
             elseif get(l:options, 'truncated_echo', 0)
-                call ale#cursor#TruncatedEcho(join(l:lines[0], '\n'))
+                if type(l:lines[0]) is# v:t_list
+                    call ale#cursor#TruncatedEcho(join(l:lines[0], '\n'))
+                else
+                    call ale#cursor#TruncatedEcho(l:lines[0])
+                endif
             elseif g:ale_hover_to_floating_preview || g:ale_floating_preview
                 call ale#floating_preview#Show(l:lines, {
                 \   'filetype': 'ale-preview.message',

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -89,7 +89,7 @@ Before:
 
   let g:last_message = ''
 
-  function! ale#cursor#Echon(message) abort
+  function! ale#cursor#Echom(message) abort
     let g:last_message = a:message
   endfunction
 


### PR DESCRIPTION
This fixes the recent issue that prompts users to press enter when the cursor is on a line with a long error diagsotic message (#4141).

This revert the change back in #3888 that replaced echom with echon to avoid poluting the `message-history`. Unfortunatelly echon does not seem to honor the "shortmess=+T" option that truncates messages and the manual trucation based on &column did not work properly as evident by how many people were affected with #4141.

Note I tried fixing the manual truncation in different ways to keep the echon but it always failed in some way. The only sure way was to revert to using echom with the shortmess=+T and let vim take care of the truncation.

Actually long ago there was some discussion on this: https://github.com/dense-analysis/ale/pull/1987#issuecomment-428864872

> Manually truncating the text is difficult because there's no way to accurately measure how wide text will be, given different fonts.
