### PR TITLE
Virtualtext formatting and alignment fixes

### DIFF
--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2367,6 +2367,40 @@ g:ale_virtualtext_prefix                             *g:ale_virtualtext_prefix*
   pulled from |&commentstring|, ALE will default to `'#'`.
 
 
+g:ale_virtualtext_column                             *g:ale_virtualtext_column*
+                                                     *b:ale_virtualtext_column*
+g:ale_virtualtext_maxcolumn                       *g:ale_virtualtext_maxcolumn*
+                                                  *b:ale_virtualtext_maxcolumn*
+  Type: |String| or |Number|
+  Default: `0`
+
+  Virtualtext column range, from `column` to `maxcolumn`.  If a line is
+  `column` or less characters long, the virtualtext message is shifted right
+  to `column`.
+
+  Where the line is greater than `column` characters long, but less than
+  `maxcolumn`, the virtualtext message is placed at the end of the line.
+
+  Where the line is greater than `maxcolumn` the virtualtext message is
+  omitted.
+
+  A |Number| greater than `0` is used as the fixed column position, however
+  a |String| ending in `%` represents a percentage of the window width.
+  When `column` is set to zero, column positioning is disabled, when `maxcolumn`
+  is set to zero, no maximum line length is enforced.
+
+g:ale_virtualtext_single                             *g:ale_virtualtext_single*
+                                                     *b:ale_virtualtext_single*
+  Type: |Number|
+  Default: `0`
+
+  Enable or disable concatenation of multiple virtualtext messages on a single
+  line.  By default, if a line has multiple errors or warnings, each will be
+  appended in turn.
+
+  With `single` set to a non-zero value, only the first message appears.
+  (No attempt is made to prefer message types such as errors over warnings)
+
 g:ale_virtualenv_dir_names                         *g:ale_virtualenv_dir_names*
                                                    *b:ale_virtualenv_dir_names*
 


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Example implementation of the enhancement described in #4472 

This include minimum and maximum columns expected for messages to start, and filtering to ensure only
one error appears per line of code.

### This change converts this:
![2023-03-09_09-30-20](https://user-images.githubusercontent.com/2985620/223870798-10acb8b5-4b92-4919-9356-ee116b48be16.gif)


### To this:
![2023-03-09_09-33-45](https://user-images.githubusercontent.com/2985620/223870971-092a3616-c39a-4cbf-9308-1ca95e309d14.gif)
