### PR TITLE
Allows configuring slim executable

### DIFF
--- a/ale_linters/slim/slimlint.vim
+++ b/ale_linters/slim/slimlint.vim
@@ -1,6 +1,8 @@
 " Author: Markus Doits - https://github.com/doits
 " Description: slim-lint for Slim files
 
+call ale#Set('ruby_slim_executable', 'slimlint')
+
 function! ale_linters#slim#slimlint#GetCommand(buffer) abort
     let l:command = 'slim-lint %t'
 
@@ -49,7 +51,7 @@ endfunction
 
 call ale#linter#Define('slim', {
 \   'name': 'slimlint',
-\   'executable': 'slim-lint',
+\   'executable': {b -> ale#Var(b, 'ruby_slim_executable')},
 \   'command': function('ale_linters#slim#slimlint#GetCommand'),
 \   'callback': 'ale_linters#slim#slimlint#Handle'
 \})


### PR DESCRIPTION
User should be able to configure the executable that runs slim linting i.e. setting g:ale_ruby_slim_executable to 'bundle' should run `bundle exec slimlint`, the same way it does with rubocop.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
