### PR TITLE
add: support config option for checkmake linter

### DIFF
--- a/ale_linters/make/checkmake.vim
+++ b/ale_linters/make/checkmake.vim
@@ -1,5 +1,7 @@
 " Author: aurieh - https://github.com/aurieh
 
+call ale#Set('make_checkmake_config', '')
+
 function! ale_linters#make#checkmake#Handle(buffer, lines) abort
     let l:pattern = '\v^(\d+):(.+):(.+)$'
     let l:output = []
@@ -17,9 +19,19 @@ function! ale_linters#make#checkmake#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#make#checkmake#GetCommand(buffer) abort
+    let l:config = ale#Var(a:buffer, 'make_checkmake_config')
+    let l:cmd = 'checkmake'
+    \   . ' --format="{{.LineNumber}}:{{.Rule}}:{{.Violation}}{{\"\r\n\"}}"'
+    \   . (!empty(l:config) ? ' --config="' . l:config . '"' : '')
+    \   . ' %s'
+
+    return l:cmd
+endfunction
+
 call ale#linter#Define('make', {
 \   'name': 'checkmake',
 \   'executable': 'checkmake',
-\   'command': 'checkmake %s --format="{{.LineNumber}}:{{.Rule}}:{{.Violation}}{{\"\r\n\"}}"',
+\   'command': function('ale_linters#make#checkmake#GetCommand'),
 \   'callback': 'ale_linters#make#checkmake#Handle',
 \})

--- a/doc/ale-make.txt
+++ b/doc/ale-make.txt
@@ -1,0 +1,18 @@
+===============================================================================
+ALE Make Integration                                           *ale-make-options*
+
+
+===============================================================================
+checkmake                                                    *ale-make-checkmake*
+
+g:ale_make_checkmake_config                         *g:ale_make_checkmake_config*
+                                                    *b:ale_make_checkmake_config*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to set the `--config` option of checkmake command.
+  if the value is empty, the checkmake command will not be invoked with the
+  option.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3037,6 +3037,8 @@ documented in additional help files.
     luafmt................................|ale-lua-luafmt|
     selene................................|ale-lua-selene|
     stylua................................|ale-lua-stylua|
+  make....................................|ale-make-options|
+    checkmake.............................|ale-make-checkmake|
   markdown................................|ale-markdown-options|
     cspell................................|ale-markdown-cspell|
     dprint................................|ale-markdown-dprint|

--- a/test/linter/test_checkmake.vader
+++ b/test/linter/test_checkmake.vader
@@ -1,0 +1,39 @@
+Before:
+  Save g:ale_make_checkmake_config
+
+  let g:ale_make_checkmake_config = ''
+
+  call ale#assert#SetUpLinterTest('make', 'checkmake')
+
+  " NOTE: the format string must be manually matched that set in the plugin
+  let b:format = '"{{.LineNumber}}:{{.Rule}}:{{.Violation}}{{\"\r\n\"}}"'
+
+After:
+  Restore
+
+  unlet! b:command_tail
+  unlet! b:ale_make_checkmake_config
+
+  call ale#assert#TearDownLinterTest()
+
+Execute(checkmake should run with default format option):
+  let b:command_tail = ' --format=' . b:format . ' %s'
+
+  AssertLinter 'checkmake', 'checkmake' . b:command_tail
+
+Execute(checkmake command should take the config option if it is non-empty):
+  let g:ale_make_checkmake_config = '/path to/checkmake.ini'
+  let b:command_tail = ' --format=' . b:format
+  \ . ' --config="' . g:ale_make_checkmake_config . '"'
+  \ . ' %s'
+
+  AssertLinter 'checkmake', 'checkmake' . b:command_tail
+
+Execute(the local buffer config option takes precedence over global option):
+  let g:ale_make_checkmake_config = '/path/to/checkmake.ini'
+  let b:ale_make_checkmake_config = '/another/checkmake.ini'
+  let b:command_tail = ' --format=' . b:format
+  \ . ' --config="' . b:ale_make_checkmake_config . '"'
+  \ . ' %s'
+
+  AssertLinter 'checkmake', 'checkmake' . b:command_tail


### PR DESCRIPTION
`checkmake` by default checks config file _"in the same folder it's
executed in"_[^0] unless `--config` option is set.

This commit allows setting the `--config` option with an option
variable (with documentation updated).

[^0]: [configuration section on checkmake manual](https://github.com/mrtazz/checkmake/blob/main/man/man1/checkmake.1.md#configuration)