### PR TITLE
Implement ALEHover/ale_hover_cursor callbacks

### DIFF
--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -98,13 +98,13 @@ function! ale#hover#HandleTSServerResponse(conn_id, response) abort
                 call balloon_show(a:response.body.displayString)
             elseif get(l:options, 'truncated_echo', 0)
                 if !empty(a:response.body.displayString)
-                    call s:cursor_callback(#{
-                    \ lines: split(a:response.body.displayString, "\n"),
+                    call s:cursor_callback({
+                    \ 'lines': split(a:response.body.displayString, "\n"),
                     \ })
                 endif
             else
-                call s:hover_callback(#{
-                \ lines: split(a:response.body.displayString, "\n"),
+                call s:hover_callback({
+                \ 'lines': split(a:response.body.displayString, "\n"),
                 \ })
             endif
         endif
@@ -278,14 +278,14 @@ function! ale#hover#HandleLSPResponse(conn_id, response) abort
             \&& (l:set_balloons is 1 || l:set_balloons is# 'hover')
                 call balloon_show(join(l:lines, "\n"))
             elseif get(l:options, 'truncated_echo', 0)
-                call s:cursor_callback(#{
-                \ lines: l:lines,
-                \ commands: l:commands
+                call s:cursor_callback({
+                \ 'lines': l:lines,
+                \ 'commands': l:commands,
                 \})
             else
-                call s:hover_callback(#{
-                \ lines: l:lines,
-                \ commands: l:commands
+                call s:hover_callback({
+                \ 'lines': l:lines,
+                \ 'commands': l:commands,
                 \})
             endif
         endif

--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -20,7 +20,7 @@ endfunction
 function! ale#hover#FloatCallback(info) abort
     call ale#floating_preview#Show(a:info.lines, {
     \   'filetype': 'ale-preview.message',
-    \   'commands': a:info.commands,
+    \   'commands': get(a:info, 'commands', []),
     \})
 endfunction
 
@@ -28,13 +28,13 @@ function! ale#hover#PreviewCallback(info) abort
     call ale#preview#Show(a:info.lines, {
     \   'filetype': 'ale-preview.message',
     \   'stay_here': 1,
-    \   'commands': a:info.commands,
+    \   'commands': get(a:info, 'commands', []),
     \})
 endfunction
 
 function! ale#hover#MessageCallback(info) abort
     call ale#util#ShowMessage(join(a:info.lines, "\n"), {
-    \   'commands': a:info.commands,
+    \   'commands': get(a:info, 'commands', []),
     \})
 endfunction
 

--- a/test/test_hover.vader
+++ b/test/test_hover.vader
@@ -130,7 +130,7 @@ Execute(tsserver quickinfo displayString values should be displayed):
   \ }
   \)
 
-  AssertEqual [['foo bar']], g:show_message_arg_list
+  AssertEqual [['foo bar', {'commands': []}]], g:show_message_arg_list
   AssertEqual {}, ale#hover#GetMap()
 
 Execute(LSP hover responses with just a string should be handled):


### PR DESCRIPTION
Proof of concept for user-defined display functions.  User can pass a FuncRef to ale#hover#SetCallback to define behavior for explicit calls to ALEHover, or to ale#hover#SetCursorCallback for cursor idle when ale_hover_cursor is set.

The callback will be passed a dictionary of information, which contains fields "lines" and "commands" that were previously given as arguments.

The idea was mentioned by @hsanson in #4215 - I'm not familiar enough with ALE's intended design goals to say whether this is the right way to implement it, but any feedback is appreciated!