### PR TITLE
support ember-template-lint 4.x

### DIFF
--- a/ale_linters/handlebars/embertemplatelint.vim
+++ b/ale_linters/handlebars/embertemplatelint.vim
@@ -11,10 +11,17 @@ function! ale_linters#handlebars#embertemplatelint#GetExecutable(buffer) abort
 endfunction
 
 function! ale_linters#handlebars#embertemplatelint#GetCommand(buffer, version) abort
-    " Reading from stdin was introduced in ember-template-lint@1.6.0
-    return ale#semver#GTE(a:version, [1, 6, 0])
-    \   ? '%e --json --filename %s'
-    \   : '%e --json %t'
+    if ale#semver#GTE(a:version, [4, 0, 0])
+        " --json was removed in favor of --format=json in ember-template-lint@4.0.0
+        return '%e --format=json --filename %s'
+    endif
+
+    if ale#semver#GTE(a:version, [1, 6, 0])
+        " Reading from stdin was introduced in ember-template-lint@1.6.0
+        return '%e --json --filename %s'
+    endif
+
+    return '%e --json %t'
 endfunction
 
 function! ale_linters#handlebars#embertemplatelint#GetCommandWithVersionCheck(buffer) abort

--- a/test/linter/test_embertemplatelint.vader
+++ b/test/linter/test_embertemplatelint.vader
@@ -1,17 +1,23 @@
 Before:
   call ale#assert#SetUpLinterTest('handlebars', 'embertemplatelint')
 
-  GivenCommandOutput ['1.6.0']
-
 After:
   call ale#assert#TearDownLinterTest()
 
-Execute(ember-template-lint executables runs the right command):
+Execute(Runs the right command for ember-template-lint >= 4.x):
+  GivenCommandOutput ['4.0.0']
+
   AssertLinter 'ember-template-lint',
+  \ ale#Escape('ember-template-lint') . ' --format=json --filename %s'
+
+Execute(Runs the right command for ember-template-lint >= 1.6, < 4.x):
+  GivenCommandOutput ['1.6.0']
+
+    AssertLinter 'ember-template-lint',
   \ ale#Escape('ember-template-lint') . ' --json --filename %s'
 
-Execute(old ember-template-lint executables runs the right command):
-  GivenCommandOutput []
+Execute(Runs the right command for ember-template-lint < 1.6):
+  GivenCommandOutput ['1.5.0']
 
   AssertLinter 'ember-template-lint',
   \ ale#Escape('ember-template-lint') . ' --json %t'


### PR DESCRIPTION
ember-template-lint [4.0.0](https://github.com/ember-template-lint/ember-template-lint/blob/master/CHANGELOG.md#v400-2022-01-05) removed the `--json` CLI option in favor of `--format=json`: https://github.com/ember-template-lint/ember-template-lint/pull/2193

This updates the ember-template-lint ale_linter to use `--format=json` when ember-template-lint >= 4.0.0