### PR TITLE
nix: durably handle versions before 2.4

### DIFF
--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -5,10 +5,10 @@
 function! ale_linters#nix#nix#Command(buffer, output, meta) abort
     let l:version = a:output[0][22:]
 
-    if l:version =~# '^\(2.[4-9]\|2.[1-9][0-9]\+\|3\).*'
-        return 'nix-instantiate --log-format internal-json --parse -'
-    else
+    if l:version =~# '^\(1\|2.[0-3]\.\).*'
         return 'nix-instantiate --parse -'
+    else
+        return 'nix-instantiate --log-format internal-json --parse -'
     endif
 endfunction
 


### PR DESCRIPTION
What I should have done in #4394. Idea: @w0rp
