### PR TITLE
Added flag to avoid mod files be generated in current dir

### DIFF
--- a/ale_linters/fortran/gcc.vim
+++ b/ale_linters/fortran/gcc.vim
@@ -5,7 +5,7 @@
 call ale#Set('fortran_gcc_use_free_form', 1)
 call ale#Set('fortran_gcc_executable', 'gcc')
 " Set this option to change the GCC options for warnings for Fortran.
-call ale#Set('fortran_gcc_options', '-Wall')
+call ale#Set('fortran_gcc_options', '-J/tmp/ -Wall')
 
 function! ale_linters#fortran#gcc#Handle(buffer, lines) abort
     " We have to match a starting line and a later ending line together,

--- a/doc/ale-fortran.txt
+++ b/doc/ale-fortran.txt
@@ -17,7 +17,7 @@ g:ale_fortran_gcc_executable                     *g:ale_fortran_gcc_executable*
 g:ale_fortran_gcc_options                           *g:ale_fortran_gcc_options*
                                                     *b:ale_fortran_gcc_options*
   Type: |String|
-  Default: `'-Wall'`
+  Default: `'-J/tmp/ -Wall'`
 
   This variable can be changed to modify flags given to gcc.
 


### PR DESCRIPTION
ALE keeps generating mod files to the current Dir and that may conflict with the project you are working with and be pretty annoying as you edit the files and it seems there is no effect (the thing is that the wrong module 'mod', generated by ALE, is being loaded).

So, I added `-J/tmp/` as it says [GCC docs](https://gcc.gnu.org/onlinedocs/gcc-4.3.3/gfortran/Directory-Options.html#Directory-Options)

Edit: I just realized that this is not portable at all... so this is more like an issue than a PR