### PR TITLE
Look for .mypy.ini when finding project root

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -26,6 +26,7 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/tox.ini')
         \|| filereadable(l:path . '/.pyre_configuration.local')
         \|| filereadable(l:path . '/mypy.ini')
+        \|| filereadable(l:path . '/.mypy.ini')
         \|| filereadable(l:path . '/pycodestyle.cfg')
         \|| filereadable(l:path . '/.flake8')
         \|| filereadable(l:path . '/.flake8rc')

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -39,6 +39,7 @@ ALE will look for configuration files with the following filenames. >
   tox.ini
   .pyre_configuration.local
   mypy.ini
+  .mypy.ini
   pycodestyle.cfg
   .flake8
   .flake8rc


### PR DESCRIPTION
We already check for mypy.ini, but the fallback .mypy.ini was ignored.