### PR TITLE
Handle golangci_lint warning and error messages correctly

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -34,7 +34,7 @@ function! ale_linters#go#golangci_lint#Handler(buffer, lines) abort
     let l:output = []
 
     for l:match in ale_linters#go#golangci_lint#GetMatches(a:lines)
-        if l:match[5] ==# 'typecheck'
+        if l:match[5] is# 'typecheck'
             let l:msg_type = 'E'
         else
             let l:msg_type = 'W'

--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -24,7 +24,7 @@ function! ale_linters#go#golangci_lint#GetCommand(buffer) abort
 endfunction
 
 function! ale_linters#go#golangci_lint#GetMatches(lines) abort
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:?:?:?\s\*?(.+)$'
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:?:?:?\s\*?(.+)\s+\((.+)\)$'
 
     return ale#util#GetMatches(a:lines, l:pattern)
 endfunction
@@ -34,14 +34,20 @@ function! ale_linters#go#golangci_lint#Handler(buffer, lines) abort
     let l:output = []
 
     for l:match in ale_linters#go#golangci_lint#GetMatches(a:lines)
+        if l:match[5] ==# 'typecheck'
+            let l:msg_type = 'E'
+        else
+            let l:msg_type = 'W'
+        endif
+
         " l:match[1] will already be an absolute path, output from
         " golangci_lint
         call add(l:output, {
         \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
         \   'lnum': l:match[2] + 0,
         \   'col': l:match[3] + 0,
-        \   'type': 'E',
-        \   'text': l:match[4],
+        \   'type': l:msg_type,
+        \   'text': l:match[4] . ' (' . l:match[5] . ')',
         \})
     endfor
 

--- a/test/handler/test_golangci_lint_handler.vader
+++ b/test/handler/test_golangci_lint_handler.vader
@@ -13,19 +13,21 @@ Execute (The golangci-lint handler should handle names with spaces):
   \     'C:\something\file with spaces.go',
   \     '12',
   \     '3',
-  \     'expected ''package'', found ''IDENT'' gibberish (staticcheck)',
+  \     'expected ''package'', found ''IDENT'' gibberish',
+  \     'staticcheck',
   \   ],
   \   [
   \     'C:\something\file with spaces.go',
   \     '37',
   \     '5',
-  \     'expected ''package'', found ''IDENT'' gibberish (golint)',
+  \     'expected ''package'', found ''IDENT'' gibberish',
+  \     'golint',
   \   ],
   \ ],
   \ map(ale_linters#go#golangci_lint#GetMatches([
   \   'C:\something\file with spaces.go:12:3: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
   \   'C:\something\file with spaces.go:37:5: expected ''package'', found ''IDENT'' gibberish (golint)',
-  \ ]), 'v:val[1:4]')
+  \ ]), 'v:val[1:5]')
 
 Execute (The golangci-lint handler should handle paths correctly):
   call ale#test#SetFilename('app/test.go')
@@ -38,18 +40,45 @@ Execute (The golangci-lint handler should handle paths correctly):
   \     'lnum': 12,
   \     'col': 3,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \     'type': 'E',
+  \     'type': 'W',
   \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
   \   },
   \   {
   \     'lnum': 37,
   \     'col': 5,
   \     'text': 'expected ''package'', found ''IDENT'' gibberish (golint)',
-  \     'type': 'E',
+  \     'type': 'W',
   \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
   \   },
   \ ],
   \ ale_linters#go#golangci_lint#Handler(bufnr(''), [
   \   file . ':12:3: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
   \   file . ':37:5: expected ''package'', found ''IDENT'' gibberish (golint)',
+  \ ])
+
+Execute (The golangci-lint handler should handle only typecheck lines as errors):
+  call ale#test#SetFilename('app/main.go')
+
+  let file = ale#path#GetAbsPath(expand('%:p:h'), 'test.go')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 30,
+  \     'col': 5,
+  \     'text': 'variable ''err'' is not used (typecheck)',
+  \     'type': 'E',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
+  \   },
+  \   {
+  \     'lnum': 505,
+  \     'col': 75,
+  \     'text': 'Magic number: 404, in <argument> detected (gomnd)',
+  \     'type': 'W',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
+  \   }
+  \ ],
+  \ ale_linters#go#golangci_lint#Handler(bufnr(''), [
+  \   file . ':30:5: variable ''err'' is not used (typecheck)',
+  \   file . ':505:75: Magic number: 404, in <argument> detected (gomnd)',
   \ ])


### PR DESCRIPTION
Improve golangci_lint plugin in order that it shows the error messages only if the message comes from the typecheck linter.

See the issue for details. https://github.com/dense-analysis/ale/issues/4168