### PR TITLE
Add support for syntax_tree fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -221,6 +221,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['swift'],
 \       'description': 'Apply SwiftFormat to a file.',
 \   },
+\   'syntax_tree': {
+\       'function': 'ale#fixers#syntax_tree#Fix',
+\       'suggested_filetypes': ['ruby'],
+\       'description': 'Fix ruby files with stree write',
+\   },
 \   'apple-swift-format': {
 \       'function': 'ale#fixers#appleswiftformat#Fix',
 \       'suggested_filetypes': ['swift'],

--- a/autoload/ale/fixers/syntax_tree.vim
+++ b/autoload/ale/fixers/syntax_tree.vim
@@ -1,0 +1,19 @@
+call ale#Set('ruby_syntax_tree_options', '')
+call ale#Set('ruby_syntax_tree_executable', 'stree')
+
+function! ale#fixers#syntax_tree#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ruby_syntax_tree_executable')
+    let l:options = ale#Var(a:buffer, 'ruby_syntax_tree_options')
+
+    return ale#ruby#EscapeExecutable(l:executable, 'stree')
+    \   . ' write'
+    \   . (!empty(l:options) ? ' ' . l:options : '')
+    \   . ' %t'
+endfunction
+
+function! ale#fixers#syntax_tree#Fix(buffer) abort
+    return {
+    \   'command': ale#fixers#syntax_tree#GetCommand(a:buffer),
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -220,4 +220,24 @@ g:ale_ruby_standardrb_options                   *g:ale_ruby_standardrb_options*
 
 
 ===============================================================================
+syntax_tree                                              *ale-ruby-syntax_tree*
+
+g:ale_ruby_syntax_tree_executable           *g:ale_ruby_syntax_tree_executable*
+                                            *b:ale_ruby_syntax_tree_executable*
+  Type: String
+  Default: `'stree'`
+
+  Override the invoked SyntaxTree binary. Set this to `'bundle'` to invoke
+  `'bundle` `exec` stree'.
+
+
+g:ale_ruby_syntax_tree_options                 *g:ale_ruby_syntax_tree_options*
+                                               *b:ale_ruby_syntax_tree_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to SyntaxTree.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -527,6 +527,7 @@ Notes:
   * `solargraph`
   * `sorbet`
   * `standardrb`
+  * `syntax_tree`
 * Rust
   * `cargo`!!
   * `cspell`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3165,6 +3165,7 @@ documented in additional help files.
     solargraph............................|ale-ruby-solargraph|
     sorbet................................|ale-ruby-sorbet|
     standardrb............................|ale-ruby-standardrb|
+    syntax_tree...........................|ale-ruby-syntax_tree|
   rust....................................|ale-rust-options|
     analyzer..............................|ale-rust-analyzer|
     cargo.................................|ale-rust-cargo|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -536,6 +536,7 @@ formatting.
   * [solargraph](https://solargraph.org)
   * [sorbet](https://github.com/sorbet/sorbet)
   * [standardrb](https://github.com/testdouble/standard)
+  * [syntax_tree](https://github.com/ruby-syntax-tree/syntax_tree)
 * Rust
   * [cargo](https://github.com/rust-lang/cargo) :floppy_disk: (see `:help ale-integration-rust` for configuration instructions)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)

--- a/test/fixers/test_syntax_tree_fixer_callback.vader
+++ b/test/fixers/test_syntax_tree_fixer_callback.vader
@@ -1,0 +1,37 @@
+Before:
+  Save g:ale_ruby_syntax_tree_executable
+  Save g:ale_ruby_syntax_tree_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_ruby_syntax_tree_executable = 'xxxinvalid'
+  let g:ale_ruby_syntax_tree_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The syntax_tree callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/ruby/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_ruby_syntax_tree_executable)
+  \     . ' write %t',
+  \ },
+  \ ale#fixers#syntax_tree#Fix(bufnr(''))
+
+Execute(The syntax_tree callback should include custom options):
+  let g:ale_ruby_syntax_tree_options = '--print-width=100 --plugins=plugin/trailing_comma'
+  call ale#test#SetFilename('../test-files/ruby/with_config/dummy.rb')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_ruby_syntax_tree_executable)
+  \     . ' write --print-width=100 --plugins=plugin/trailing_comma %t',
+  \ },
+  \ ale#fixers#syntax_tree#Fix(bufnr(''))


### PR DESCRIPTION
This is the library that now powers prettier/plugin-ruby but is also stands on its own: https://github.com/ruby-syntax-tree/syntax_tree

I added tests based on existing examples, but much of this was new for me.  I'm happy to tweak or update any of this to fit within the rest of this plugin.  I have also tested it locally and it's working as I'd expect for me.