### PR TITLE
VSCode LSPs for CSS, HTML and JSON

### DIFF
--- a/ale_linters/css/vscodecss.vim
+++ b/ale_linters/css/vscodecss.vim
@@ -1,0 +1,16 @@
+" Author: Dalius Dobravolskas <dalius.dobravolskas@gmail.com>
+" Description: VSCode css language server
+
+function! ale_linters#css#vscodecss#GetProjectRoot(buffer) abort
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
+endfunction
+
+call ale#linter#Define('css', {
+\   'name': 'vscodecss',
+\   'lsp': 'stdio',
+\   'executable': 'vscode-css-language-server',
+\   'command': '%e --stdio',
+\   'project_root': function('ale_linters#css#vscodecss#GetProjectRoot'),
+\})

--- a/ale_linters/html/vscodehtml.vim
+++ b/ale_linters/html/vscodehtml.vim
@@ -1,0 +1,16 @@
+" Author: Dalius Dobravolskas <dalius.dobravolskas@gmail.com>
+" Description: VSCode html language server
+
+function! ale_linters#html#vscodehtml#GetProjectRoot(buffer) abort
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    return !empty(l:git_path) ? fnamemodify(l:git_path, ':h:h') : ''
+endfunction
+
+call ale#linter#Define('html', {
+\   'name': 'vscodehtml',
+\   'lsp': 'stdio',
+\   'executable': 'vscode-html-language-server',
+\   'command': '%e --stdio',
+\   'project_root': function('ale_linters#html#vscodehtml#GetProjectRoot'),
+\})

--- a/ale_linters/json/vscodejson.vim
+++ b/ale_linters/json/vscodejson.vim
@@ -1,5 +1,5 @@
 " Author: Dalius Dobravolskas <dalius.dobravolskas@gmail.com>
-" Description: VSCode json languageserver
+" Description: VSCode json language server
 
 function! ale_linters#json#vscodejson#GetProjectRoot(buffer) abort
     let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
@@ -10,7 +10,7 @@ endfunction
 call ale#linter#Define('json', {
 \   'name': 'vscodejson',
 \   'lsp': 'stdio',
-\   'executable': 'vscode-json-languageserver',
+\   'executable': 'vscode-json-language-server',
 \   'command': '%e --stdio',
 \   'project_root': function('ale_linters#json#vscodejson#GetProjectRoot'),
 \})

--- a/doc/ale-css.txt
+++ b/doc/ale-css.txt
@@ -50,4 +50,17 @@ g:ale_css_stylelint_use_global                 *g:ale_css_stylelint_use_global*
 
 
 ===============================================================================
+vscodecss                                                      *ale-css-vscode*
+
+Website: https://github.com/hrsh7th/vscode-langservers-extracted
+
+Installation
+-------------------------------------------------------------------------------
+
+Install VSCode css language server either globally or locally: >
+
+  npm install -g vscode-langservers-extracted
+<
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -165,6 +165,19 @@ g:ale_html_tidy_use_global                             *g:html_tidy_use_global*
 
 
 ===============================================================================
+vscodehtml                                                    *ale-html-vscode*
+
+Website: https://github.com/hrsh7th/vscode-langservers-extracted
+
+Installation
+-------------------------------------------------------------------------------
+
+Install VSCode html language server either globally or locally: >
+
+  npm install -g vscode-langservers-extracted
+<
+
+===============================================================================
 write-good                                                *ale-html-write-good*
 
 See |ale-write-good-options|

--- a/doc/ale-json.txt
+++ b/doc/ale-json.txt
@@ -156,14 +156,14 @@ g:ale_json_spectral_use_global                 *g:ale_json_spectral_use_global*
 ===============================================================================
 vscodejson                                                    *ale-json-vscode*
 
-Website: https://www.npmjs.com/package/vscode-json-languageserver
+Website: https://github.com/hrsh7th/vscode-langservers-extracted
 
 Installation
 -------------------------------------------------------------------------------
 
 Install VSCode json language server either globally or locally: >
 
-  npm install -g vscode-json-languageserver
+  npm install -g vscode-langservers-extracted
 <
 
 ===============================================================================

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -114,6 +114,7 @@ Notes:
   * `ameba`!!
   * `crystal`!!
 * CSS
+  * `VSCode CSS language server`
   * `cspell`
   * `csslint`
   * `fecs`
@@ -240,6 +241,7 @@ Notes:
 * HCL
   * `terraform-fmt`
 * HTML
+  * `VSCode HTML language server`
   * `alex`
   * `angular`
   * `cspell`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -643,7 +643,7 @@ displayed.
 ALE supports jumping to the files and locations where symbols are implemented
 through any enabled LSP linters. The locations ALE will jump to depend on the
 information returned by LSP servers. The |ALEGoToImplementation| command will
-jump to the implementation of symbols under the cursor. See the documentation 
+jump to the implementation of symbols under the cursor. See the documentation
 for the command for configuring how the location will be displayed.
 
 -------------------------------------------------------------------------------
@@ -2806,6 +2806,7 @@ documented in additional help files.
     fecs..................................|ale-css-fecs|
     prettier..............................|ale-css-prettier|
     stylelint.............................|ale-css-stylelint|
+    vscodecss.............................|ale-css-vscode|
   cuda....................................|ale-cuda-options|
     nvcc..................................|ale-cuda-nvcc|
     clangd................................|ale-cuda-clangd|
@@ -2920,6 +2921,7 @@ documented in additional help files.
     prettier..............................|ale-html-prettier|
     stylelint.............................|ale-html-stylelint|
     tidy..................................|ale-html-tidy|
+    vscodehtml............................|ale-html-vscode|
     write-good............................|ale-html-write-good|
   idris...................................|ale-idris-options|
     idris.................................|ale-idris-idris|
@@ -3425,7 +3427,7 @@ ALEGoToTypeDefinition                                   *ALEGoToTypeDefinition*
 ALEGoToImplementation                                   *ALEGoToImplementation*
 
   This works similar to |ALEGoToDefinition| but instead jumps to the
-  implementation of symbol under the cursor. ALE will jump to a definition if 
+  implementation of symbol under the cursor. ALE will jump to a definition if
   an LSP server provides a location to jump to. Otherwise, ALE will do nothing.
 
   The locations opened in different ways using the following variations.

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -123,6 +123,7 @@ formatting.
   * [ameba](https://github.com/veelenga/ameba) :floppy_disk:
   * [crystal](https://crystal-lang.org/) :floppy_disk:
 * CSS
+  * [VSCode CSS language server](https://github.com/hrsh7th/vscode-langservers-extracted)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)
   * [csslint](http://csslint.net/)
   * [fecs](http://fecs.baidu.com/)
@@ -249,6 +250,7 @@ formatting.
 * HCL
   * [terraform-fmt](https://github.com/hashicorp/terraform)
 * HTML
+  * [VSCode HTML language server](https://github.com/hrsh7th/vscode-langservers-extracted)
   * [alex](https://github.com/get-alex/alex)
   * [angular](https://www.npmjs.com/package/@angular/language-server)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)
@@ -292,7 +294,7 @@ formatting.
   * [tsserver](https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29)
   * [xo](https://github.com/sindresorhus/xo)
 * JSON
-  * [VSCode JSON language server](https://www.npmjs.com/package/vscode-json-languageserver)
+  * [VSCode JSON language server](https://github.com/hrsh7th/vscode-langservers-extracted)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell) :warning:
   * [dprint](https://dprint.dev)
   * [eslint](http://eslint.org/) :warning:


### PR DESCRIPTION
Switched to `vscode-langservers-extracted` as it is the one most
up-to-date.
