### PR TITLE
Pass input via stdin and filename as arg to clj-kondo

### DIFF
--- a/ale_linters/clojure/clj_kondo.vim
+++ b/ale_linters/clojure/clj_kondo.vim
@@ -8,7 +8,8 @@ function! ale_linters#clojure#clj_kondo#GetCommand(buffer) abort
 
     let l:command = 'clj-kondo'
     \   . ale#Pad(l:options)
-    \   . ' --lint %t'
+    \   . ' --lint -'
+    \   . ' --filename %s'
 
     return l:command
 endfunction

--- a/test/linter/test_clj_kondo.vader
+++ b/test/linter/test_clj_kondo.vader
@@ -6,10 +6,10 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'clj-kondo', 'clj-kondo'
-  \   . ' --cache --lint %t'
+  \   . ' --cache --lint - --filename %s'
 
 Execute(Extra options should be supported):
   let g:ale_clojure_clj_kondo_options = '--config ./clj-kondo/config.edn'
 
   AssertLinter 'clj-kondo', 'clj-kondo'
-  \   . ' --config ./clj-kondo/config.edn --lint %t'
+  \   . ' --config ./clj-kondo/config.edn --lint - --filename %s'


### PR DESCRIPTION
This allows using linters like `:namespace-name-mismatch`.

This replaces: https://github.com/dense-analysis/ale/pull/4109
