### PR TITLE
Use buffer input for cmake_lint linter

### DIFF
--- a/ale_linters/cmake/cmake_lint.vim
+++ b/ale_linters/cmake/cmake_lint.vim
@@ -15,7 +15,7 @@ function! ale_linters#cmake#cmake_lint#Command(buffer) abort
     let l:executable = ale_linters#cmake#cmake_lint#Executable(a:buffer)
     let l:options = ale#Var(a:buffer, 'cmake_cmake_lint_options')
 
-    return ale#Escape(l:executable) . ' ' . l:options . ' %t'
+    return ale#Escape(l:executable) . ' ' . l:options . ' %s'
 endfunction
 
 function! ale_linters#cmake#cmake_lint#Handle(buffer, lines) abort


### PR DESCRIPTION
cmake-lint supports stdin input, at least since v0.3.6 (2018).

Beyond the performance consequence, use stdin vs copy in /tmp
fix the cmake-lint usage. cmake-lint is based on a config file,
which is recursively searched in parent directories from the
currently analyzed file path. Analyze a file in /tmp breaks this
behavior, then the config file is ignored and default cmake
config is used.

-----

I didn't fix `ale_linters/cmake/cmakelint.vim`, because I don't know when it is supposed to be used.
Also, I can see that just using `%s` is enough. I would have expected to add `-` in the cmake-lint command line (for stdin input), but I imagine it is magically added somewhere.

Futhermore, this patch greatly improves cmake-lint usage (because it actually now work, at least on my configuration). But reading ale-dev, I can see that I can not trust `getcwd()`. cmake-lint, when reading input from stdin, search for config file from python `getcwd()`. It is not ideal, as vim could be started from a given path, and a buffer could be opened in another path, depending on another config file. `getcwd()` will be wrong in this case. Also, ale-dev states that asynchronous execution may lead to unreliable `getcwd()`.

I will certainly make a PR to cmake-lint in that direction, to add a new command line option like `--config-file-search-path`, and then coming back to ale to add this new option.