### PR TITLE
omni: racket should complete at end of keywords

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -130,6 +130,7 @@ let s:should_complete_map = {
 \   '<default>': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$|\.$',
 \   'clojure': s:lisp_regex,
 \   'lisp': s:lisp_regex,
+\   'racket': '\k\+$',
 \   'typescript': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$|\.$|''$|"$',
 \   'rust': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$|\.$|::$',
 \   'cpp': '\v[a-zA-Z$_][a-zA-Z$_0-9]*$|\.$|::$|-\>$',


### PR DESCRIPTION
Consider a file like
```
#lang racket
(require racket/gui)
```
Type `Go(eventspace-`.

Pressing <C-x><C-o> to trigger omnicomplete should suggest
```
eventspace-handler-thread
eventspace-shutdown?
eventspace-event-evt
```

It does not (instead producing "top-level" completions, as if `(eventspace-` wasn't even there).

Debugging, place the cursor on a space _after_. Now `ale#completion#OmniFunc(1, '')` correctly returns `1`, but when given `(0, 'eventspace-')` it returns either the empty list or generic completion results as described above. I'm not entirely sure of the mechanism, but it seems that `b:ale_completion_info.prefix` is the key, and that this is set by `ale#completion#GetPrefix`. Calling `ale#completion#GetPrefix('racket', line('.'), col('.'))` returned `''`!

Now, it returns `eventspace-` and the completions work correctly again.

Ref #4293, #4186, #3870