### PR TITLE
Fix virtual text for vim 8.2

### DIFF
--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -39,7 +39,7 @@ function! ale#virtualtext#Clear() abort
             call prop_remove({'type': 'ale'})
             call popup_close(s:last_virt)
             let s:last_virt = -1
-        elseif s:last_virt != 1
+        elseif !s:emulate_virt && s:last_virt != 1
             call prop_remove({'id': s:last_virt})
             let s:last_virt = 1
         endif


### PR DESCRIPTION
See #4290

We need to guard the if condition with another check for whether we are running vim 9, otherwise it is possible to enter vim 9 code paths even when we are using vim 8.2.
