### PR TITLE
Fallback to summary field if detail exists but is empty in terraform linter

### DIFF
--- a/ale_linters/terraform/terraform.vim
+++ b/ale_linters/terraform/terraform.vim
@@ -21,7 +21,12 @@ function! ale_linters#terraform#terraform#GetType(severity) abort
 endfunction
 
 function! ale_linters#terraform#terraform#GetDetail(error) abort
-    return get(a:error, 'detail', get(a:error, 'summary', ''))
+    let l:detail = get(a:error, 'detail', '')
+    if strlen(l:detail) > 0
+        return l:detail
+    else
+        return get(a:error, 'summary', '')
+    endif
 endfunction
 
 function! ale_linters#terraform#terraform#Handle(buffer, lines) abort

--- a/ale_linters/terraform/terraform.vim
+++ b/ale_linters/terraform/terraform.vim
@@ -22,6 +22,7 @@ endfunction
 
 function! ale_linters#terraform#terraform#GetDetail(error) abort
     let l:detail = get(a:error, 'detail', '')
+    
     if strlen(l:detail) > 0
         return l:detail
     else

--- a/ale_linters/terraform/terraform.vim
+++ b/ale_linters/terraform/terraform.vim
@@ -22,7 +22,7 @@ endfunction
 
 function! ale_linters#terraform#terraform#GetDetail(error) abort
     let l:detail = get(a:error, 'detail', '')
-    
+
     if strlen(l:detail) > 0
         return l:detail
     else

--- a/test/handler/test_terraform_handler.vader
+++ b/test/handler/test_terraform_handler.vader
@@ -97,3 +97,42 @@ Execute(Should use summary if detail not available):
   \ '  ]',
   \ '}'
   \ ])
+
+Execute(Should use summary if detail available but empty):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 91,
+  \     'col': 41,
+  \     'filename': ale#path#Simplify(g:dir . '/main.tf'),
+  \     'type': 'E',
+  \     'text': 'storage_os_disk: required field is not set',
+  \   }
+  \ ],
+  \ ale_linters#terraform#terraform#Handle(bufnr(''), [
+  \ '{',
+  \ '  "valid": false,',
+  \ '  "error_count": 1,',
+  \ '  "warning_count": 0,',
+  \ '  "diagnostics": [',
+  \ '    {',
+  \ '      "severity": "error",',
+  \ '      "summary": "storage_os_disk: required field is not set",',
+  \ '      "detail": "",',
+  \ '      "range": {',
+  \ '        "filename": "main.tf",',
+  \ '        "start": {',
+  \ '          "line": 91,',
+  \ '          "column": 41,',
+  \ '          "byte": 2381',
+  \ '        },',
+  \ '        "end": {',
+  \ '          "line": 91,',
+  \ '          "column": 41,',
+  \ '          "byte": 2381',
+  \ '        }',
+  \ '      }',
+  \ '    }',
+  \ '  ]',
+  \ '}'
+  \ ])


### PR DESCRIPTION
Terraform linter incorrectly chooses empty detail field for message when both summary and detail fields exist in `terraform validate` output, but detail is empty. Example problematic output from `terraform validate` command:
```
{
  "format_version": "1.0",
  "valid": false,
  "error_count": 1,
  "warning_count": 0,
  "diagnostics": [
    {
      "severity": "error",
      "summary": "registry.terraform.io/hashicorp/aws: there is no package for registry.terraform.io/hashicorp/aws 4.9.0 cached in .terraform/providers",
      "detail": ""
    }
  ]
}
```
This PR fixes this by checking if detail is not empty before returning it.
