### PR TITLE
Use stdin for Selene Lua linter

### DIFF
--- a/ale_linters/lua/selene.vim
+++ b/ale_linters/lua/selene.vim
@@ -3,7 +3,7 @@ call ale#Set('lua_selene_options', '')
 
 function! ale_linters#lua#selene#GetCommand(buffer) abort
     return '%e' . ale#Pad(ale#Var(a:buffer, 'lua_selene_options'))
-    \   . ' --display-style=json %s'
+    \   . ' --display-style=json -'
 endfunction
 
 function! ale_linters#lua#selene#Handle(buffer, lines) abort
@@ -43,5 +43,4 @@ call ale#linter#Define('lua', {
 \   'executable': {b -> ale#Var(b, 'lua_selene_executable')},
 \   'command': function('ale_linters#lua#selene#GetCommand'),
 \   'callback': 'ale_linters#lua#selene#Handle',
-\   'lint_file': 1,
 \})

--- a/test/linter/test_lua_selene.vader
+++ b/test/linter/test_lua_selene.vader
@@ -5,15 +5,15 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The lua selene command callback should return the correct default string):
-  AssertLinter 'selene', ale#Escape('selene') . ' --display-style=json %s'
+  AssertLinter 'selene', ale#Escape('selene') . ' --display-style=json -'
 
 Execute(The lua selene command callback should let you set options):
   let g:ale_lua_selene_options = '--num-threads 2'
 
   AssertLinter 'selene',
-  \ ale#Escape('selene') . ' --num-threads 2 --display-style=json %s'
+  \ ale#Escape('selene') . ' --num-threads 2 --display-style=json -'
 
 Execute(The selene executable should be configurable):
   let g:ale_lua_selene_executable = 'selene.sh'
 
-  AssertLinter 'selene.sh', ale#Escape('selene.sh') . ' --display-style=json %s'
+  AssertLinter 'selene.sh', ale#Escape('selene.sh') . ' --display-style=json -'


### PR DESCRIPTION
When I added Selene as a linter, I wasn't aware it had the option to process stdin using `-`.