### PR TITLE
Fix 3837 - update test to use latest vim 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM testbed/vim:20
 
 RUN install_vim -tag v8.0.0027 -build \
-                -tag v8.2.2401 -build \
+                -tag v8.2.4693 -build \
                 -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.6.1 -build
 


### PR DESCRIPTION
Update tests to use a more recent vim 8.2 patch (v8.2.4693).