### PR TITLE
Clear virtualtext no matter how enabled

### DIFF
--- a/autoload/ale/toggle.vim
+++ b/autoload/ale/toggle.vim
@@ -14,7 +14,7 @@ function! s:DisablePostamble() abort
         call ale#highlight#UpdateHighlights()
     endif
 
-    if g:ale_virtualtext_cursor is# 'current' || g:ale_virtualtext_cursor == 1
+    if g:ale_virtualtext_cursor isnot# 'disabled' && g:ale_virtualtext_cursor != 0
         call ale#virtualtext#Clear(bufnr(''))
     endif
 endfunction


### PR DESCRIPTION
When toggling ALE off, clear the virtualtext even when `g:ale_virtualtext_cursor` is `'all'` / `2`, not just when it is `'current'` / `1`.