### PR TITLE
Add support for `rustywind` fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -600,6 +600,11 @@ let s:default_registry = {
 \       'function': 'ale#fixers#pycln#Fix',
 \       'suggested_filetypes': ['python'],
 \       'description': 'remove unused python import statements',
+\   },
+\   'rustywind': {
+\       'function': 'ale#fixers#rustywind#Fix',
+\       'suggested_filetypes': ['html'],
+\       'description': 'Sort Tailwind CSS classes',
 \   }
 \}
 

--- a/autoload/ale/fixers/rustywind.vim
+++ b/autoload/ale/fixers/rustywind.vim
@@ -1,0 +1,17 @@
+scriptencoding utf-8
+" Author: Guillermo Roig <groig@protonmail.com>
+" Description: Sort TailwindCSS classes with rustywind
+
+call ale#Set('html_rustywind_executable', 'rustywind')
+call ale#Set('html_rustywind_options', '')
+
+function! ale#fixers#rustywind#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'html_rustywind_executable')
+    let l:options = ale#Var(a:buffer, 'html_rustywind_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' --stdin'
+    \}
+endfunction

--- a/doc/ale-html.txt
+++ b/doc/ale-html.txt
@@ -103,6 +103,25 @@ See |ale-javascript-prettier| for information about the available options.
 
 
 ===============================================================================
+rustywind                                                  *ale-html-rustywind*
+
+g:ale_html_rustywind_executable               *g:ale_html_rustywind_executable*
+                                              *b:ale_html_rustywind_executable*
+  Type: |String|
+  Default: `'rustywind'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_html_rustywind_options                     *g:ale_html_rustywind_options*
+                                                 *b:ale_html_rustywind_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to rustywind.
+
+
+===============================================================================
 stylelint                                                  *ale-html-stylelint*
 
 g:ale_html_stylelint_executable               *g:ale_html_stylelint_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -262,6 +262,7 @@ Notes:
   * `htmlhint`
   * `prettier`
   * `proselint`
+  * `rustywind`
   * `tidy`
   * `write-good`
 * Idris

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2996,6 +2996,7 @@ documented in additional help files.
     html-beautify.........................|ale-html-beautify|
     htmlhint..............................|ale-html-htmlhint|
     prettier..............................|ale-html-prettier|
+    rustywind.............................|ale-html-rustywind|
     stylelint.............................|ale-html-stylelint|
     tidy..................................|ale-html-tidy|
     vscodehtml............................|ale-html-vscode|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -271,6 +271,7 @@ formatting.
   * [htmlhint](http://htmlhint.com/)
   * [prettier](https://github.com/prettier/prettier)
   * [proselint](http://proselint.com/)
+  * [rustywind](https://github.com/avencera/rustywind)
   * [tidy](http://www.html-tidy.org/)
   * [write-good](https://github.com/btford/write-good)
 * Idris

--- a/test/fixers/test_rustywind_fixer_callback.vader
+++ b/test/fixers/test_rustywind_fixer_callback.vader
@@ -1,0 +1,36 @@
+Before:
+  Save g:ale_html_rustywind_executable
+  Save g:ale_html_rustywind_options
+
+  " Use an invalid global executable, so we don't match it.
+  let g:ale_html_rustywind_executable = 'xxxinvalid'
+  let g:ale_html_rustywind_options = ''
+
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The rustywind callback should return the correct default values):
+  call ale#test#SetFilename('../test-files/rustywind/test.html')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' --stdin',
+  \ },
+  \ ale#fixers#rustywind#Fix(bufnr(''))
+
+Execute(The rustywind callback should include custom rustywind options):
+  let g:ale_html_rustywind_options = "--custom-regex some-regex"
+  call ale#test#SetFilename('../test-files/rustywind/test.html')
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('xxxinvalid')
+  \     . ' ' . g:ale_html_rustywind_options
+  \     . ' --stdin',
+  \ },
+  \ ale#fixers#rustywind#Fix(bufnr(''))


### PR DESCRIPTION
This PR adds support for [rustywind](https://github.com/avencera/rustywind), an utility to sort Tailwind CSS classes in html files.