### PR TITLE
Allow customization of all floating window borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,14 +931,14 @@ If the terminal supports Unicode, you might try setting the value like below, to
 make it look nicer.
 
 ```vim
-let g:ale_floating_window_border = ['│', '─', '╭', '╮', '╯', '╰']
+let g:ale_floating_window_border = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
 ```
 
 Since vim's default uses nice unicode characters when possible, you can trick
 ale into using that default with
 
 ```vim
-let g:ale_floating_window_border = repeat([''], 6)
+let g:ale_floating_window_border = repeat([''], 8)
 ```
 
 <a name="faq-vim-lsp"></a>

--- a/README.md
+++ b/README.md
@@ -931,7 +931,7 @@ If the terminal supports Unicode, you might try setting the value like below, to
 make it look nicer.
 
 ```vim
-let g:ale_floating_window_border = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+let g:ale_floating_window_border = ['│', '─', '╭', '╮', '╯', '╰', '│', '─']
 ```
 
 Since vim's default uses nice unicode characters when possible, you can trick

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -106,18 +106,31 @@ function! s:NvimPrepareWindowContent(lines) abort
     let l:width += 2
     let l:height += 2
 
-    let l:hor          = g:ale_floating_window_border[0]
-    let l:top          = g:ale_floating_window_border[1]
-    let l:top_left     = g:ale_floating_window_border[2]
-    let l:top_right    = g:ale_floating_window_border[3]
-    let l:bottom_right = g:ale_floating_window_border[4]
-    let l:bottom_left  = g:ale_floating_window_border[5]
+    if len(g:ale_floating_window_border) == 6
+        let l:left         = g:ale_floating_window_border[0]
+        let l:right        = l:left
+        let l:top          = g:ale_floating_window_border[1]
+        let l:bottom       = l:top
+        let l:top_left     = g:ale_floating_window_border[2]
+        let l:top_right    = g:ale_floating_window_border[3]
+        let l:bottom_right = g:ale_floating_window_border[4]
+        let l:bottom_left  = g:ale_floating_window_border[5]
+    else
+        let l:top          = g:ale_floating_window_border[0]
+        let l:right        = g:ale_floating_window_border[1]
+        let l:bottom       = g:ale_floating_window_border[2]
+        let l:left         = g:ale_floating_window_border[3]
+        let l:top_left     = g:ale_floating_window_border[4]
+        let l:top_right    = g:ale_floating_window_border[5]
+        let l:bottom_right = g:ale_floating_window_border[6]
+        let l:bottom_left  = g:ale_floating_window_border[7]
+    endif
 
     let l:lines = [l:top_left . repeat(l:top, l:width - 2) . l:top_right]
 
     for l:line in a:lines
         let l:line_width = strchars(l:line)
-        let l:lines = add(l:lines, l:hor . l:line . repeat(' ', l:width - l:line_width - 2). l:hor)
+        let l:lines = add(l:lines, l:left . l:line . repeat(' ', l:width - l:line_width - 2). l:right)
     endfor
 
     " Truncate the lines
@@ -125,7 +138,7 @@ function! s:NvimPrepareWindowContent(lines) abort
         let l:lines = l:lines[0:l:max_height]
     endif
 
-    let l:lines = add(l:lines, l:bottom_left . repeat(l:top, l:width - 2) . l:bottom_right)
+    let l:lines = add(l:lines, l:bottom_left . repeat(l:bottom, l:width - 2) . l:bottom_right)
 
     return [l:lines, l:width, l:height]
 endfunction
@@ -157,7 +170,10 @@ function! s:VimCreate(options) abort
     \    'close': 'button',
     \    'padding': [0, 1, 0, 1],
     \    'border': [],
