### PR TITLE
Use snippets for completion.

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -581,9 +581,14 @@ function! ale#completion#ParseLSPCompletions(response) abort
             continue
         endif
 
-        if get(l:item, 'insertTextFormat', s:LSP_INSERT_TEXT_FORMAT_PLAIN) is s:LSP_INSERT_TEXT_FORMAT_PLAIN
+        let l:insertTextFormat = get(l:item, 'insertTextFormat', s:LSP_INSERT_TEXT_FORMAT_PLAIN)
+
+        if l:insertTextFormat is s:LSP_INSERT_TEXT_FORMAT_PLAIN
         \&& type(get(l:item, 'textEdit')) is v:t_dict
             let l:text = l:item.textEdit.newText
+        elseif l:insertTextFormat is s:LSP_INSERT_TEXT_FORMAT_SNIPPET
+        \&& !empty(get(l:item, 'label'))
+            let l:text = l:item.label
         elseif type(get(l:item, 'insertText')) is v:t_string
             let l:text = l:item.insertText
         else

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -422,7 +422,7 @@ function! s:SendInitMessage(conn) abort
     \               'completion': {
     \                   'dynamicRegistration': v:false,
     \                   'completionItem': {
-    \                       'snippetSupport': v:false,
+    \                       'snippetSupport': v:true,
     \                       'commitCharactersSupport': v:false,
     \                       'documentationFormat': ['plaintext'],
     \                       'deprecatedSupport': v:false,

--- a/test/completion/test_lsp_completion_parsing.vader
+++ b/test/completion/test_lsp_completion_parsing.vader
@@ -734,3 +734,37 @@ Execute(Should still handle completion messages with empty additionalTextEdits w
   \     ],
   \   },
   \ })
+
+Execute(Should take label only from snippet completions):
+  let g:ale_completion_autoimport = 0
+
+  AssertEqual
+  \ [
+  \   {
+  \     'word': 'lastName',
+  \     'dup': 0,
+  \     'menu': '',
+  \     'info': 'The person''s last name.',
+  \     'kind': 'm',
+  \     'icase': 1,
+  \     'user_data': json_encode({'_ale_completion_item': 1}),
+  \   }
+  \ ],
+  \ ale#completion#ParseLSPCompletions({
+  \   'id': 5,
+  \   'jsonrpc': '2.0',
+  \   'result': {
+  \     'isIncomplete': v:false,
+  \     'items': [
+  \       {
+  \         'label': 'lastName',
+  \         'documentation': 'The person''s last name.',
+  \         'kind': 10,
+  \         'filterText': '"lastName"',
+  \         'insertText': '"lastName": "$1",',
+  \         'textEdit': {'range': {'end': {'character': 5, 'line': 3}, 'start': {'character': 2, 'line': 3}}, 'newText': '"lastName": "$1",'},
+  \         'insertTextFormat': 2
+  \       }
+  \     ]
+  \   }
+  \ })

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -163,7 +163,7 @@ Before:
       \           'completion': {
       \             'dynamicRegistration': v:false,
       \             'completionItem': {
-      \               'snippetSupport': v:false,
+      \               'snippetSupport': v:true,
       \               'commitCharactersSupport': v:false,
       \               'documentationFormat': ['plaintext'],
       \               'deprecatedSupport': v:false,


### PR DESCRIPTION
Some LSPs returns label with snippet that can be used for completion.
This way we can extract at least some value from snippets even if full snippets
support is not available.
