### PR TITLE
Add vim 9.0 and remove 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       matrix:
         vim-version:
-          - '--vim-80-only'
           - '--vim-82-only'
+          - '--vim-90-only'
           - '--neovim-02-only'
           - '--neovim-07-only'
           - '--linters-only'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         vim-version:
-          - '--vim-82-only'
+          - '--vim-80-only'
           - '--vim-90-only'
           - '--neovim-02-only'
           - '--neovim-07-only'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM testbed/vim:20
 
-RUN install_vim -tag v8.2.4693 -build \
+RUN install_vim -tag v8.0.0027 -build \
                 -tag v9.0.0133 -build \
                 -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.7.0 -build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM testbed/vim:20
 
-RUN install_vim -tag v8.0.0027 -build \
-                -tag v8.2.4693 -build \
+RUN install_vim -tag v8.2.4693 -build \
+                -tag v9.0.0133 -build \
                 -tag neovim:v0.2.0 -build \
                 -tag neovim:v0.7.0 -build
 

--- a/run-tests
+++ b/run-tests
@@ -26,7 +26,7 @@ verbose_flag=''
 quiet_flag=''
 run_neovim_02_tests=1
 run_neovim_07_tests=1
-run_vim_82_tests=1
+run_vim_80_tests=1
 run_vim_90_tests=1
 run_linters=1
 
@@ -41,7 +41,7 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --build-image)
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_vim_90_tests=0
         run_neovim_02_tests=0
         run_neovim_07_tests=0
@@ -49,21 +49,21 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --neovim-only)
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_vim_90_tests=0
         run_linters=0
         shift
     ;;
     --neovim-02-only)
         run_neovim_07_tests=0
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_vim_90_tests=0
         run_linters=0
         shift
     ;;
     --neovim-07-only)
         run_neovim_02_tests=0
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_vim_90_tests=0
         run_linters=0
         shift
@@ -74,7 +74,7 @@ while [ $# -ne 0 ]; do
         run_linters=0
         shift
     ;;
-    --vim-82-only)
+    --vim-80-only)
         run_neovim_02_tests=0
         run_neovim_07_tests=0
         run_linters=0
@@ -83,19 +83,19 @@ while [ $# -ne 0 ]; do
     --vim-90-only)
         run_neovim_02_tests=0
         run_neovim_07_tests=0
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_linters=0
         shift
     ;;
     --linters-only)
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_vim_90_tests=0
         run_neovim_02_tests=0
         run_neovim_07_tests=0
         shift
     ;;
     --fast)
-        run_vim_82_tests=0
+        run_vim_80_tests=0
         run_vim_90_tests=0
         run_neovim_02_tests=0
         run_neovim_07_tests=1
@@ -115,7 +115,7 @@ while [ $# -ne 0 ]; do
         echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
         echo '  --neovim-07-only  Run tests only for NeoVim 0.7'
         echo '  --vim-only        Run tests only for Vim'
-        echo '  --vim-82-only     Run tests only for Vim 8.2'
+        echo '  --vim-80-only     Run tests only for Vim 8.2'
         echo '  --vim-90-only     Run tests only for Vim 9.0'
         echo '  --linters-only    Run only Vint and custom checks'
         echo '  --fast            Run only the fastest Vim and custom checks'
@@ -216,7 +216,7 @@ cancel_tests() {
 trap cancel_tests INT TERM
 
 for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neovim\|^vim' ); do
-    if ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
+    if ( [[ $vim =~ ^vim-v8.0 ]] && ((run_vim_80_tests)) ) \
     || ( [[ $vim =~ ^vim-v9.0 ]] && ((run_vim_90_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.7 ]] && ((run_neovim_07_tests)) ); then

--- a/run-tests
+++ b/run-tests
@@ -26,8 +26,8 @@ verbose_flag=''
 quiet_flag=''
 run_neovim_02_tests=1
 run_neovim_07_tests=1
-run_vim_80_tests=1
 run_vim_82_tests=1
+run_vim_90_tests=1
 run_linters=1
 
 while [ $# -ne 0 ]; do
@@ -41,30 +41,30 @@ while [ $# -ne 0 ]; do
         shift
     ;;
     --build-image)
-        run_vim_80_tests=0
         run_vim_82_tests=0
+        run_vim_90_tests=0
         run_neovim_02_tests=0
         run_neovim_07_tests=0
         run_linters=0
         shift
     ;;
     --neovim-only)
-        run_vim_80_tests=0
         run_vim_82_tests=0
+        run_vim_90_tests=0
         run_linters=0
         shift
     ;;
     --neovim-02-only)
         run_neovim_07_tests=0
-        run_vim_80_tests=0
         run_vim_82_tests=0
+        run_vim_90_tests=0
         run_linters=0
         shift
     ;;
     --neovim-07-only)
         run_neovim_02_tests=0
-        run_vim_80_tests=0
         run_vim_82_tests=0
+        run_vim_90_tests=0
         run_linters=0
         shift
     ;;
@@ -74,30 +74,29 @@ while [ $# -ne 0 ]; do
         run_linters=0
         shift
     ;;
-    --vim-80-only)
-        run_neovim_02_tests=0
-        run_neovim_07_tests=0
-        run_vim_82_tests=0
-        run_linters=0
-        shift
-    ;;
     --vim-82-only)
         run_neovim_02_tests=0
         run_neovim_07_tests=0
-        run_vim_80_tests=0
+        run_linters=0
+        shift
+    ;;
+    --vim-90-only)
+        run_neovim_02_tests=0
+        run_neovim_07_tests=0
+        run_vim_82_tests=0
         run_linters=0
         shift
     ;;
     --linters-only)
-        run_vim_80_tests=0
         run_vim_82_tests=0
+        run_vim_90_tests=0
         run_neovim_02_tests=0
         run_neovim_07_tests=0
         shift
     ;;
     --fast)
-        run_vim_80_tests=0
         run_vim_82_tests=0
+        run_vim_90_tests=0
         run_neovim_02_tests=0
         run_neovim_07_tests=1
         shift
@@ -116,8 +115,8 @@ while [ $# -ne 0 ]; do
         echo '  --neovim-02-only  Run tests only for NeoVim 0.2'
         echo '  --neovim-07-only  Run tests only for NeoVim 0.7'
         echo '  --vim-only        Run tests only for Vim'
-        echo '  --vim-80-only     Run tests only for Vim 8.0'
         echo '  --vim-82-only     Run tests only for Vim 8.2'
+        echo '  --vim-90-only     Run tests only for Vim 9.0'
         echo '  --linters-only    Run only Vint and custom checks'
         echo '  --fast            Run only the fastest Vim and custom checks'
         echo '  --help            Show this help text'
@@ -217,8 +216,8 @@ cancel_tests() {
 trap cancel_tests INT TERM
 
 for vim in $(docker run --rm "$DOCKER_RUN_IMAGE" ls /vim-build/bin | grep '^neovim\|^vim' ); do
-    if ( [[ $vim =~ ^vim-v8.0 ]] && ((run_vim_80_tests)) ) \
-    || ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
+    if ( [[ $vim =~ ^vim-v8.2 ]] && ((run_vim_82_tests)) ) \
+    || ( [[ $vim =~ ^vim-v9.0 ]] && ((run_vim_90_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.2 ]] && ((run_neovim_02_tests)) ) \
     || ( [[ $vim =~ ^neovim-v0.7 ]] && ((run_neovim_07_tests)) ); then
         echo "Starting Vim: $vim..."


### PR DESCRIPTION
Replaces vim 8.0 with vim 9.0 in the test scripts.

Closes #4242 