### PR TITLE
Prevent buffering of job output and excessive polling

### DIFF
--- a/autoload/ale/job.vim
+++ b/autoload/ale/job.vim
@@ -250,10 +250,16 @@ function! ale#job#Start(command, options) abort
 
         if has_key(a:options, 'out_cb')
             let l:job_options.out_cb = function('s:VimOutputCallback')
+        else
+            " prevent buffering of output and excessive polling in case close_cb is set
+            let l:job_options.out_cb = {->0}
         endif
 
         if has_key(a:options, 'err_cb')
             let l:job_options.err_cb = function('s:VimErrorCallback')
+        else
+            " prevent buffering of output and excessive polling in case close_cb is set
+            let l:job_options.err_cb = {->0}
         endif
 
         if has_key(a:options, 'exit_cb')


### PR DESCRIPTION
When 'close_cb' is set for job_start(), but out_cb or err_cb isn't, vim buffers data instead of dropping it (in case someone wanted to read and process it in close_cb), and additionally polls for new data every 10 milliseconds, causing excessive wakeups and CPU usage. Since we don't read the data anywhere outside of out_cb/err_cb, any LSP that prints an error to stderr triggers this and vim keeps spinning until :ALEStopAllLSPs.

Fix this by always setting both callbacks, thus dropping any data we're not interested in.

See https://github.com/vim/vim/issues/10758 for an upstream report of the excessive polling. It's possible this is intentional, I dunno.

Fixes: b42153eb1786 ("Fix #4098 - Clear LSP data when servers crash")

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

> Where are the tests? Have you added tests? Have you updated the tests? Read the comment above and the documentation referenced in it first. Write tests!
> Seriously, read `:help ale-dev` and write tests.

I don't think this is easily unit-testable. :-(
