### PR TITLE
phpstan: set cwd to configuration file directory

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -26,10 +26,8 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
     \   : ''
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')
-    let l:config_file_exists = ale#path#FindNearestFile(a:buffer, 'phpstan.neon')
-    let l:dist_config_file_exists = ale#path#FindNearestFile(a:buffer, 'phpstan.neon.dist')
 
-    if empty(l:level) && empty(l:config_file_exists) && empty(l:dist_config_file_exists)
+    if empty(l:level) && empty(ale_linters#php#phpstan#FindConfigFile(a:buffer))
         " if no configuration file is found, then use 4 as a default level
         let l:level = '4'
     endif
@@ -70,6 +68,22 @@ function! ale_linters#php#phpstan#Handle(buffer, lines) abort
     return l:output
 endfunction
 
+function! ale_linters#php#phpstan#GetCwd(buffer) abort
+    let l:result = ale#path#Dirname(ale_linters#php#phpstan#FindConfigFile(a:buffer))
+
+    return empty(l:result) ? v:null : l:result
+endfunction
+
+function! ale_linters#php#phpstan#FindConfigFile(buffer) abort
+    let l:result = ale#path#FindNearestFile(a:buffer, 'phpstan.neon')
+
+    if empty(l:result)
+        let l:result = ale#path#FindNearestFile(a:buffer, 'phpstan.neon.dist')
+    endif
+
+    return l:result
+endfunction
+
 call ale#linter#Define('php', {
 \   'name': 'phpstan',
 \   'executable': {buffer -> ale#path#FindExecutable(buffer, 'php_phpstan', [
@@ -86,4 +100,5 @@ call ale#linter#Define('php', {
 \       function('ale_linters#php#phpstan#GetCommand'),
 \   )},
 \   'callback': 'ale_linters#php#phpstan#Handle',
+\   'cwd': function('ale_linters#php#phpstan#GetCwd'),
 \})

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -5,8 +5,12 @@ Before:
 
   " Create a temporary directory and work within it, otherwise these tests
   " cannot be run in parallel.
-  let g:dir = tempname()
+  let g:parent_dir = tempname()
+  let g:dir = ale#path#Simplify(g:parent_dir . '/src')
+
+  call mkdir(g:parent_dir, '', 0750)
   call mkdir(g:dir, '', 0750)
+
   silent! execute 'cd ' . fnameescape(g:dir)
   silent! noautocmd execute 'file ' . fnameescape(ale#path#Simplify(g:dir . '/test.php'))
 
@@ -30,6 +34,7 @@ Execute(The local phpstan executable should be used):
 
   AssertLinter g:executable,
   \ ale#Escape(g:executable) . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' %s'
+  AssertLinterCwd v:null
 
 Execute(use_global should override local executable detection):
   let g:ale_php_phpstan_use_global = 1
@@ -77,6 +82,7 @@ Execute(Configuration file exists in current directory):
   \ ale#Escape('phpstan') . ' --version',
   \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json %s'
   \ ]
+  AssertLinterCwd g:dir
 
 Execute(Configuration dist file exists in current directory):
   call writefile(['parameters:', '  level: 7'], './phpstan.neon.dist')
@@ -87,6 +93,7 @@ Execute(Configuration dist file exists in current directory):
   \ ale#Escape('phpstan') . ' --version',
   \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json %s'
   \ ]
+  AssertLinterCwd g:dir
 
 Execute(Configuration file exists in current directory, but force phpstan level):
   call writefile(['parameters:', '  level: 7'], './phpstan.neon')
@@ -119,3 +126,10 @@ Execute(Memory limit parameter is added to the command):
 
   AssertLinter 'phpstan',
   \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' --memory-limit ' . ale#Escape('500M') . ' %s'
+
+Execute(Directory is changed to that of the configuration file):
+  call writefile([], '../phpstan.neon')
+
+  AssertLinterCwd g:parent_dir
+  AssertLinter 'phpstan',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json %s'


### PR DESCRIPTION
PHPStan will only detect a configuration file in the current working directory, so set that to the directory in which ALE finds the configuration file.