### PR TITLE
WIP Better pylint message equivalence

### DIFF
--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -93,6 +93,15 @@ function! ale_linters#python#pylint#Handle(buffer, lines) abort
         if l:code[:0] is# 'E'
             let l:item.type = 'E'
         endif
+        
+        if l:code[:0] is# 'C'
+            let l:item.type = 'W'
+            let l:item.subtype = 'style'
+        endif
+
+        if l:code[:0] is# 'R'
+            let l:item.type = 'I'
+        endif
 
         call add(l:output, l:item)
     endfor


### PR DESCRIPTION
Pylint has [6 error categories](https://pylint.pycqa.org/en/latest/user_guide/messages/index.html), and currently ALE maps them to two: Error and Warning (all codes that are not errors are classified as warnings)

This patch proposes the following mapping:
[Error](https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html#error-category) => `ALEError`
[Warning](https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html#warning-category) => `ALEWarning`
[Convention](https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html#convention-category) => `ALEStyleWarning`
[Refactor](https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html#refactor-category) => `ALEInfo`

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
