### PR TITLE
Fix 4249 - Revert change to stop compl menu.

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -6,7 +6,6 @@ scriptencoding utf-8
 " only valid in Insert mode. This way, feedkeys() won't send these keys if you
 " quit Insert mode quickly enough.
 inoremap <silent> <Plug>(ale_show_completion_menu) <C-x><C-o><C-p>
-inoremap <silent> <Plug>(ale_stop_completion_menu) <C-x><C-z>
 " If we hit the key sequence in normal mode, then we won't show the menu, so
 " we should restore the old settings right away.
 nnoremap <silent> <Plug>(ale_show_completion_menu) :call ale#completion#RestoreCompletionOptions()<CR>
@@ -981,14 +980,6 @@ function! ale#completion#StopTimer() abort
     let s:timer_id = -1
 endfunction
 
-" Close the previous completion menu (if any), so that the newer autocompletion
-" candidates will show up
-function! s:closePreviousCompletionMenu() abort
-    if exists('*complete_info') && !empty(complete_info(['mode']))
-        call ale#util#FeedKeys("\<Plug>(ale_stop_completion_menu)")
-    endif
-endfunction
-
 function! ale#completion#Queue() abort
     if !get(b:, 'ale_completion_enabled', g:ale_completion_enabled)
         return
@@ -1009,8 +1000,6 @@ function! ale#completion#Queue() abort
     endif
 
     call ale#completion#StopTimer()
-
-    call s:closePreviousCompletionMenu()
 
     let s:timer_id = timer_start(g:ale_completion_delay, function('s:TimerHandler'))
 endfunction


### PR DESCRIPTION
In #4231 some code was added to stop the completion menu if any when
opening a new one. This resulted in an issue in Vim that fills the
buffer with Ctrl-Z characters when deleting to the end of a line in a
position that triggers auto-completion.

Since auto-completion seems to work fine on all my tests I am reverting
this specific change.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
