### PR TITLE
Make `astyle` under `:ALEFix` operate on buffer

### DIFF
--- a/autoload/ale/fixers/astyle.vim
+++ b/autoload/ale/fixers/astyle.vim
@@ -49,11 +49,9 @@ endfunction
 function! ale#fixers#astyle#Fix(buffer) abort
     let l:executable = ale#fixers#astyle#Var(a:buffer, 'executable')
     let l:proj_options = ale#fixers#astyle#FindProjectOptions(a:buffer)
-    let l:command = ' --stdin=' . ale#Escape(expand('#' . a:buffer))
 
     return {
     \   'command': ale#Escape(l:executable)
     \     . (empty(l:proj_options) ? '' : ' --project=' . l:proj_options)
-    \     . l:command
     \}
 endfunction

--- a/test/fixers/test_astyle_fixer_callback.vader
+++ b/test/fixers/test_astyle_fixer_callback.vader
@@ -25,7 +25,6 @@ Execute(The astyle callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_c_astyle_executable)
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -39,7 +38,6 @@ Execute(The astyle callback should support cpp files):
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_cpp_astyle_executable)
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -53,7 +51,6 @@ Execute(The astyle callback should support cpp files with option file set):
   \ {
   \   'command': ale#Escape('invalidpp')
   \     . ' --project=' . g:ale_cpp_astyle_project_options
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -66,7 +63,6 @@ Execute(The astyle callback should return the correct default values with a spec
   \ {
   \   'command': ale#Escape('xxxinvalid')
   \     . ' --project=' . g:ale_c_astyle_project_options
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -78,7 +74,6 @@ Execute(The astyle callback should find nearest default option file _astylrc):
   \ {
   \   'command': ale#Escape('xxxinvalid')
   \     . ' --project=_astylerc'
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))
 
@@ -91,6 +86,5 @@ Execute(The astyle callback should find .astylrc in the same directory as src):
   \ {
   \   'command': ale#Escape('invalidpp')
   \     . ' --project=.astylerc'
-  \     . ' --stdin=' . ale#Escape(targetfile)
   \ },
   \ ale#fixers#astyle#Fix(bufnr(''))


### PR DESCRIPTION
Previously, `:ALEFix` made `astyle` operate on the disk file, and populated the buffer with the results, potentially losing work.

This PR regresses #3257, but that appears to be a bug with `astyle` itself, not with `ale`, so it should be fixed there anyways. I feel avoiding data-loss should be a higher goal than working around `astyle` bugs.

Thanks for your awesome work!