### PR TITLE
Handle ghc panic in haskell

### DIFF
--- a/autoload/ale/handlers/haskell.vim
+++ b/autoload/ale/handlers/haskell.vim
@@ -19,7 +19,7 @@ let s:temp_regex_prefix =
 \   . substitute(s:temp_dir, '\\', '\\\\', 'g')
 \   . '\.\{-}'
 
-function! s:panic_output(lines) abort
+function! s:PanicOutput(lines) abort
     return [{
     \   'lnum': 1,
     \   'col': 1,
@@ -49,7 +49,7 @@ function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
     let l:panic_end = match(a:lines,'Please report this as a GHC bug:')
 
     if l:panic_position >= 0
-        return s:panic_output(a:lines[l:panic_position : l:panic_end])
+        return s:PanicOutput(a:lines[l:panic_position : l:panic_end])
     endif
 
     " Group the lines into smaller lists.

--- a/autoload/ale/handlers/haskell.vim
+++ b/autoload/ale/handlers/haskell.vim
@@ -19,6 +19,16 @@ let s:temp_regex_prefix =
 \   . substitute(s:temp_dir, '\\', '\\\\', 'g')
 \   . '\.\{-}'
 
+function! s:panic_output(lines) abort
+    return [{
+    \   'lnum': 1,
+    \   'col': 1,
+    \   'text': 'ghc panic!',
+    \   'type': 'E',
+    \   'detail' : join(a:lines, "\n"),
+    \}]
+endfunction
+
 function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
     " Look for lines like the following.
     "
@@ -33,6 +43,14 @@ function! ale#handlers#haskell#HandleGHCFormat(buffer, lines) abort
     let l:output = []
 
     let l:corrected_lines = []
+
+    " If ghc panic error, put the whole message in details and exit.
+    let l:panic_position = match(a:lines,'ghc: panic!')
+    let l:panic_end = match(a:lines,'Please report this as a GHC bug:')
+
+    if l:panic_position >= 0
+        return s:panic_output(a:lines[l:panic_position : l:panic_end])
+    endif
 
     " Group the lines into smaller lists.
     for l:line in a:lines

--- a/test/handler/test_ghc_handler.vader
+++ b/test/handler/test_ghc_handler.vader
@@ -130,3 +130,48 @@ Execute(The ghc handler should handle stack 1.5.1 output):
   \   '    160 | pattern F :: Exp a',
   \   '        |              ^^^^^',
   \ ])
+
+Execute(The ghc handler should handle ghc panic):
+  let g:detail = [
+    \      '[15 of 15] Compiling SizedTypes.List',
+    \      'ghc: panic! (the ''impossible'' happened)',
+    \      '  (GHC version 8.10.3:',
+    \      '	src/SizedTypes/List.hs:(46,19)-(50,0) Specified type does not refine Haskell type for `SizedTypes.List.out` (Plugged Init types new)',
+    \      '                                      The Liquid type',
+    \      '                                      .',
+    \      '                                          GHC.Types.Int -> (SizedTypes.List.List a) -> (_, (SizedTypes.List.List a))',
+    \      '                                      .',
+    \      '                                      is inconsistent with the Haskell type',
+    \      '                                      .',
+    \      '                                          forall p a ->',
+    \      'p -> SizedTypes.List.List a -> (a, SizedTypes.List.List a)',
+    \      '                                      .',
+    \      '                                      defined at src/SizedTypes/List.hs:52:1-3',
+    \      '                                      .',
+    \      '                                      Specifically, the Liquid component',
+    \      '                                      .',
+    \      '                                          {VV##0 : GHC.Types.Int | VV##0 >= 0}',
+    \      '                                      .',
+    \      '                                      is inconsistent with the Haskell component',
+    \      '                                      .',
+    \      '                                          p',
+    \      '                                      .',
+    \      '                                      ',
+    \      '                                      HINT: Use the hole ''_'' instead of the mismatched component (in the Liquid specification)',
+    \      '',
+    \      'Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug',
+    \      '',
+    \      ''
+  \ ]
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'ghc panic!',
+  \     'detail': join(g:detail[1:-3], "\n"),
+  \   },
+  \ ],
+  \ ale#handlers#haskell#HandleGHCFormat(bufnr(''), g:detail)
+  unlet g:detail


### PR DESCRIPTION
Primitive handling for **ghc: panic!** (compiler error): Just put everything on detail and location at start of file (1,1). 

It is not very sophisticated, but the current behaviour on **ghc: panic!** is identical to not having errors.