### PR TITLE
racket: start completion in a full keyword

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -138,6 +138,7 @@ let s:should_complete_map = {
 " Regular expressions for finding the start column to replace with completion.
 let s:omni_start_map = {
 \   '<default>': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$',
+\   'racket': '\k\+',
 \}
 
 " A map of exact characters for triggering LSP completions. Do not forget to


### PR DESCRIPTION
The default `omni_start_map` is too restrictive for Lisps and Schemes
like Racket, which permit hyphens (among other special characters).

As recorded in #3870, trying to complete `file-name-from-path` when
typing `file-name<C-x><C-o>` would give completions like `namespace`
because the hyphen is ignored to find the start of the word for
completion.

Now the racket filetype searches for the start using the keyword class
`\k`, which is more precise.