-    \    'borderchars': empty(g:ale_floating_window_border) ? [' '] : [
+    \    'borderchars':
+    \         empty(g:ale_floating_window_border) ? [' '] :
+    \         len(g:ale_floating_window_border) != 6 ? g:ale_floating_window_border :
+    \    [
     \        g:ale_floating_window_border[1],
     \        g:ale_floating_window_border[0],
     \        g:ale_floating_window_border[1],

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -106,25 +106,14 @@ function! s:NvimPrepareWindowContent(lines) abort
     let l:width += 2
     let l:height += 2
 
-    if len(g:ale_floating_window_border) == 6
-        let l:left         = g:ale_floating_window_border[0]
-        let l:right        = l:left
-        let l:top          = g:ale_floating_window_border[1]
-        let l:bottom       = l:top
-        let l:top_left     = g:ale_floating_window_border[2]
-        let l:top_right    = g:ale_floating_window_border[3]
-        let l:bottom_right = g:ale_floating_window_border[4]
-        let l:bottom_left  = g:ale_floating_window_border[5]
-    else
-        let l:top          = g:ale_floating_window_border[0]
-        let l:right        = g:ale_floating_window_border[1]
-        let l:bottom       = g:ale_floating_window_border[2]
-        let l:left         = g:ale_floating_window_border[3]
-        let l:top_left     = g:ale_floating_window_border[4]
-        let l:top_right    = g:ale_floating_window_border[5]
-        let l:bottom_right = g:ale_floating_window_border[6]
-        let l:bottom_left  = g:ale_floating_window_border[7]
-    endif
+    let l:left         = get(g:ale_floating_window_border, 0, '|')
+    let l:top          = get(g:ale_floating_window_border, 1, '-')
+    let l:top_left     = get(g:ale_floating_window_border, 2, '+')
+    let l:top_right    = get(g:ale_floating_window_border, 3, '+')
+    let l:bottom_right = get(g:ale_floating_window_border, 4, '+')
+    let l:bottom_left  = get(g:ale_floating_window_border, 5, '+')
+    let l:right        = get(g:ale_floating_window_border, 6, l:left)
+    let l:bottom       = get(g:ale_floating_window_border, 7, l:top)
 
     let l:lines = [l:top_left . repeat(l:top, l:width - 2) . l:top_right]
 
@@ -170,18 +159,15 @@ function! s:VimCreate(options) abort
     \    'close': 'button',
     \    'padding': [0, 1, 0, 1],
     \    'border': [],
-    \    'borderchars':
-    \         empty(g:ale_floating_window_border) ? [' '] :
-    \         len(g:ale_floating_window_border) != 6 ? g:ale_floating_window_border :
-    \    [
-    \        g:ale_floating_window_border[1],
-    \        g:ale_floating_window_border[0],
-    \        g:ale_floating_window_border[1],
-    \        g:ale_floating_window_border[0],
-    \        g:ale_floating_window_border[2],
-    \        g:ale_floating_window_border[3],
-    \        g:ale_floating_window_border[4],
-    \        g:ale_floating_window_border[5],
+    \    'borderchars': empty(g:ale_floating_window_border) ? [' '] : [
+    \        get(g:ale_floating_window_border, 1, '-'),
+    \        get(g:ale_floating_window_border, 6, '|'),
+    \        get(g:ale_floating_window_border, 7, '-'),
+    \        get(g:ale_floating_window_border, 0, '|'),
+    \        get(g:ale_floating_window_border, 2, '+'),
+    \        get(g:ale_floating_window_border, 3, '+'),
+    \        get(g:ale_floating_window_border, 4, '+'),
+    \        get(g:ale_floating_window_border, 5, '+'),
     \    ],
     \    'moved': 'any',
     \    })

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1237,18 +1237,19 @@ g:ale_floating_preview                                 *g:ale_floating_preview*
 g:ale_floating_window_border                       *g:ale_floating_window_border*
 
   Type: |List|
-  Default: `['-', '|', '-', '|', '+', '+', '+', '+']`
+  Default: `['|', '-', '+', '+', '+', '+', '|', '-']`
 
   When set to `[]`, window borders are disabled. The elements in the list set
-  the top, right, bottom, left, top-left, top-right, bottom-right and
-  bottom-left border characters, respectively.
+	the the characters for the left side, top, top-left corner, top-right
+	corner, bottom-right corner, bottom-left corner, right side, and bottom of
+	the floating window, respectively.
 
   If the terminal supports Unicode, you might try setting the value to
-  ` ['─', '│', '─', '│', '╭', '╮', '╯', '╰']`, to make it look nicer.
+  ` ['│', '─', '╭', '╮', '╯', '╰', '│', '─']`, to make it look nicer.
 
-  NOTE: For compatibility with previous versions, if the list contains only
-  six elements, the first sets both the top and bottom borders, and the second
-  sets both side borders.
+  NOTE: For compatibility with previous versions, if the list does not have
+	elements for the right side and bottom, the left side and top will be used
+	instead.
 
 
 g:ale_history_enabled                                   *g:ale_history_enabled*

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -676,7 +676,8 @@ Hover information can be displayed in the preview window instead by setting
 
 When using Neovim or Vim with |popupwin|, if |g:ale_hover_to_floating_preview|
 or |g:ale_floating_preview| is set to 1, the hover information will show in a
-floating window. And |g:ale_floating_window_border| for the border setting.
+floating window. The borders of the floating preview window can be customized
+by setting |g:ale_floating_window_border|.
 
 For Vim 8.1+ terminals, mouse hovering is disabled by default. Enabling
 |balloonexpr| commands in terminals can cause scrolling issues in terminals,
@@ -1236,14 +1237,18 @@ g:ale_floating_preview                                 *g:ale_floating_preview*
 g:ale_floating_window_border                       *g:ale_floating_window_border*
 
   Type: |List|
-  Default: `['|', '-', '+', '+', '+', '+']`
+  Default: `['-', '|', '-', '|', '+', '+', '+', '+']`
 
   When set to `[]`, window borders are disabled. The elements in the list set
-  the horizontal, top, top-left, top-right, bottom-right and bottom-left
-  border characters, respectively.
+  the top, right, bottom, left, top-left, top-right, bottom-right and
+  bottom-left border characters, respectively.
 
   If the terminal supports Unicode, you might try setting the value to
-  ` ['│', '─', '╭', '╮', '╯', '╰']`, to make it look nicer.
+  ` ['─', '│', '─', '│', '╭', '╮', '╯', '╰']`, to make it look nicer.
+
+  NOTE: For compatibility with previous versions, if the list contains only
+  six elements, the first sets both the top and bottom borders, and the second
+  sets both side borders.
 
 
 g:ale_history_enabled                                   *g:ale_history_enabled*

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -153,9 +153,10 @@ let g:ale_hover_to_floating_preview = get(g:, 'ale_hover_to_floating_preview', 0
 let g:ale_detail_to_floating_preview = get(g:, 'ale_detail_to_floating_preview', 0)
 
 " Border setting for floating preview windows
-" The elements in the list represent the top, right, bottom, left, top-left,
-" top-right, bottom-right and bottom-left borders
-let g:ale_floating_window_border = get(g:, 'ale_floating_window_border', ['-', '|', '-', '|', '+', '+', '+', '+'])
+" The elements in the list set the characters for the left, top, top-left,
+" top-right, bottom-right, bottom-left, right, and bottom of the border
+" respectively
+let g:ale_floating_window_border = get(g:, 'ale_floating_window_border', ['|', '-', '+', '+', '+', '+', '|', '-'])
 
 " This flag can be set to 0 to disable warnings for trailing whitespace
 let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -152,10 +152,10 @@ let g:ale_hover_to_floating_preview = get(g:, 'ale_hover_to_floating_preview', 0
 " Detail uses floating windows in Neovim
 let g:ale_detail_to_floating_preview = get(g:, 'ale_detail_to_floating_preview', 0)
 
-" Border setting for floating preview windows in Neovim
-" The element in the list presents - horizontal, top, top-left, top-right,
-" bottom-right and bottom-left
-let g:ale_floating_window_border = get(g:, 'ale_floating_window_border', ['|', '-', '+', '+', '+', '+'])
+" Border setting for floating preview windows
+" The elements in the list represent the top, right, bottom, left, top-left,
+" top-right, bottom-right and bottom-left borders
+let g:ale_floating_window_border = get(g:, 'ale_floating_window_border', ['-', '|', '-', '|', '+', '+', '+', '+'])
 
 " This flag can be set to 0 to disable warnings for trailing whitespace
 let g:ale_warn_about_trailing_whitespace = get(g:, 'ale_warn_about_trailing_whitespace', 1)


### PR DESCRIPTION
Users may not necessarily want the same border character for top+bottom or left+right, so allow all eight border characters to be configured in `g:ale_floating_window_border`.

For backwards compatibility, the old rules are still applied if only six elements are given.