### PR TITLE
run-tests: download images only on x86-64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM testbed/vim:24
+ARG TESTBED_VIM_VERSION=24
+
+FROM testbed/vim:${TESTBED_VIM_VERSION}
 
 RUN install_vim -tag v8.0.0027 -build \
                 -tag v9.0.0297 -build \

--- a/run-tests
+++ b/run-tests
@@ -151,37 +151,48 @@ fi
 # Delete .swp files in the test directory, which cause Vim 8 to hang.
 find test -name '*.swp' -delete
 
+set -eu
+
 # Check if docker un image is available locally
 has_image=$(docker images --quiet "${image}:${image_tag}" | wc -l)
+arch=$(docker info -f '{{ .Architecture }}')
 
-if [ "$has_image" -eq 0 ]
-then
-
+download_image() {
+  if [[ $arch != x86_64 ]]; then
+    echo "Pre-built docker image is not available for architecture ${arch}"
+    return 1
+  fi
   echo "Downloading run image ${image}:${image_tag}"
   docker pull "${image}:${image_tag}" &> /dev/null
+}
 
-  if [ $? -eq 1 ]
+if [ "$has_image" -eq 0 ] && ! download_image
+then
+  echo "Building run image ${image}:${image_tag}"
+
+  build_args=( --build-arg GIT_VERSION="$git_version" )
+
+  if [[ $arch != x86_64 ]]; then
+    echo "Building testbed/vim:24 for $arch"
+	testbed_vim_ref=902917c4caa50db2f2e80009b839605602f9f014
+    docker build -t "testbed/vim:$testbed_vim_ref" "https://github.com/Vimjas/vim-testbed.git#$testbed_vim_ref"
+	build_args+=( --build-arg TESTBED_VIM_VERSION="$testbed_vim_ref" )
+  fi
+
+  docker build "${build_args[@]}" -t "${image}:${image_tag}" .
+  docker tag "${image}:${image_tag}" "${image}:latest"
+
+  if [[ -z "${DOCKER_HUB_USER:-}" || -z "${DOCKER_HUB_PASS:-}" ]]
   then
-    echo "Could not pull image ${image}:${image_tag}"
-    echo "Building run image ${image}:${image_tag}"
-    docker build --build-arg GIT_VERSION="$git_version" -t "${image}:${image_tag}" .
-    docker tag "${image}:${image_tag}" "${image}:latest"
-
-    if [[ -z "${DOCKER_HUB_USER:-}" || -z "${DOCKER_HUB_PASS:-}" ]]
-    then
-      echo "Docker Hub credentials not set, skip push"
-    else
-      echo "Push ${image}:${image_tag} to Docker Hub"
-      echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
-      docker push "${image}:${image_tag}"
-    fi
+    echo "Docker Hub credentials not set, skip push"
+  else
+    echo "Push ${image}:${image_tag} to Docker Hub"
+    echo "$DOCKER_HUB_PASS" | docker login -u "$DOCKER_HUB_USER" --password-stdin
+    docker push "${image}:${image_tag}"
   fi
 else
   echo "Docker run image ${image}:${image_tag} ready"
 fi
-
-set -e
-set -u
 
 docker tag "${image}:${image_tag}" "${image}:latest"
 


### PR DESCRIPTION
When running the tests on aarch64, the run-tests script tries to download a pre-built image that is built for x86-64, and thus does not run.

This change adds a check for the Docker daemon host platform and only downloads the image if it will run.

Furthermore, the image dependency testbed/vim:24 is also built unless the platform is x86_64, since it is also only provided for this platform.