### PR TITLE
Add pyright config files to project root files list

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -33,6 +33,8 @@ function! ale#python#FindProjectRootIni(buffer) abort
         \|| filereadable(l:path . '/pylama.ini')
         \|| filereadable(l:path . '/pylintrc')
         \|| filereadable(l:path . '/.pylintrc')
+        \|| filereadable(l:path . '/pyrightconfig.json')
+        \|| filereadable(l:path . '/pyrightconfig.toml')
         \|| filereadable(l:path . '/Pipfile')
         \|| filereadable(l:path . '/Pipfile.lock')
         \|| filereadable(l:path . '/poetry.lock')

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -46,6 +46,8 @@ ALE will look for configuration files with the following filenames. >
   pylama.ini
   pylintrc
   .pylintrc
+  pyrightconfig.json
+  pyrightconfig.toml
   Pipfile
   Pipfile.lock
   poetry.lock


### PR DESCRIPTION
Add configuration files for pyright (JSON and TOML) to list of files which identify a project root directory. Update documentation accordingly.

Fixes #3964

This root-defining file list seems not to be tested as a quick comparison with `flake8`` tests indicates - hence no tests added for this PR as well.

