### PR TITLE
Fixes for ALECodeAction and rust-analyzer

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -458,6 +458,7 @@ function! s:ExecuteGetCodeFix(linter, range, MenuCallback) abort
     endif
 
     let l:column = min([l:column, len(getline(l:line))])
+    let l:column = max([l:column, 1])
     let l:end_column = min([l:end_column, len(getline(l:end_line))])
 
     let l:Callback = function(

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -443,6 +443,11 @@ function! s:SendInitMessage(conn) abort
     \               },
     \               'codeAction': {
     \                   'dynamicRegistration': v:false,
+    \                   'codeActionLiteralSupport': {
+    \						'codeActionKind': {
+    \							'valueSet': []
+    \						}
+    \					}
     \               },
     \               'rename': {
     \                   'dynamicRegistration': v:false,


### PR DESCRIPTION
Two commits that make it possible to invoke the code actions for rust-analyzer.

The first is a quick fix that removes an error where ALE submits a column of -1 on an empty line, when rust-analyzer (and the specification) expects an unsigned integer.

The second advertises the [`codeAction.codeActionLiteralSupport`](https://microsoft.github.io/language-server-protocol/specification#textDocument_codeAction) capability during initialization.  Without this, [rust-analyzer never reports any code actions](https://github.com/rust-lang/rust-analyzer/blob/f83dce0a4a70e1690fdbd8123d787fbaa6f37970/crates/rust-analyzer/src/handlers.rs#L1048-L1053).  The code already handled processing the CodeAction literals, so no further changes were needed.  It's possible the `valueSet` key should have some actual [`CodeActionKind`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind) values, but the spec also says having the key at all  "the client guarantees that it will handle values outside its set gracefully".