### PR TITLE
Deno: find project root using deno.json/deno.jsonc

### DIFF
--- a/autoload/ale/handlers/deno.vim
+++ b/autoload/ale/handlers/deno.vim
@@ -29,6 +29,8 @@ function! ale#handlers#deno#GetProjectRoot(buffer) abort
     endif
 
     let l:possible_project_roots = [
+    \   'deno.json',
+    \   'deno.jsonc',
     \   'tsconfig.json',
     \   '.git',
     \   bufname(a:buffer),


### PR DESCRIPTION
Deno LSP automatically detects config files named deno.json or deno.jsonc since version 1.18.

For Deno 1.18+ this means that ALE no longer needs to resolve the project root. However, removing the project root logic from ALE means breaking changes for people that are still using an older version. Adding deno.json to the list of looking files to look for will keep the behavior consistent and compatible with the Deno config file naming convention.

See also:
https://deno.com/blog/v1.18#auto-discovery-of-the-config-file