### PR TITLE
Fix #3616, #3903 - Use proper floating window borders in neovim

### DIFF
--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -103,6 +103,9 @@ function! s:NvimPrepareWindowContent(lines) abort
 endfunction
 
 function! s:NvimCreate(options) abort
+    let l:left = get(g:ale_floating_window_border, 0, '|')
+    let l:top = get(g:ale_floating_window_border, 1, '-')
+
     let l:popup_opts = extend({
     \    'relative': 'cursor',
     \    'row': 1,
@@ -112,13 +115,13 @@ function! s:NvimCreate(options) abort
     \    'style': 'minimal',
     \    'border': empty(g:ale_floating_window_border) ? 'none' : [
     \        get(g:ale_floating_window_border, 2, '+'),
-    \        get(g:ale_floating_window_border, 1, '-'),
+    \        l:top,
     \        get(g:ale_floating_window_border, 3, '+'),
-    \        get(g:ale_floating_window_border, 6, '|'),
+    \        get(g:ale_floating_window_border, 6, l:left),
     \        get(g:ale_floating_window_border, 4, '+'),
-    \        get(g:ale_floating_window_border, 7, '-'),
+    \        get(g:ale_floating_window_border, 7, l:top),
     \        get(g:ale_floating_window_border, 5, '+'),
-    \        get(g:ale_floating_window_border, 0, '|'),
+    \        l:left,
     \    ],
     \ }, s:GetPopupOpts())
 

--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -99,38 +99,7 @@ function! s:NvimPrepareWindowContent(lines) abort
     let l:width = max(map(copy(a:lines), 'strdisplaywidth(v:val)'))
     let l:height = min([len(a:lines), l:max_height])
 
-    if empty(g:ale_floating_window_border)
-        return [a:lines, l:width, l:height]
-    endif
-
-    " Add the size of borders
-    let l:width += 2
-    let l:height += 2
-
-    let l:left         = get(g:ale_floating_window_border, 0, '|')
-    let l:top          = get(g:ale_floating_window_border, 1, '-')
-    let l:top_left     = get(g:ale_floating_window_border, 2, '+')
-    let l:top_right    = get(g:ale_floating_window_border, 3, '+')
-    let l:bottom_right = get(g:ale_floating_window_border, 4, '+')
-    let l:bottom_left  = get(g:ale_floating_window_border, 5, '+')
-    let l:right        = get(g:ale_floating_window_border, 6, l:left)
-    let l:bottom       = get(g:ale_floating_window_border, 7, l:top)
-
-    let l:lines = [l:top_left . repeat(l:top, l:width - 2) . l:top_right]
-
-    for l:line in a:lines
-        let l:line_width = strchars(l:line)
-        let l:lines = add(l:lines, l:left . l:line . repeat(' ', l:width - l:line_width - 2). l:right)
-    endfor
-
-    " Truncate the lines
-    if len(l:lines) > l:max_height + 1
-        let l:lines = l:lines[0:l:max_height]
-    endif
-
-    let l:lines = add(l:lines, l:bottom_left . repeat(l:bottom, l:width - 2) . l:bottom_right)
-
-    return [l:lines, l:width, l:height]
+    return [a:lines[0:l:height-1], l:width, l:height]
 endfunction
 
 function! s:NvimCreate(options) abort
@@ -140,7 +109,17 @@ function! s:NvimCreate(options) abort
     \    'col': 0,
     \    'width': 42,
     \    'height': 4,
-    \    'style': 'minimal'
+    \    'style': 'minimal',
+    \    'border': empty(g:ale_floating_window_border) ? 'none' : [
+    \        get(g:ale_floating_window_border, 2, '+'),
+    \        get(g:ale_floating_window_border, 1, '-'),
+    \        get(g:ale_floating_window_border, 3, '+'),
+    \        get(g:ale_floating_window_border, 6, '|'),
+    \        get(g:ale_floating_window_border, 4, '+'),
+    \        get(g:ale_floating_window_border, 7, '-'),
+    \        get(g:ale_floating_window_border, 5, '+'),
+    \        get(g:ale_floating_window_border, 0, '|'),
+    \    ],
     \ }, s:GetPopupOpts())
 
     let l:buffer = nvim_create_buf(v:false, v:false)

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1252,10 +1252,12 @@ g:ale_floating_preview_popup_opts           *g:ale_floating_preview_popup_opts*
 
   For example, to enhance popups with a title: >
 
-  function! CustomOpts() abort {
+  function! CustomOpts() abort
     let [l:info, l:loc] = ale#util#FindItemAtCursor(bufnr(''))
     return {'title': ' ALE: ' . (l:loc.linter_name) . ' '}
   endfunction
+
+  let g:ale_floating_preview_popup_opts = 'g:CustomOpts'
 <
 
 


### PR DESCRIPTION
Floating window borders in neovim have been broken for a long time for floating windows with wide contents (see the linked issues).

Replacing the manually injected borders with native neovim borders fixes the issues. :slightly_smiling_face: 