### PR TITLE
Add support for Packer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -438,7 +438,7 @@ let s:default_registry = {
 \   },
 \   'packer': {
 \       'function': 'ale#fixers#packer#Fix',
-\       'suggested_filetypes': ['hcl'],
+\       'suggested_filetypes': ['hcl', 'packer'],
 \       'description': 'Fix Packer HCL files with packer fmt.',
 \   },
 \   'crystal': {

--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -436,6 +436,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['hcl', 'terraform'],
 \       'description': 'Fix tf and hcl files with terraform fmt.',
 \   },
+\   'packer': {
+\       'function': 'ale#fixers#packer#Fix',
+\       'suggested_filetypes': ['hcl'],
+\       'description': 'Fix Packer HCL files with packer fmt.',
+\   },
 \   'crystal': {
 \       'function': 'ale#fixers#crystal#Fix',
 \       'suggested_filetypes': ['cr'],

--- a/autoload/ale/fixers/packer.vim
+++ b/autoload/ale/fixers/packer.vim
@@ -1,0 +1,17 @@
+" Author: Zhuoyun Wei <wzyboy@wzyboy.org>
+" Description: Fixer for Packer HCL files
+
+call ale#Set('packer_fmt_executable', 'packer')
+call ale#Set('packer_fmt_options', '')
+
+function! ale#fixers#packer#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'packer_fmt_executable')
+    let l:options = ale#Var(a:buffer, 'packer_fmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . ' fmt'
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' -'
+    \}
+endfunction

--- a/doc/ale-hcl.txt
+++ b/doc/ale-hcl.txt
@@ -3,14 +3,14 @@ ALE HCL Integration                                           *ale-hcl-options*
 
 
 ===============================================================================
-terraform-fmt                                           *ale-hcl-terraform-fmt*
-
-See |ale-terraform-fmt-fixer| for information about the available options.
-
-===============================================================================
 packer-fmt                                                 *ale-hcl-packer-fmt*
 
 See |ale-packer-fmt-fixer| for information about the available options.
+
+===============================================================================
+terraform-fmt                                           *ale-hcl-terraform-fmt*
+
+See |ale-terraform-fmt-fixer| for information about the available options.
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-hcl.txt
+++ b/doc/ale-hcl.txt
@@ -8,4 +8,9 @@ terraform-fmt                                           *ale-hcl-terraform-fmt*
 See |ale-terraform-fmt-fixer| for information about the available options.
 
 ===============================================================================
+packer-fmt                                                 *ale-hcl-packer-fmt*
+
+See |ale-packer-fmt-fixer| for information about the available options.
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-packer.txt
+++ b/doc/ale-packer.txt
@@ -1,0 +1,24 @@
+===============================================================================
+ALE Packer Integration                                     *ale-packer-options*
+
+
+===============================================================================
+packer-fmt-fixer                                         *ale-packer-fmt-fixer*
+
+g:ale_packer_fmt_executable                       *g:ale_packer_fmt_executable*
+                                                  *b:ale_packer_fmt_executable*
+
+  Type: |String|
+  Default: `'packer'`
+
+  This variable can be changed to use a different executable for packer.
+
+
+g:ale_packer_fmt_options                             *g:ale_packer_fmt_options*
+                                                     *b:ale_packer_fmt_options*
+  Type: |String|
+  Default: `''`
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -392,6 +392,8 @@ Notes:
   * `ibm_validator`
   * `prettier`
   * `yamllint`
+* Packer
+  * `packer-fmt-fixer`
 * Pascal
   * `ptop`
 * Pawn

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -239,6 +239,7 @@ Notes:
   * `stack-ghc`
   * `stylish-haskell`
 * HCL
+  * `packer-fmt`
   * `terraform-fmt`
 * HTML
   * `VSCode HTML language server`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2909,6 +2909,7 @@ documented in additional help files.
     hie...................................|ale-haskell-hie|
     ormolu................................|ale-haskell-ormolu|
   hcl.....................................|ale-hcl-options|
+    packer-fmt............................|ale-hcl-packer-fmt|
     terraform-fmt.........................|ale-hcl-terraform-fmt|
   help....................................|ale-help-options|
     cspell................................|ale-help-cspell|

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3039,6 +3039,8 @@ documented in additional help files.
     ibm_validator.........................|ale-openapi-ibm-validator|
     prettier..............................|ale-openapi-prettier|
     yamllint..............................|ale-openapi-yamllint|
+  packer..................................|ale-packer-options|
+    packer-fmt-fixer......................|ale-packer-fmt-fixer|
   pascal..................................|ale-pascal-options|
     ptop..................................|ale-pascal-ptop|
   pawn....................................|ale-pawn-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -248,6 +248,7 @@ formatting.
   * [stack-ghc](https://haskellstack.org/)
   * [stylish-haskell](https://github.com/jaspervdj/stylish-haskell)
 * HCL
+  * [packer-fmt](https://github.com/hashicorp/packer)
   * [terraform-fmt](https://github.com/hashicorp/terraform)
 * HTML
   * [VSCode HTML language server](https://github.com/hrsh7th/vscode-langservers-extracted)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -401,6 +401,8 @@ formatting.
   * [ibm_validator](https://github.com/IBM/openapi-validator)
   * [prettier](https://github.com/prettier/prettier)
   * [yamllint](https://yamllint.readthedocs.io/)
+* Packer (HCL)
+  * [packer-fmt-fixer](https://github.com/hashicorp/packer)
 * Pascal
   * [ptop](https://www.freepascal.org/tools/ptop.var)
 * Pawn

--- a/test/fixers/test_packer_fmt_fixer_callback.vader
+++ b/test/fixers/test_packer_fmt_fixer_callback.vader
@@ -1,0 +1,34 @@
+Before:
+  Save g:ale_packer_fmt_executable
+  Save g:ale_packer_fmt_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_packer_fmt_executable = 'xxxinvalid'
+  let g:ale_packer_fmt_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The packer fmt callback should return the correct default values):
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid') . ' fmt -',
+  \ },
+  \ ale#fixers#packer#Fix(bufnr(''))
+
+Execute(The packer fmt callback should include custom options):
+  let g:ale_packer_fmt_options = "-list=true"
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' fmt'
+  \     . ' ' . g:ale_packer_fmt_options
+  \     . ' -',
+  \ },
+  \ ale#fixers#packer#Fix(bufnr(''))


### PR DESCRIPTION
This PR adds basic fixer support for Packer.

Terraform and Packer are both developed by HashiCorp and share the same HCL syntax. However, `terraform fmt` and `packer fmt` cannot be used inter-changably.

I have no experience with VimL, so I just copied the `terraform` fixer (and its test) into `packer` variant and it seems to work fine and all tests passed.

Please feel free to edit the PR if I made n00b mistakes on VimL.
