### PR TITLE
Remove duplicated word in help g:ale_virtualtext_cursor

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2323,7 +2323,7 @@ g:ale_virtualtext_cursor                             *g:ale_virtualtext_cursor*
 
   Messages are only displayed after a short delay. See |g:ale_virtualtext_delay|.
 
-  Messages can be prefixed prefixed with a string. See |g:ale_virtualtext_prefix|.
+  Messages can be prefixed with a string. See |g:ale_virtualtext_prefix|.
 
   ALE will use the following highlight groups for problems:
 


### PR DESCRIPTION
Just a fix for a small typo in the documentation.