### PR TITLE
Add the buffer-local options 'b:ale_shell' and 'b:ale_shell_arguments'.

### DIFF
--- a/autoload/ale/job.vim
+++ b/autoload/ale/job.vim
@@ -187,10 +187,16 @@ function! ale#job#PrepareCommand(buffer, command) abort
     \ : a:command
 
     " If a custom shell is specified, use that.
-    if exists('g:ale_shell')
-        let l:shell_arguments = get(g:, 'ale_shell_arguments', &shellcmdflag)
+    if exists('b:ale_shell')
+        let l:ale_shell = b:ale_shell
+    elseif exists('g:ale_shell')
+        let l:ale_shell = g:ale_shell
+    endif
 
-        return split(g:ale_shell) + split(l:shell_arguments) + [l:command]
+    if exists('l:ale_shell')
+        let l:shell_arguments = get(b:, 'ale_shell_arguments', get(g:, 'ale_shell_arguments', &shellcmdflag))
+
+        return split(l:ale_shell) + split(l:shell_arguments) + [l:command]
     endif
 
     if has('win32')

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2093,6 +2093,7 @@ g:ale_sign_priority                                       *g:ale_sign_priority*
 
 
 g:ale_shell                                                       *g:ale_shell*
+                                                                  *b:ale_shell*
 
   Type: |String|
   Default: not set
@@ -2110,6 +2111,7 @@ g:ale_shell                                                       *g:ale_shell*
 
 
 g:ale_shell_arguments                                   *g:ale_shell_arguments*
+                                                        *b:ale_shell_arguments*
 
   Type: |String|
   Default: not set

--- a/test/test_prepare_command.vader
+++ b/test/test_prepare_command.vader
@@ -4,6 +4,12 @@ Before:
   Save g:ale_shell
   Save g:ale_shell_arguments
 
+  Save b:ale_shell
+  Save b:ale_shell_arguments
+
+  unlet! b:ale_shell
+  unlet! b:ale_shell_arguments
+
   unlet! g:ale_shell
   unlet! g:ale_shell_arguments
 
@@ -61,7 +67,7 @@ Execute(cmd /s/c as a string should be used on Windows):
     AssertEqual 'cmd /s/c "foobar"', ale#job#PrepareCommand(bufnr(''), 'foobar')
   endif
 
-Execute(Setting ale_shell should cause ale#job#PrepareCommand to use set shell):
+Execute(Setting g:ale_shell should cause ale#job#PrepareCommand to use set shell):
   let g:ale_shell = '/foo/bar'
 
   if has('win32')
@@ -71,5 +77,20 @@ Execute(Setting ale_shell should cause ale#job#PrepareCommand to use set shell):
   endif
 
   let g:ale_shell_arguments = '-x'
+
+  AssertEqual ['/foo/bar', '-x', 'foobar'], ale#job#PrepareCommand(bufnr(''), "foobar")
+
+Execute(Setting b:ale_shell should cause ale#job#PrepareCommand to use set shell):
+  let g:ale_shell = '/wrong/foo/bar'
+  let b:ale_shell = '/foo/bar'
+
+  if has('win32')
+    AssertEqual ['/foo/bar', '/c', 'foobar'], ale#job#PrepareCommand(bufnr(''), "foobar")
+  else
+    AssertEqual ['/foo/bar', '-c', 'foobar'], ale#job#PrepareCommand(bufnr(''), "foobar")
+  endif
+
+  let g:ale_shell_arguments = '--verbose -x'
+  let b:ale_shell_arguments = '-x'
 
   AssertEqual ['/foo/bar', '-x', 'foobar'], ale#job#PrepareCommand(bufnr(''), "foobar")


### PR DESCRIPTION
This pull request adds the following buffer-local options:
- `b:ale_shell`: the buffer-local version of `g:ale_shell`.
- `b:ale_shell_arguments`: the buffer-local version of `b:ale_shell_arguments`.