### PR TITLE
Fix 4246 - Add ansible language-server

### DIFF
--- a/ale_linters/ansible/ansible_language_server.vim
+++ b/ale_linters/ansible/ansible_language_server.vim
@@ -1,0 +1,46 @@
+" Author: Horacio Sanson <https://github.com/hsanson>
+" Description: Support ansible language server https://github.com/ansible/ansible-language-server/
+
+call ale#Set('ansible_language_server_executable', 'ansible-language-server')
+call ale#Set('ansible_language_server_config', {})
+
+function! ale_linters#ansible#ansible_language_server#Executable(buffer) abort
+    return ale#Var(a:buffer, 'ansible_language_server_executable')
+endfunction
+
+function! ale_linters#ansible#ansible_language_server#GetCommand(buffer) abort
+    let l:executable = ale_linters#ansible#ansible_language_server#Executable(a:buffer)
+
+    return ale#Escape(l:executable) . ' --stdio'
+endfunction
+
+function! ale_linters#ansible#ansible_language_server#FindProjectRoot(buffer) abort
+    let l:dir = fnamemodify(
+    \   ale#path#FindNearestFile(a:buffer, 'ansible.cfg'),
+    \   ':h'
+    \)
+
+    if l:dir isnot# '.' && isdirectory(l:dir)
+        return l:dir
+    endif
+
+    let l:dir = fnamemodify(
+    \   ale#path#FindNearestDirectory(a:buffer, '.git'),
+    \   ':h:h'
+    \)
+
+    if l:dir isnot# '.' && isdirectory(l:dir)
+        return l:dir
+    endif
+
+    return ''
+endfunction
+
+call ale#linter#Define('ansible', {
+\   'name': 'ansible-language-server',
+\   'lsp': 'stdio',
+\   'executable': function('ale_linters#ansible#ansible_language_server#Executable'),
+\   'command': function('ale_linters#ansible#ansible_language_server#GetCommand'),
+\   'project_root': function('ale_linters#ansible#ansible_language_server#FindProjectRoot'),
+\   'lsp_config': {b -> ale#Var(b, 'ansible_language_server_config')}
+\})

--- a/doc/ale-ansible.txt
+++ b/doc/ale-ansible.txt
@@ -1,6 +1,28 @@
 ===============================================================================
 ALE Ansible Integration                                   *ale-ansible-options*
 
+===============================================================================
+ansible-language-server                             *ale-ansible-language-server*
+
+
+g:ale_ansible_language_server_executable          *g:ale_ansible_language_server*
+                                                  *b:ale_ansible_language_server*
+
+  Type: |String|
+  Default: 'ansible-language-server'
+
+  Variable can be used to modify the executable used for ansible language server.
+
+
+g:ale_ansible_language_server_config        *g:ale_ansible_language_server_config*
+                                            *b:ale_ansible_language_server_config*
+
+  Type: |Dictionary|
+  Default: '{}'
+
+  Configuration parameters sent to the language server on start. Refer to the
+  ansible language server configuration documentation for list of available
+  options: https://als.readthedocs.io/en/latest/settings/
 
 ===============================================================================
 ansible-lint                                         *ale-ansible-ansible-lint*
@@ -11,6 +33,7 @@ g:ale_ansible_ansible_lint_executable   *g:ale_ansible_ansible_lint_executable*
   Default: `'ansible-lint'`
 
   This variable can be changed to modify the executable used for ansible-lint.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -18,6 +18,7 @@ Notes:
   * `gcc`
   * `gnatpp`
 * Ansible
+  * `ansible-language-server`
   * `ansible-lint`!!
 * API Blueprint
   * `drafter`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2767,6 +2767,7 @@ documented in additional help files.
     gnatpp................................|ale-ada-gnatpp|
     ada-language-server...................|ale-ada-language-server|
   ansible.................................|ale-ansible-options|
+    ansible-language-server...............|ale-ansible-language-server|
     ansible-lint..........................|ale-ansible-ansible-lint|
   apkbuild................................|ale-apkbuild-options|
     apkbuild-lint.........................|ale-apkbuild-apkbuild-lint|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -27,6 +27,7 @@ formatting.
   * [gcc](https://gcc.gnu.org)
   * [gnatpp](https://docs.adacore.com/gnat_ugn-docs/html/gnat_ugn/gnat_ugn/gnat_utility_programs.html#the-gnat-pretty-printer-gnatpp) :floppy_disk:
 * Ansible
+  * [ansible-language-server](https://github.com/ansible/ansible-language-server/)
   * [ansible-lint](https://github.com/willthames/ansible-lint) :floppy_disk:
 * API Blueprint
   * [drafter](https://github.com/apiaryio/drafter)

--- a/test/linter/test_ansible_language_server.vader
+++ b/test/linter/test_ansible_language_server.vader
@@ -1,0 +1,18 @@
+Before:
+  call ale#assert#SetUpLinterTest('ansible', 'ansible_language_server')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The ansible language server command callback should return default string):
+  AssertLinter 'ansible-language-server', ale#Escape('ansible-language-server') . ' --stdio'
+
+Execute(The ansible language server executable should be configurable):
+  let g:ale_ansible_language_server_executable = '~/.local/bin/als'
+
+  AssertLinter '~/.local/bin/als' , ale#Escape('~/.local/bin/als') . ' --stdio'
+
+Execute(Should accept configuration settings):
+  AssertLSPConfig {}
+  let b:ale_ansible_language_server_config = {'ansible-language-server': {'ansible': {'completion': {'provideRedirectModules': v:false}}}}
+  AssertLSPConfig {'ansible-language-server': {'ansible': {'completion': {'provideRedirectModules': v:false}}}}


### PR DESCRIPTION
This PR add support for ansible language server.  Only tested on simple ansible files and seems to work properly.

Requires more testing, specially when setting custom configurations to the language server.

Is recommended to have an ansible plugin capable of detecting ansible files and set proper file type (e.g. https://github.com/pearofducks/ansible-vim) to ensure the language server is started.


Closes #4246
