### PR TITLE
fix: make autoimport fixer read from file instead of stdin

### DIFF
--- a/autoload/ale/fixers/autoimport.vim
+++ b/autoload/ale/fixers/autoimport.vim
@@ -22,6 +22,7 @@ function! ale#fixers#autoimport#Fix(buffer) abort
     \   'cwd': '%s:h',
     \   'command': ale#Escape(l:executable)
     \       . (!empty(l:options) ? ' ' . l:options : '')
-    \       . ' -',
+    \       . ' %t',
+    \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_autoimport_fixer_callback.vader
+++ b/test/fixers/test_autoimport_fixer_callback.vader
@@ -26,7 +26,8 @@ Execute(The autoimport callback should return the correct default values):
   AssertEqual
   \ {
   \   'cwd': '%s:h',
-  \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/autoimport')) . ' -',
+  \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/autoimport')) . ' %t',
+  \   'read_temporary_file': 1,
   \ },
   \ ale#fixers#autoimport#Fix(bufnr(''))
 
@@ -42,6 +43,7 @@ Execute(The autoimport callback should respect custom options):
   \ {
   \   'cwd': '%s:h',
   \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/autoimport'))
-  \     . ' --multi-line=3 --trailing-comma -',
+  \     . ' --multi-line=3 --trailing-comma %t',
+  \   'read_temporary_file': 1,
   \ },
   \ ale#fixers#autoimport#Fix(bufnr(''))


### PR DESCRIPTION
Enables use of `--ignore-init-modules` flag introduced in https://github.com/lyz-code/autoimport/pull/228