### PR TITLE
Adding a fixer implementation for gopls

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -301,6 +301,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['gomod'],
 \       'description': 'Fix Go module files with go mod edit -fmt.',
 \   },
+\   'gopls': {
+\       'function': 'ale#fixers#gopls#Fix',
+\       'suggested_filetypes': ['go'],
+\       'description': 'Fix Go files with gopls.',
+\   },
 \   'tslint': {
 \       'function': 'ale#fixers#tslint#Fix',
 \       'suggested_filetypes': ['typescript'],

--- a/autoload/ale/fixers/gopls.vim
+++ b/autoload/ale/fixers/gopls.vim
@@ -1,0 +1,23 @@
+" Author: Sean Enck <enckse@voidedtech.com>
+" Description: Integration of gopls format with ALE.
+
+call ale#Set('go_gopls_fix_executable', 'gopls')
+call ale#Set('go_gopls_fix_options', '')
+
+function! ale#fixers#gopls#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'go_gopls_fix_executable')
+    let l:options = ale#Var(a:buffer, 'go_gopls_fix_options')
+    let l:env = ale#go#EnvString(a:buffer)
+
+    if !executable(l:executable)
+        return 0
+    endif
+
+    return {
+    \   'command': l:env . ale#Escape(l:executable)
+    \       . ' format'
+    \       . ale#Pad(l:options)
+    \       . ' -l -w %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -269,6 +269,21 @@ g:ale_go_gopls_options                                 *g:ale_go_gopls_options*
   Command-line options passed to the gopls executable. See `gopls -h`.
 
 
+g:ale_go_gopls_fix_executable                   *g:ale_go_gopls_fix_executable*
+                                                *b:ale_go_gopls_fix_executable*
+  Type: |String|
+  Default: `'gopls'`
+
+  Executable to run to use as the gopls fixer.
+
+g:ale_go_gopls_fix_options                         *g:ale_go_gopls_fix_options*
+                                                   *b:ale_go_gopls_fix_options*
+  Type: |String|
+  Default: `''`
+
+  Options to pass to the gopls fixer.
+
+
 g:ale_go_gopls_init_options                       *g:ale_go_gopls_init_options*
                                                   *b:ale_go_gopls_init_options*
   Type: |Dictionary|

--- a/test/fixers/test_gopls_fixer_callback.vader
+++ b/test/fixers/test_gopls_fixer_callback.vader
@@ -1,0 +1,57 @@
+Before:
+  Save g:ale_go_gopls_fix_executable
+  Save g:ale_go_gopls_fix_options
+  Save g:ale_go_go111module
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_go_gopls_fix_executable = 'xxxinvalid'
+  let g:ale_go_gopls_fix_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+  call ale#test#SetFilename('../test-files/go/testfile.go')
+
+After:
+  Restore
+
+  unlet! b:ale_go_go111module
+
+  call ale#test#RestoreDirectory()
+
+Execute(The gopls callback should return 0 when the executable isn't executable):
+  AssertEqual
+  \ 0,
+  \ ale#fixers#gopls#Fix(bufnr(''))
+
+Execute(The gopls callback should the command when the executable test passes):
+  let g:ale_go_gopls_fix_executable = has('win32') ? 'cmd' : 'echo'
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_go_gopls_fix_executable) . ' format -l -w %t'
+  \ },
+  \ ale#fixers#gopls#Fix(bufnr(''))
+
+Execute(The gopls callback should include extra options):
+  let g:ale_go_gopls_fix_executable = has('win32') ? 'cmd' : 'echo'
+  let g:ale_go_gopls_fix_options = '--xxx'
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape(g:ale_go_gopls_fix_executable) . ' format --xxx -l -w %t'
+  \ },
+  \ ale#fixers#gopls#Fix(bufnr(''))
+
+Execute(The gopls callback should support Go environment variables):
+  let g:ale_go_gopls_fix_executable = has('win32') ? 'cmd' : 'echo'
+  let g:ale_go_go111module = 'on'
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Env('GO111MODULE', 'on')
+  \     . ale#Escape(g:ale_go_gopls_fix_executable)
+  \     . ' format -l -w %t'
+  \ },
+  \ ale#fixers#gopls#Fix(bufnr(''))


### PR DESCRIPTION
Adds an implementation of a fixer for `gopls` (which is going to be similar input/output to `goimports` but built-in to `gopls`)

I've done a pass at trying to get this setup properly (at a minimum it works locally) but given that there is already a `gopls` implementation for other aspects of ale if I have done anything out of bounds or irregular, etc. - let me know and I'm happy to update my PR.