### PR TITLE
Add support for ansible-lint 6.0.0

### DIFF
--- a/test/linter/test_ansible_lint.vader
+++ b/test/linter/test_ansible_lint.vader
@@ -15,6 +15,10 @@ Execute(The ansible_lint version >=5.0.0 command callback should return default 
   GivenCommandOutput ['v5.1.2']
   AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --nocolor --parseable-severity -x yaml %s'
 
+Execute(The ansible_lint version >=6.0.0 command callback should return default string):
+  GivenCommandOutput ['v6.0.2']
+  AssertLinter 'ansible-lint', ale#Escape('ansible-lint') . ' --nocolor -f json -x yaml %s'
+
 Execute(The ansible_lint executable should be configurable):
   let g:ale_ansible_ansible_lint_executable = '~/.local/bin/ansible-lint'
   GivenCommandOutput ['v4.1.2']


### PR DESCRIPTION
ansible-lint 6.0.0 removed the `--parseable-severity` option. Use the JSON
output in its place.

Fixes #4188