### PR TITLE
Add 'dockerfile_hadolint_options' config setting

### DIFF
--- a/ale_linters/dockerfile/hadolint.vim
+++ b/ale_linters/dockerfile/hadolint.vim
@@ -3,6 +3,7 @@
 " always, yes, never
 call ale#Set('dockerfile_hadolint_use_docker', 'never')
 call ale#Set('dockerfile_hadolint_docker_image', 'hadolint/hadolint')
+call ale#Set('dockerfile_hadolint_options', '')
 
 function! ale_linters#dockerfile#hadolint#Handle(buffer, lines) abort
     " Matches patterns line the following:
@@ -102,7 +103,7 @@ endfunction
 
 function! ale_linters#dockerfile#hadolint#GetCommand(buffer) abort
     let l:command = ale_linters#dockerfile#hadolint#GetExecutable(a:buffer)
-    let l:opts = '--no-color -'
+    let l:opts = ale#Var(a:buffer, 'dockerfile_hadolint_options') . ' --no-color -'
 
     if l:command is# 'docker'
         return printf('docker run --rm -i %s hadolint %s',

--- a/doc/ale-dockerfile.txt
+++ b/doc/ale-dockerfile.txt
@@ -37,6 +37,16 @@ hadolint                                              *ale-dockerfile-hadolint*
   hadolint can be found at: https://github.com/hadolint/hadolint
 
 
+g:ale_dockerfile_hadolint_options           *g:ale_dockerfile_hadolint_options*
+                                            *b:ale_dockerfile_hadolint_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to add command-line arguments to the hadolint
+  invocation. These arguments will be used whether docker is being used or not
+  (see below).
+
+
 g:ale_dockerfile_hadolint_use_docker     *g:ale_dockerfile_hadolint_use_docker*
                                          *b:ale_dockerfile_hadolint_use_docker*
   Type: |String|

--- a/test/test_dockerfile_hadolint_linter.vader
+++ b/test/test_dockerfile_hadolint_linter.vader
@@ -19,6 +19,7 @@ After:
   Restore
   silent! unlet b:ale_dockerfile_hadolint_use_docker
   silent! unlet b:ale_dockerfile_hadolint_docker_image
+  silent! unlet b:ale_dockerfile_hadolint_options
 
 
 Execute(linter honors ..._use_docker correctly):
@@ -55,15 +56,30 @@ Execute(command is correct when using docker):
   let b:ale_dockerfile_hadolint_use_docker = 'always'
 
   AssertEqual
-  \ "docker run --rm -i hadolint/hadolint hadolint --no-color -",
+  \ "docker run --rm -i hadolint/hadolint hadolint  --no-color -",
   \ ale_linters#dockerfile#hadolint#GetCommand(bufnr(''))
 
+Execute(command is correct when using docker and supplying options):
+  let b:ale_dockerfile_hadolint_use_docker = 'always'
+  let b:ale_dockerfile_hadolint_options = '--ignore DL3006'
+
+  AssertEqual
+  \ "docker run --rm -i hadolint/hadolint hadolint --ignore DL3006 --no-color -",
+  \ ale_linters#dockerfile#hadolint#GetCommand(bufnr(''))
 
 Execute(command is correct when not docker):
   let b:ale_dockerfile_hadolint_use_docker = 'never'
 
   AssertEqual
-  \ "hadolint --no-color -",
+  \ "hadolint  --no-color -",
+  \ ale_linters#dockerfile#hadolint#GetCommand(bufnr(''))
+
+Execute(command is correct when not docker and supplying options):
+  let b:ale_dockerfile_hadolint_use_docker = 'never'
+  let b:ale_dockerfile_hadolint_options = '--ignore DL3006'
+
+  AssertEqual
+  \ "hadolint --ignore DL3006 --no-color -",
   \ ale_linters#dockerfile#hadolint#GetCommand(bufnr(''))
 
 Execute(test warnings from hadolint):


### PR DESCRIPTION
This PR adds the ability for users to configure command line arguments to send to `hadolint` using the `ale_dockerfile_hadolint_options` setting. This setting is respected for running `hadolint` via the executable and in Docker.

The most direct issue this would fix is #2875. It's similar to a solution described in #4248, but my assumption is that `--no-color` is probably necessary or desired for Ale to parse the output and display it in Vim; and besides,  `--no-color` has been supported by `hadolint` for the last 17 versions (one a major bump), [first being introduced about 20 months ago now](https://github.com/hadolint/hadolint/releases/tag/v1.23.0), so I would guess there isn't a strong desire on Ale's part to support those older versions of `hadolint`. 

> Where are the tests? Have you added tests? Have you updated the tests? Read the comment above and the documentation referenced in it first. Write tests!
>
> Seriously, read `:help ale-dev` and write tests.

I made the necessary modifications to existing tests, and added a couple more for the positive cases using the new config setting. I also updated the docs and ran all the tests/linters before committing.