### PR TITLE
Add CodeAction codeActionLiteralSupport Feature

### DIFF
--- a/autoload/ale/codefix.vim
+++ b/autoload/ale/codefix.vim
@@ -457,7 +457,7 @@ function! s:ExecuteGetCodeFix(linter, range, MenuCallback) abort
         let [l:end_line, l:end_column] = getpos("'>")[1:2]
     endif
 
-    let l:column = min([l:column, len(getline(l:line))])
+    let l:column = max([min([l:column, len(getline(l:line))]), 1])
     let l:end_column = min([l:end_column, len(getline(l:end_line))])
 
     let l:Callback = function(

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -444,10 +444,10 @@ function! s:SendInitMessage(conn) abort
     \               'codeAction': {
     \                   'dynamicRegistration': v:false,
     \                   'codeActionLiteralSupport': {
-    \						'codeActionKind': {
-    \							'valueSet': []
-    \						}
-    \					}
+    \                        'codeActionKind': {
+    \                            'valueSet': []
+    \                        }
+    \                    }
     \               },
     \               'rename': {
     \                   'dynamicRegistration': v:false,

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -443,6 +443,11 @@ function! s:SendInitMessage(conn) abort
     \               },
     \               'codeAction': {
     \                   'dynamicRegistration': v:false,
+    \                   'codeActionLiteralSupport': {
+    \						'codeActionKind': {
+    \							'valueSet': []
+    \						}
+    \					}
     \               },
     \               'rename': {
     \                   'dynamicRegistration': v:false,

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -194,6 +194,11 @@ Before:
       \           },
       \           'codeAction': {
       \             'dynamicRegistration': v:false,
+      \             'codeActionLiteralSupport': {
+      \                  'codeActionKind': {
+      \                      'valueSet': []
+      \                  }
+      \              }
       \           },
       \           'rename': {
       \             'dynamicRegistration': v:false,


### PR DESCRIPTION
## Why the Pull Request?

As per [ale dev philosophy](https://github.com/dense-analysis/ale/wiki/ALE-Development-Philosophy#important-principles-for-ale-code) point 8 this feature is added to allow use code actions like import fixes, implementation of interfaces. This could fix `no code action received from server` mentioned in #3523.

The working is based on allowing lsp with capability `CodeActionClientCapabilities` with `codeActionLiteralSupport` to advertise as such.

## Tasks
- [x] get feature working
- [x] fix coding standards issue
- [x] write test cases for code
- [x] Add documentation

## References
- [LSP codeActionClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionClientCapabilities)

Credits: @Benabik for initial version