### PR TITLE
Handle empty answer of ansible-lint

### DIFF
--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -25,12 +25,7 @@ function! ale_linters#ansible#ansible_lint#Handle(buffer, version, lines) abort
 
     if '>=6.0.0' is# l:version_group
         let l:error_codes = { 'blocker': 'E', 'critical': 'E', 'major': 'W', 'minor': 'W', 'info': 'I' }
-
-        if join(a:lines, '') == ''
-            let l:linter_issues = []
-        else
-            let l:linter_issues = json_decode(join(a:lines, ''))
-        endif
+        let l:linter_issues = ale#util#FuzzyJSONDecode(a:lines, [])
 
         for l:issue in l:linter_issues
             if ale#path#IsBufferPath(a:buffer, l:issue.location.path)

--- a/ale_linters/ansible/ansible_lint.vim
+++ b/ale_linters/ansible/ansible_lint.vim
@@ -25,7 +25,12 @@ function! ale_linters#ansible#ansible_lint#Handle(buffer, version, lines) abort
 
     if '>=6.0.0' is# l:version_group
         let l:error_codes = { 'blocker': 'E', 'critical': 'E', 'major': 'W', 'minor': 'W', 'info': 'I' }
-        let l:linter_issues = json_decode(join(a:lines, ''))
+
+        if join(a:lines, '') == ''
+            let l:linter_issues = []
+        else
+            let l:linter_issues = json_decode(join(a:lines, ''))
+        endif
 
         for l:issue in l:linter_issues
             if ale#path#IsBufferPath(a:buffer, l:issue.location.path)

--- a/test/handler/test_ansible_lint_handler.vader
+++ b/test/handler/test_ansible_lint_handler.vader
@@ -93,3 +93,9 @@ Execute (The ansible-lint handler should ignore errors from other files):
   \ ale_linters#ansible#ansible_lint#Handle(bufnr(''), [5, 1, 2], [
   \   '/foo/bar/roles/test_playbook.yml:6: [command-instead-of-module] [VERY_LOW] curl used in place of get_url or uri module',
   \ ])
+
+Execute (The ansible-lint handler should work with empty input):
+  AssertEqual
+  \ [
+  \ ],
+  \ ale_linters#ansible#ansible_lint#Handle(bufnr(''), [6, 0, 0], [])


### PR DESCRIPTION
The variable a:lines might be empty if ansible-lint exited early, in that case json_decode would trow an error. 
Closes #4303