### PR TITLE
omni: find last racket keyword for completion

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -139,7 +139,7 @@ let s:should_complete_map = {
 " Regular expressions for finding the start column to replace with completion.
 let s:omni_start_map = {
 \   '<default>': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$',
-\   'racket': '\k\+',
+\   'racket': '\k\+$',
 \}
 
 " A map of exact characters for triggering LSP completions. Do not forget to


### PR DESCRIPTION
Otherwise it finds the first keyword, which is usually not relevant to the
cursor position, and incorrectly calculates the completion position.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
