### PR TITLE
Fall back `ale#c#FindProjectRoot` on buffer dirname.

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -286,6 +286,13 @@ function! ale#c#FindProjectRoot(buffer) abort
         endfor
     endif
 
+    " Fall back on buffer dirname.
+    if empty(l:root)
+        let l:path = fnamemodify(bufname(a:buffer), ':p:h')
+
+        return l:path
+    endif
+
     return l:root
 endfunction
 

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -142,6 +142,8 @@ function! s:OnReady(line, column, options, capability, linter, lsp_details) abor
             let l:message = ale#lsp#message#TypeDefinition(l:buffer, a:line, a:column)
         elseif a:capability is# 'implementation'
             let l:message = ale#lsp#message#Implementation(l:buffer, a:line, a:column)
+        elseif a:capability is# 'declaration'
+            let l:message = ale#lsp#message#Declaration(l:buffer, a:line, a:column)
         else
             " XXX: log here?
             return
@@ -191,6 +193,14 @@ function! ale#definition#GoToImpl(options) abort
     endfor
 endfunction
 
+function! ale#definition#GoToDecl(options) abort
+    for l:linter in ale#linter#Get(&filetype)
+        if !empty(l:linter.lsp)
+            call s:GoToLSPDefinition(l:linter, a:options, 'declaration')
+        endif
+    endfor
+endfunction
+
 function! ale#definition#GoToCommandHandler(command, ...) abort
     let l:options = {}
 
@@ -218,6 +228,8 @@ function! ale#definition#GoToCommandHandler(command, ...) abort
         call ale#definition#GoToType(l:options)
     elseif a:command is# 'implementation'
         call ale#definition#GoToImpl(l:options)
+    elseif a:command is# 'declaration'
+        call ale#definition#GoToDecl(l:options)
     else
         call ale#definition#GoTo(l:options)
     endif

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -45,6 +45,7 @@ function! ale#lsp#Register(executable_or_address, project, init_options) abort
         \       'definition': 0,
         \       'typeDefinition': 0,
         \       'implementation': 0,
+        \       'declaration': 0,
         \       'symbol_search': 0,
         \       'code_actions': 0,
         \       'did_save': 0,
@@ -268,6 +269,14 @@ function! s:UpdateCapabilities(conn, capabilities) abort
         let a:conn.capabilities.implementation = 1
     endif
 
+    if get(a:capabilities, 'declarationProvider') is v:true
+        let a:conn.capabilities.declaration = 1
+    endif
+
+    if type(get(a:capabilities, 'declarationProvider')) is v:t_dict
+        let a:conn.capabilities.declaration = 1
+    endif
+
     if get(a:capabilities, 'workspaceSymbolProvider') is v:true
         let a:conn.capabilities.symbol_search = 1
     endif
@@ -389,6 +398,7 @@ function! ale#lsp#MarkConnectionAsTsserver(conn_id) abort
     let l:conn.capabilities.definition = 1
     let l:conn.capabilities.typeDefinition = 1
     let l:conn.capabilities.implementation = 1
+    let l:conn.capabilities.declaration = 1
     let l:conn.capabilities.symbol_search = 1
     let l:conn.capabilities.rename = 1
     let l:conn.capabilities.filerename = 1
@@ -449,6 +459,10 @@ function! s:SendInitMessage(conn) abort
     \                   'dynamicRegistration': v:false,
     \               },
     \               'implementation': {
+    \                   'dynamicRegistration': v:false,
+    \                   'linkSupport': v:false,
+    \               },
+    \               'declaration': {
     \                   'dynamicRegistration': v:false,
     \                   'linkSupport': v:false,
     \               },

--- a/autoload/ale/lsp/message.vim
+++ b/autoload/ale/lsp/message.vim
@@ -148,6 +148,15 @@ function! ale#lsp#message#Implementation(buffer, line, column) abort
     \}]
 endfunction
 
+function! ale#lsp#message#Declaration(buffer, line, column) abort
+    return [0, 'textDocument/declaration', {
+    \   'textDocument': {
+    \       'uri': ale#util#ToURI(expand('#' . a:buffer . ':p')),
+    \   },
+    \   'position': {'line': a:line - 1, 'character': a:column - 1},
+    \}]
+endfunction
+
 function! ale#lsp#message#References(buffer, line, column) abort
     return [0, 'textDocument/references', {
     \   'textDocument': {

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -323,6 +323,7 @@ nnoremap <silent> <Plug>(ale_go_to_type_definition) :ALEGoToTypeDefinition<Retur
 nnoremap <silent> <Plug>(ale_go_to_type_definition_in_tab) :ALEGoToTypeDefinition -tab<Return>
 nnoremap <silent> <Plug>(ale_go_to_type_definition_in_split) :ALEGoToTypeDefinition -split<Return>
 nnoremap <silent> <Plug>(ale_go_to_type_definition_in_vsplit) :ALEGoToTypeDefinitionIn -vsplit<Return>
+nnoremap <silent> <Plug>(ale_go_to_implementation) :ALEGoToImplementation<Return>
 nnoremap <silent> <Plug>(ale_go_to_implementation_in_tab) :ALEGoToImplementation -tab<Return>
 nnoremap <silent> <Plug>(ale_go_to_implementation_in_split) :ALEGoToImplementation -split<Return>
 nnoremap <silent> <Plug>(ale_go_to_implementation_in_vsplit) :ALEGoToImplementation -vsplit<Return>

--- a/plugin/ale.vim
+++ b/plugin/ale.vim
@@ -256,6 +256,9 @@ command! -bar -nargs=* ALEGoToTypeDefinition :call ale#definition#GoToCommandHan
 " Go to implementation for tsserver and LSP
 command! -bar -nargs=* ALEGoToImplementation :call ale#definition#GoToCommandHandler('implementation', <f-args>)
 
+" Go to declaration for tsserver and LSP
+command! -bar -nargs=* ALEGoToDeclaration :call ale#definition#GoToCommandHandler('declaration', <f-args>)
+
 " Repeat a previous selection in the preview window
 command! -bar ALERepeatSelection :call ale#preview#RepeatSelection()
 
@@ -327,6 +330,10 @@ nnoremap <silent> <Plug>(ale_go_to_implementation) :ALEGoToImplementation<Return
 nnoremap <silent> <Plug>(ale_go_to_implementation_in_tab) :ALEGoToImplementation -tab<Return>
 nnoremap <silent> <Plug>(ale_go_to_implementation_in_split) :ALEGoToImplementation -split<Return>
 nnoremap <silent> <Plug>(ale_go_to_implementation_in_vsplit) :ALEGoToImplementation -vsplit<Return>
+nnoremap <silent> <Plug>(ale_go_to_declaration) :ALEGoToDeclaration<Return>
+nnoremap <silent> <Plug>(ale_go_to_declaration_in_tab) :ALEGoToDeclaration -tab<Return>
+nnoremap <silent> <Plug>(ale_go_to_declaration_in_split) :ALEGoToDeclaration -split<Return>
+nnoremap <silent> <Plug>(ale_go_to_declaration_in_vsplit) :ALEGoToDeclaration -vsplit<Return>
 nnoremap <silent> <Plug>(ale_find_references) :ALEFindReferences<Return>
 nnoremap <silent> <Plug>(ale_hover) :ALEHover<Return>
 nnoremap <silent> <Plug>(ale_documentation) :ALEDocumentation<Return>


### PR DESCRIPTION
LSP linters should have a sane default project root.

This is useful when linting a single file.

Solves https://github.com/dense-analysis/ale/issues/4240
