### PR TITLE
Fix 4155 - Show error when project root not found

### DIFF
--- a/autoload/ale/lsp_linter.vim
+++ b/autoload/ale/lsp_linter.vim
@@ -141,6 +141,10 @@ function! s:HandleLSPErrorMessage(linter_name, response) abort
         return
     endif
 
+    call ale#lsp_linter#AddErrorMessage(a:linter_name, l:message)
+endfunction
+
+function! ale#lsp_linter#AddErrorMessage(linter_name, message) abort
     " This global variable is set here so we don't load the debugging.vim file
     " until someone uses :ALEInfo.
     let g:ale_lsp_error_messages = get(g:, 'ale_lsp_error_messages', {})
@@ -149,7 +153,7 @@ function! s:HandleLSPErrorMessage(linter_name, response) abort
         let g:ale_lsp_error_messages[a:linter_name] = []
     endif
 
-    call add(g:ale_lsp_error_messages[a:linter_name], l:message)
+    call add(g:ale_lsp_error_messages[a:linter_name], a:message)
 endfunction
 
 function! ale#lsp_linter#HandleLSPResponse(conn_id, response) abort
@@ -430,6 +434,8 @@ function! ale#lsp_linter#StartLSP(buffer, linter, Callback) abort
     if empty(l:root) && a:linter.lsp isnot# 'tsserver'
         " If there's no project root, then we can't check files with LSP,
         " unless we are using tsserver, which doesn't use project roots.
+        call ale#lsp_linter#AddErrorMessage(a:linter.name, "Failed to find project root, language server wont't start.")
+
         return 0
     endif
 


### PR DESCRIPTION
Adds an error to the list of LSP errors if ALE fails to find the project root. 

Closes #4155
