### PR TITLE
Communicate support for markdown to the lsp server (#4450)

### DIFF
--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -424,7 +424,7 @@ function! s:SendInitMessage(conn) abort
     \                   'completionItem': {
     \                       'snippetSupport': v:false,
     \                       'commitCharactersSupport': v:false,
-    \                       'documentationFormat': ['plaintext'],
+    \                       'documentationFormat': ['plaintext', 'markdown'],
     \                       'deprecatedSupport': v:false,
     \                       'preselectSupport': v:false,
     \                   },
@@ -432,7 +432,7 @@ function! s:SendInitMessage(conn) abort
     \               },
     \               'hover': {
     \                   'dynamicRegistration': v:false,
-    \                   'contentFormat': ['plaintext'],
+    \                   'contentFormat': ['plaintext', 'markdown'],
     \               },
     \               'references': {
     \                   'dynamicRegistration': v:false,

--- a/test/lsp/test_lsp_startup.vader
+++ b/test/lsp/test_lsp_startup.vader
@@ -165,7 +165,7 @@ Before:
       \             'completionItem': {
       \               'snippetSupport': v:false,
       \               'commitCharactersSupport': v:false,
-      \               'documentationFormat': ['plaintext'],
+      \               'documentationFormat': ['plaintext', 'markdown'],
       \               'deprecatedSupport': v:false,
       \               'preselectSupport': v:false,
       \             },
@@ -173,7 +173,7 @@ Before:
       \           },
       \           'hover': {
       \             'dynamicRegistration': v:false,
-      \             'contentFormat': ['plaintext'],
+      \             'contentFormat': ['plaintext', 'markdown'],
       \           },
       \           'references': {
       \             'dynamicRegistration': v:false,


### PR DESCRIPTION
Closes #4450

Here is the change that I provided in #4450.

Unfortunately I was unable to run the docker images as I am a bit short on disk space, I might try and get that setup again in the future.

I am expecting `test/test_lsp_startup.vader` to fail, as it seems to have a copy of the init message in the assert. Will see if that happens in the checks.