### PR TITLE
Allow to pass options to the buf linter

### DIFF
--- a/ale_linters/proto/buf_lint.vim
+++ b/ale_linters/proto/buf_lint.vim
@@ -3,12 +3,15 @@
 
 call ale#Set('proto_buf_lint_executable', 'buf')
 call ale#Set('proto_buf_lint_config', '')
+call ale#Set('proto_buf_lint_options', '')
 
 function! ale_linters#proto#buf_lint#GetCommand(buffer) abort
     let l:config = ale#Var(a:buffer, 'proto_buf_lint_config')
+    let l:options = ale#Var(a:buffer, 'proto_buf_lint_options')
 
     return '%e lint'
     \ . (!empty(l:config) ? ' --config=' . ale#Escape(l:config) : '')
+    \ . (!empty(l:options) ? ' ' . l:options : '')
     \ . ' %s#include_package_files=true'
 endfunction
 

--- a/test/linter/test_buf_lint.vader
+++ b/test/linter/test_buf_lint.vader
@@ -11,7 +11,7 @@ Execute(The default command should be correct):
   \ . ' lint'
   \ . ' %s#include_package_files=true'
 
-Execute(The callback should include any additional options):
+Execute(The callback should include any additional config):
   let b:ale_proto_buf_lint_executable = '/tmp/buf'
   let b:ale_proto_buf_lint_config = '/tmp/buf.yaml'
 
@@ -19,4 +19,14 @@ Execute(The callback should include any additional options):
   \ ale#Escape('/tmp/buf')
   \ . ' lint'
   \ . ' --config=' . ale#Escape('/tmp/buf.yaml')
+  \ . ' %s#include_package_files=true'
+
+Execute(The callback should include additional options):
+  let b:ale_proto_buf_lint_executable = '/tmp/buf'
+  let b:ale_proto_buf_lint_options = '--disable-symlinks'
+
+  AssertLinter '/tmp/buf',
+  \ ale#Escape('/tmp/buf')
+  \ . ' lint'
+  \ . ' --disable-symlinks'
   \ . ' %s#include_package_files=true'


### PR DESCRIPTION
I need to pass `--disable-symlinks` to the `buf lint` command.