### PR TITLE
change the default linters of rust

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -33,7 +33,7 @@ let s:default_ale_linter_aliases = {
 "
 " No linters are used for plaintext files by default.
 "
-" Only cargo and rls are enabled for Rust by default.
+" rust-analyzer, cargo and rls are enabled for Rust by default.
 " rpmlint is disabled by default because it can result in code execution.
 " hhast is disabled by default because it executes code in the project root.
 "
@@ -52,7 +52,7 @@ let s:default_ale_linters = {
 \   'perl': ['perlcritic'],
 \   'perl6': [],
 \   'python': ['flake8', 'mypy', 'pylint', 'pyright', 'ruff'],
-\   'rust': ['cargo', 'rls'],
+\   'rust': ['analyzer', 'cargo', 'rls'],
 \   'spec': [],
 \   'text': [],
 \   'vader': ['vimls'],


### PR DESCRIPTION
issue#4461

RLS has been deprecated and is no longer supported. It has been replaced with [rust-analyzer](https://rust-analyzer.github.io/).
Now, rust-analyzer is the official LSP for rust. It is necessary to change the default rust linter of ALE too.