### PR TITLE
Add deadnix linter

### DIFF
--- a/ale_linters/nix/deadnix.vim
+++ b/ale_linters/nix/deadnix.vim
@@ -2,7 +2,7 @@ call ale#Set('nix_deadnix_executable', 'deadnix')
 call ale#Set('nix_deadnix_options', '')
 
 function! ale_linters#nix#deadnix#GetCommand(buffer) abort
-    return '%e -o json' . ale#Pad(ale#Var(a:buffer, 'nix_deadnix_options')) . ale#Pad('-- %t')
+    return '%e -o json' . ale#Pad(ale#Var(a:buffer, 'nix_deadnix_options')) . ' -- %t'
 endfunction
 
 call ale#linter#Define('nix', {

--- a/ale_linters/nix/deadnix.vim
+++ b/ale_linters/nix/deadnix.vim
@@ -1,0 +1,13 @@
+call ale#Set('nix_deadnix_executable', 'deadnix')
+call ale#Set('nix_deadnix_options', '')
+
+function! ale_linters#nix#deadnix#GetCommand(buffer) abort
+    return '%e -o json' . ale#Pad(ale#Var(a:buffer, 'nix_deadnix_options')) . ale#Pad('-- %t')
+endfunction
+
+call ale#linter#Define('nix', {
+\   'name': 'deadnix',
+\   'executable': {b -> ale#Var(b, 'nix_deadnix_executable')},
+\   'command': function('ale_linters#nix#deadnix#GetCommand'),
+\   'callback': 'ale#handlers#deadnix#Handle',
+\})

--- a/autoload/ale/handlers/deadnix.vim
+++ b/autoload/ale/handlers/deadnix.vim
@@ -1,0 +1,23 @@
+function! ale#handlers#deadnix#Handle(buffer, lines) abort
+    let l:output = []
+
+    for l:line in a:lines
+        try
+            let l:file = json_decode(l:line)
+        catch
+            continue
+        endtry
+
+        for l:error in l:file['results']
+            call add(l:output, {
+            \   'lnum': l:error['line'],
+            \   'col': l:error['column'],
+            \   'end_col': l:error['endColumn'],
+            \   'text': l:error['message'],
+            \   'type': 'W',
+            \})
+        endfor
+    endfor
+
+    return l:output
+endfunction

--- a/autoload/ale/handlers/deadnix.vim
+++ b/autoload/ale/handlers/deadnix.vim
@@ -3,19 +3,25 @@ function! ale#handlers#deadnix#Handle(buffer, lines) abort
 
     for l:line in a:lines
         try
-            let l:file = json_decode(l:line)
+            let l:results = json_decode(l:line)['results']
         catch
             continue
         endtry
 
-        for l:error in l:file['results']
-            call add(l:output, {
-            \   'lnum': l:error['line'],
-            \   'col': l:error['column'],
-            \   'end_col': l:error['endColumn'],
-            \   'text': l:error['message'],
-            \   'type': 'W',
-            \})
+        for l:error in l:results
+            try
+                let l:ale_error = {
+                \   'lnum': l:error['line'],
+                \   'col': l:error['column'],
+                \   'end_col': l:error['endColumn'],
+                \   'text': l:error['message'],
+                \   'type': 'W',
+                \}
+            catch
+                continue
+            endtry
+
+            call add(l:output, l:ale_error)
         endfor
     endfor
 

--- a/autoload/ale/handlers/deadnix.vim
+++ b/autoload/ale/handlers/deadnix.vim
@@ -3,12 +3,16 @@ function! ale#handlers#deadnix#Handle(buffer, lines) abort
 
     for l:line in a:lines
         try
-            let l:results = json_decode(l:line)['results']
+            let l:file = ale#util#FuzzyJSONDecode(l:line, v:null)
         catch
             continue
         endtry
 
-        for l:error in l:results
+        if type(l:file) isnot v:t_dict
+            continue
+        endif
+
+        for l:error in l:file['results']
             try
                 let l:ale_error = {
                 \   'lnum': l:error['line'],

--- a/doc/ale-nix.txt
+++ b/doc/ale-nix.txt
@@ -76,4 +76,22 @@ g:ale_nix_statix_fix_options                     *g:ale_nix_statix_fix_options*
 
 
 ===============================================================================
+deadnix                                                       *ale-nix-deadnix*
+
+g:ale_nix_deadnix_executable                     *g:ale_nix_deadnix_executable*
+                                                 *b:ale_nix_deadnix_executable*
+  Type: |String|
+  Default: `'deadnix'`
+
+  This variable sets the executable used for deadnix.
+
+g:ale_nix_deadnix_options                           *g:ale_nix_deadnix_options*
+                                                    *b:ale_nix_deadnix_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to pass additional options to deadnix.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3097,6 +3097,7 @@ documented in additional help files.
     nixfmt................................|ale-nix-nixfmt|
     nixpkgs-fmt...........................|ale-nix-nixpkgs-fmt|
     statix................................|ale-nix-statix|
+    deadnix...............................|ale-nix-deadnix|
   nroff...................................|ale-nroff-options|
     write-good............................|ale-nroff-write-good|
   objc....................................|ale-objc-options|

--- a/test/handler/test_deadnix_handler.vader
+++ b/test/handler/test_deadnix_handler.vader
@@ -1,0 +1,23 @@
+Execute(The deadnix handler should handle deadnix output):
+  let output = [
+  \'{"file":"./flake.nix","results":[{"column":5,"endColumn":9,"line":23,"message":"Unused lambda pattern: self"},{"column":2,"endColumn":6,"line":1,"message":"Unused lambda pattern: pkgs"}]}'
+  \]
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 23,
+  \     'col': 5,
+  \     'end_col': 9,
+  \     'text': 'Unused lambda pattern: self',
+  \     'type': 'W',
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'col': 2,
+  \     'end_col': 6,
+  \     'text': 'Unused lambda pattern: pkgs',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale#handlers#deadnix#Handle(bufnr(''), output)

--- a/test/handler/test_deadnix_handler.vader
+++ b/test/handler/test_deadnix_handler.vader
@@ -21,3 +21,7 @@ Execute(The deadnix handler should handle deadnix output):
   \   },
   \ ],
   \ ale#handlers#deadnix#Handle(bufnr(''), output)
+
+  AssertEqual [], ale#handlers#deadnix#Handle(bufnr(''), [''])
+  AssertEqual [], ale#handlers#deadnix#Handle(bufnr(''), ['not json'])
+  AssertEqual [], ale#handlers#deadnix#Handle(bufnr(''), ['{"results":[{}]}'])

--- a/test/linter/test_nix_deadnix.vader
+++ b/test/linter/test_nix_deadnix.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpLinterTest('nix', 'deadnix')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The deadnix command should be correct):
+  AssertLinter 'deadnix', ale#Escape('deadnix') . ' -o json -- %t'
+
+Execute(Additional deadnix options should be configurable):
+  let g:ale_nix_deadnix_options = '--foobar'
+
+  AssertLinter 'deadnix',
+  \ ale#Escape('deadnix') . ' -o json --foobar -- %t'
+
+Execute(The deadnix command should be configurable):
+  let g:ale_nix_deadnix_executable = 'foo/bar'
+
+  AssertLinter 'foo/bar', ale#Escape('foo/bar') . ' -o json -- %t'


### PR DESCRIPTION
[deadnix](https://github.com/astro/deadnix) detects unused variables in Nix code.

<img width="415" alt="Screenshot 2023-02-03 at 13 46 21" src="https://user-images.githubusercontent.com/122977/216595640-1fb16de1-7b7b-437c-835a-a17e240f730d.png">
