### PR TITLE
Markdown: allow passing custom executable for markdownlint

### DIFF
--- a/ale_linters/markdown/markdownlint.vim
+++ b/ale_linters/markdown/markdownlint.vim
@@ -1,10 +1,15 @@
 " Author: Ty-Lucas Kelley <tylucaskelley@gmail.com>
 " Description: Adds support for markdownlint
 
+call ale#Set('markdown_markdownlint_executable', 'markdownlint')
 call ale#Set('markdown_markdownlint_options', '')
 
+function! ale_linters#markdown#markdownlint#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'markdown_markdownlint_executable')
+endfunction
+
 function! ale_linters#markdown#markdownlint#GetCommand(buffer) abort
-    let l:executable = 'markdownlint'
+    let l:executable = ale_linters#markdown#markdownlint#GetExecutable(a:buffer)
 
     let l:options = ale#Var(a:buffer, 'markdown_markdownlint_options')
 
@@ -14,7 +19,7 @@ endfunction
 
 call ale#linter#Define('markdown', {
 \   'name': 'markdownlint',
-\   'executable': 'markdownlint',
+\   'executable': function('ale_linters#markdown#markdownlint#GetExecutable'),
 \   'lint_file': 1,
 \   'output_stream': 'both',
 \   'command': function('ale_linters#markdown#markdownlint#GetCommand'),

--- a/doc/ale-markdown.txt
+++ b/doc/ale-markdown.txt
@@ -17,6 +17,15 @@ See |ale-dprint-options| and https://dprint.dev/plugins/markdown
 ===============================================================================
 markdownlint                                        *ale-markdown-markdownlint*
 
+g:ale_markdown_markdown_executable     *g:ale_markdown_markdownlint_executable*
+                                       *b:ale_markdown_markdownlint_executable*
+  Type: |String|
+  Default: `'markdownlint'`
+
+  Override the invoked markdownlint binary. You can use other binaries such as
+  markdownlint-cli2.
+
+
 g:ale_markdown_markdownlint_options       *g:ale_markdown_markdownlint_options*
                                           *b:ale_markdown_markdownlint_options*
   Type: |String|

--- a/test/linter/test_markdown_markdownlint.vader
+++ b/test/linter/test_markdown_markdownlint.vader
@@ -7,6 +7,11 @@ After:
 Execute(The default command should be correct):
   AssertLinter 'markdownlint', ale#Escape('markdownlint') . ' %s'
 
+Execute(The executable should be configurable):
+  let g:ale_markdown_markdownlint_executable = 'foo bar'
+
+  AssertLinter 'foo bar', ale#Escape('foo bar') . ' %s'
+
 Execute(The options should be configurable):
   let g:ale_markdown_markdownlint_options = '--config ~/custom/.markdownlintrc'
 


### PR DESCRIPTION
Should fix #3750.