### PR TITLE
Use native virtual-text for vim9

### DIFF
--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -8,14 +8,21 @@ let g:ale_virtualtext_delay = get(g:, 'ale_virtualtext_delay', 10)
 let s:cursor_timer = -1
 let s:last_pos = [0, 0, 0]
 let s:has_virt_text = 0
+let s:emulate_virt = 0
 
 if has('nvim-0.3.2')
     let s:ns_id = nvim_create_namespace('ale')
     let s:has_virt_text = 1
 elseif has('textprop') && has('popupwin')
-    call prop_type_add('ale', {})
-    let s:last_popup = -1
     let s:has_virt_text = 1
+    let s:emulate_virt = !has('patch-9.0.0214')
+
+    if s:emulate_virt
+        call prop_type_add('ale', {})
+        let s:last_virt = -1
+    else
+        let s:last_virt = 1
+    endif
 endif
 
 function! ale#virtualtext#Clear() abort
@@ -28,10 +35,13 @@ function! ale#virtualtext#Clear() abort
     if has('nvim')
         call nvim_buf_clear_highlight(l:buffer, s:ns_id, 0, -1)
     else
-        if s:last_popup != -1
+        if s:emulate_virt && s:last_virt != -1
             call prop_remove({'type': 'ale'})
-            call popup_close(s:last_popup)
-            let s:last_popup = -1
+            call popup_close(s:last_virt)
+            let s:last_virt = -1
+        elseif s:last_virt != 1
+            call prop_remove({'id': s:last_virt})
+            let s:last_virt = 1
         endif
     endif
 endfunction
@@ -48,12 +58,12 @@ function! ale#virtualtext#ShowMessage(message, hl_group) abort
 
     if has('nvim')
         call nvim_buf_set_virtual_text(l:buffer, s:ns_id, l:line-1, [[l:msg, a:hl_group]], {})
-    else
+    elseif s:emulate_virt
         let l:left_pad = col('$')
         call prop_add(l:line, l:left_pad, {
         \ 'type': 'ale',
         \})
-        let s:last_popup = popup_create(l:msg, {
+        let s:last_virt = popup_create(l:msg, {
         \ 'line': -1,
         \ 'padding': [0, 0, 0, 1],
         \ 'mask': [[1, 1, 1, 1]],
@@ -62,6 +72,17 @@ function! ale#virtualtext#ShowMessage(message, hl_group) abort
         \ 'fixed': 1,
         \ 'wrap': 0,
         \ 'zindex': 2
+        \})
+    else
+        let type = prop_type_get(a:hl_group)
+
+        if type == {}
+            call prop_type_add(a:hl_group, {'highlight': a:hl_group})
+        endif
+
+        let s:last_virt = prop_add(l:line, 0, {
+        \ 'type': a:hl_group,
+        \ 'text': ' ' . l:msg
         \})
     endif
 endfunction


### PR DESCRIPTION
This reimplements virtual text for vim with the new native virtual text API. Please see the commit message for more details.

When this gets merged, I can finally tackle #2962 and implement multiple virtual texts being visible at once.

# Screenshot

Before: At the top (implementation is a bit janky)
After: At the bottom (jank is fixed with native virtual text)
![Screenshot_20220812_135049](https://user-images.githubusercontent.com/21310755/184348342-c12d471a-e31b-4b11-b4d1-db20bf02a550.png)