### PR TITLE
Rust : Look for analyzer.json

### DIFF
--- a/ale_linters/rust/analyzer.vim
+++ b/ale_linters/rust/analyzer.vim
@@ -28,7 +28,7 @@ function! ale_linters#rust#analyzer#GetProjectRoot(buffer) abort
 endfunction
 
 function! ale_linters#rust#analyzer#GetConfig(buffer) abort
-    let l:config = ale#Var(a:buffer, 'rust_analyzer_config')
+    let l:config = copy(ale#Var(a:buffer, 'rust_analyzer_config'))
 
     if ale#Var(a:buffer, 'rust_analyzer_use_local_config')
         let l:config_local_path = ale#path#FindNearestFile(a:buffer, 'analyzer.json')

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -60,7 +60,7 @@ g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
   Type: |Dictionary|
   Default: `{}`
 
-  Dictionary with configuration settings for |rust-analyzer|.
+  Dictionary with configuration settings for `rust-analyzer`.
 
 
 g:ale_rust_analyzer_use_local_config     *g:ale_rust_analyzer_use_local_config*
@@ -68,9 +68,9 @@ g:ale_rust_analyzer_use_local_config     *g:ale_rust_analyzer_use_local_config*
   Type: |Number|
   Default: `0`
 
-  When set to 1, search for closest "analyzer.json" for |rust-analyzer|.
-  If found, use it to extend *g:ale_rust_analyzer_config,* it is usefull handle
-  automatically config by project.
+  When set to 1, search for the closest config `analyzer.json` for
+  `rust-analyzer`. If found, use it to extend *g:ale_rust_analyzer_config*.
+  It is usefull for using automatically a different config by project.
 
 
 ===============================================================================

--- a/doc/ale-rust.txt
+++ b/doc/ale-rust.txt
@@ -60,7 +60,17 @@ g:ale_rust_analyzer_config                         *g:ale_rust_analyzer_config*
   Type: |Dictionary|
   Default: `{}`
 
-  Dictionary with configuration settings for rust-analyzer.
+  Dictionary with configuration settings for |rust-analyzer|.
+
+
+g:ale_rust_analyzer_use_local_config     *g:ale_rust_analyzer_use_local_config*
+                                         *b:ale_rust_analyzer_use_local_config*
+  Type: |Number|
+  Default: `0`
+
+  When set to 1, search for closest "analyzer.json" for |rust-analyzer|.
+  If found, use it to extend *g:ale_rust_analyzer_config,* it is usefull handle
+  automatically config by project.
 
 
 ===============================================================================

--- a/test/linter/test_rust_analyzer.vader
+++ b/test/linter/test_rust_analyzer.vader
@@ -26,3 +26,10 @@ Execute(Should accept configuration settings):
   AssertLSPConfig {}
   let b:ale_rust_analyzer_config = {'diagnostics': {'disabled': ['unresolved-import']}}
   AssertLSPOptions {'diagnostics': {'disabled': ['unresolved-import']}}
+
+Execute(Should override configuration settings with analyzer.json):
+  AssertLSPConfig {}
+  call ale#test#SetFilename('../test-files/rust/analyzer/analyzer.json')
+  let b:ale_rust_analyzer_config = {'diagnostics': {'disabled': ['unresolved-import']}}
+  let b:ale_rust_analyzer_use_local_config = 1
+  AssertLSPOptions {'diagnostics': {'disabled': []}, 'server': {'extraEnv': {'RUSTUP_TOOLCHAIN': 'nightly'}, }, }

--- a/test/test-files/rust/analyzer/analyzer.json
+++ b/test/test-files/rust/analyzer/analyzer.json
@@ -1,0 +1,10 @@
+{
+  "diagnostics": {
+    "disabled": []
+  },
+  "server": {
+    "extraEnv": {
+      "RUSTUP_TOOLCHAIN": "nightly"
+    }
+  }
+}


### PR DESCRIPTION
Add option `g:ale_rust_analyzer_use_local_config`. When set, it will `FindNearestFile` _analyzer.json_, then it will make an union with the global user config `g:ale_rust_analyzer_config`.

The point is to detect and use config by project.