### PR TITLE
Fix jsonnet lint pattern

### DIFF
--- a/ale_linters/jsonnet/jsonnet_lint.vim
+++ b/ale_linters/jsonnet/jsonnet_lint.vim
@@ -19,7 +19,7 @@ function! ale_linters#jsonnet#jsonnet_lint#Handle(buffer, lines) abort
     " ERROR: foo.jsonnet:22:3-12 expected token OPERATOR but got (IDENTIFIER, "bar")
     " ERROR: hoge.jsonnet:20:3 unexpected: "}" while parsing terminal
     " ERROR: main.jsonnet:212:1-14 Expected , or ; but got (IDENTIFIER, "older_cluster")
-    let l:pattern = '^ERROR: [^:]*:\(\d\+\):\(\d\+\)\(-\d\+\)* \(.*\)'
+    let l:pattern = '^[^:]*:\(\d\+\):\(\d\+\)\(-\d\+\)* \(.*\)'
     let l:output = []
 
     for l:line in a:lines


### PR DESCRIPTION
The current version does not prefix the output with ERROR anymore e.g:
`hoi.jsonnet:5:3-8 Expected a comma before next field`