### PR TITLE
Add support for llvm-mc as an assembly linter

### DIFF
--- a/ale_linters/asm/llvm_mc.vim
+++ b/ale_linters/asm/llvm_mc.vim
@@ -1,0 +1,37 @@
+" Author: uidops <uidops@protonmail.com>
+" Description: llvm-mc linter for asm files
+
+call ale#Set('asm_llvm_mc_executable', 'llvm-mc')
+call ale#Set('asm_llvm_mc_options', '')
+
+function! ale_linters#asm#llvm_mc#GetCommand(buffer) abort
+    return '%e --assemble'
+    \  . ' --filetype=asm'
+    \  . ' -o ' . g:ale#util#nul_file
+    \  . ' ' . ale#Var(a:buffer, 'asm_llvm_mc_options')
+endfunction
+
+function! ale_linters#asm#llvm_mc#Handle(buffer, lines) abort
+    let l:pattern = '^.\+:\(\d\+\):\(\d\+\): \([^:]\+\): \(.\+\)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \  'lnum': l:match[1] + 0,
+        \  'col': l:match[2] + 0,
+        \  'type': l:match[3] =~? 'error' ? 'E' : 'W',
+        \  'text': l:match[4],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('asm', {
+\    'name': 'llvm_mc',
+\    'output_stream': 'stderr',
+\    'executable': {b -> ale#Var(b, 'asm_llvm_mc_executable')},
+\    'command': function('ale_linters#asm#llvm_mc#GetCommand'),
+\    'callback': 'ale_linters#asm#llvm_mc#Handle',
+\})
+

--- a/doc/ale-asm.txt
+++ b/doc/ale-asm.txt
@@ -22,4 +22,23 @@ g:ale_asm_gcc_options                                   *g:ale_asm_gcc_options*
 
 
 ===============================================================================
+llvm_mc                                                       *ale-asm-llvm_mc*
+
+g:ale_asm_clang_executable                       *g:ale_asm_llvm_mc_executable*
+                                                 *b:ale_asm_llvm_mc_executable*
+  Type: |String|
+  Default: `'llvm-mc'`
+
+This variable can be changed to use a different executable for llvm-mc.
+
+
+g:ale_asm_clang_options                             *g:ale_asm_llvm_mc_options*
+                                                    *b:ale_asm_llvm_mc_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be set to pass additional options to llvm-mc.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -36,6 +36,7 @@ Notes:
   * `write-good`
 * ASM
   * `gcc`
+  * `llvm-mc`
 * AVRA
   * `avra`
 * Awk

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2788,6 +2788,7 @@ documented in additional help files.
     textlint..............................|ale-asciidoc-textlint|
   asm.....................................|ale-asm-options|
     gcc...................................|ale-asm-gcc|
+    llvm-mc...............................|ale-asm-llvm_mc|
   avra....................................|ale-avra-options|
     avra..................................|ale-avra-avra|
   awk.....................................|ale-awk-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -45,6 +45,7 @@ formatting.
   * [write-good](https://github.com/btford/write-good)
 * ASM
   * [gcc](https://gcc.gnu.org)
+  * [llvm-mc](https://llvm.org)
 * AVRA
   * [avra](https://github.com/Ro5bert/avra)
 * Awk

--- a/test/handler/test_llvm_mc_handler.vader
+++ b/test/handler/test_llvm_mc_handler.vader
@@ -1,0 +1,28 @@
+Before:
+  runtime ale_linters/asm/llvm_mc.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The asm llvm-mc handler should parse lines correctly):
+
+  AssertEqual
+  \ [
+  \    {
+  \      'lnum': 10,
+  \      'col' : 15,
+  \      'text': "invalid operand for instruction",
+  \      'type': 'E',
+  \    },
+  \    {
+  \      'lnum': 11,
+  \      'col' : 2,
+  \      'text': "invalid instruction mnemonic 'lpaq'",
+  \      'type': 'E',
+  \    },
+  \ ],
+  \ ale_linters#asm#llvm_mc#Handle(357, [
+  \   "xorq %rbp, %rbp",
+  \   "{standard_input}:10:15: error: invalid operand for instruction",
+  \   "{standard input}:11:2: error: invalid instruction mnemonic 'lpaq'",
+  \ ])

--- a/test/linter/test_llvm_mc.vader
+++ b/test/linter/test_llvm_mc.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpLinterTest('asm', 'llvm_mc')
+  call ale#test#SetFilename('test.cpp')
+  let b:command_tail = ' --assemble'
+  \   . ' --filetype=asm'
+  \   . ' -o ' . (has('win32') ? 'nul': '/dev/null')
+  \   . ' '
+
+After:
+  unlet! b:command_tail
+
+  call ale#assert#TearDownLinterTest()
+
+Execute(The executable should be configurable):
+  AssertLinter 'llvm-mc', ale#Escape('llvm-mc') . b:command_tail
+
+  let b:ale_asm_llvm_mc_executable = 'foobar'
+
+  AssertLinter 'foobar', ale#Escape('foobar') . b:command_tail


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->
This is a fork of `asm-gcc`