### PR TITLE
More virtual text work

### DIFF
--- a/autoload/ale/toggle.vim
+++ b/autoload/ale/toggle.vim
@@ -14,7 +14,9 @@ function! s:DisablePostamble() abort
         call ale#highlight#UpdateHighlights()
     endif
 
-    if g:ale_virtualtext_cursor isnot# 'disabled' && g:ale_virtualtext_cursor != 0
+    if g:ale_virtualtext_cursor isnot# 'disabled'
+    \&& g:ale_virtualtext_cursor isnot# 0
+    \&& g:ale_virtualtext_cursor isnot# '0'
         call ale#virtualtext#Clear(bufnr(''))
     endif
 endfunction

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -253,3 +253,39 @@ function! ale#virtualtext#SetTexts(buffer, loclist) abort
         endif
     endfor
 endfunction
+
+if get(g:, 'ale_private_testing_mode', 0)
+    function! ale#virtualtext#IsSupported() abort
+        return s:has_virt_text
+    endfunction
+
+    function! ale#virtualtext#IsEmulated() abort
+        return s:emulate_virt
+    endfunction
+
+    function! ale#virtualtext#CountTexts(buffer) abort
+        if !s:has_virt_text
+            return 0
+        elseif s:emulate_virt
+            return s:last_virt != -1
+        elseif has('nvim')
+            if exists('*nvim_buf_get_extmarks')
+                return len(nvim_buf_get_extmarks(
+                \   a:buffer,
+                \   s:ns_id,
+                \   0,
+                \   -1,
+                \   {'details': 0}
+                \))
+            else
+                throw 'Cannot determine the number of virtual texts'
+            endif
+        else
+            return len(prop_list(1, {
+            \   'bufnr': a:buffer,
+            \   'types': s:hl_list,
+            \   'end_lnum': -1
+            \}))
+        endif
+    endfunction
+endif

--- a/autoload/ale/virtualtext.vim
+++ b/autoload/ale/virtualtext.vim
@@ -138,12 +138,20 @@ function! ale#virtualtext#ShowMessage(buffer, item) abort
     let s:last_message = l:msg
 
     if has('nvim')
-        call nvim_buf_set_virtual_text(
-        \   a:buffer,
-        \   s:ns_id, l:line - 1,
-        \   [[l:msg, l:hl_group]],
-        \   {}
-        \)
+        if exists('*nvim_buf_set_extmark')
+            call nvim_buf_set_extmark(
+            \   a:buffer,
+            \   s:ns_id, l:line - 1, 0,
+            \   {'virt_text': [[l:msg, l:hl_group]]}
+            \)
+        else
+            call nvim_buf_set_virtual_text(
+            \   a:buffer,
+            \   s:ns_id, l:line - 1,
+            \   [[l:msg, l:hl_group]],
+            \   {}
+            \)
+        endif
     elseif s:emulate_virt
         let l:left_pad = col('$')
         call prop_add(l:line, l:left_pad, {'type': 'ale'})

--- a/test/test_ale_toggle.vader
+++ b/test/test_ale_toggle.vader
@@ -6,6 +6,7 @@ Before:
   Save g:ale_pattern_options
   Save g:ale_pattern_options_enabled
   Save g:ale_set_balloons
+  Save g:ale_virtualtext_cursor
 
   let g:ale_set_signs = 1
   let g:ale_set_lists_synchronously = 1
@@ -74,6 +75,57 @@ Before:
     return l:results
   endfunction
 
+  function! TestVirtualtext(buffer, disabled, current, all)
+    if ale#virtualtext#IsSupported()
+      let g:ale_virtualtext_cursor = a:current
+
+      ALEDisable
+      call setpos('.', [0, 1, 1, 0])
+      ALEEnable
+      call ale#test#FlushJobs()
+      AssertEqual 0, ale#virtualtext#CountTexts(a:buffer),
+      \ 'There should be no virtual texts when g:ale_virtualtext_cursor is '
+      \ . string(a:current) . ' and the cursor is on line 1'
+
+      ALEDisable
+      call setpos('.', [0, 2, 1, 0])
+      ALEEnable
+      call ale#test#FlushJobs()
+      AssertEqual 1, ale#virtualtext#CountTexts(a:buffer),
+      \ 'There should be one virtual text when g:ale_virtualtext_cursor is '
+      \ . string(a:current) . ' and the cursor is on line 2'
+
+      ALEDisable
+      AssertEqual 0, ale#virtualtext#CountTexts(a:buffer),
+      \ 'The virtual texts should be cleared when ALE is disabled'
+
+      let g:ale_virtualtext_cursor = a:disabled
+
+      ALEEnable
+      call ale#test#FlushJobs()
+      AssertEqual 0, ale#virtualtext#CountTexts(a:buffer),
+      \ 'There should be no virtual texts when g:ale_virtualtext_cursor is '
+      \ . string(a:disabled)
+
+      if !ale#virtualtext#IsEmulated()
+        let g:ale_virtualtext_cursor = a:all
+
+        ALEDisable
+        call setpos('.', [0, 1, 1, 0])
+        ALEEnable
+        call ale#test#FlushJobs()
+        AssertEqual 1, ale#virtualtext#CountTexts(a:buffer),
+        \ 'There should be one virtual text (from line 2) when '
+        \ . 'g:ale_virtualtext_cursor is '. string(a:all) . ' and the cursor '
+        \ . 'is on line 1'
+
+        ALEDisable
+        AssertEqual 0, ale#virtualtext#CountTexts(a:buffer),
+        \ 'The virtual texts should be cleared when ALE is disabled'
+      endif
+    endif
+  endfunction
+
   call ale#linter#Define('foobar', {
   \ 'name': 'testlinter',
   \ 'callback': 'ToggleTestCallback',
@@ -103,6 +155,7 @@ After:
 
   delfunction ToggleTestCallback
   delfunction ParseAuGroups
+  delfunction TestVirtualtext
 
   call setloclist(0, [])
   call ale#sign#Clear()
@@ -442,3 +495,12 @@ Execute(Enabling ALE should enable balloons if the setting is on):
 
     AssertEqual 'ale#balloon#Expr()', &balloonexpr
   endif
+
+Execute(Enabling ALE should enable virtual text if the setting is on (strings)):
+  call TestVirtualtext(bufnr(''), 'disabled', 'current', 'all')
+
+Execute(Enabling ALE should enable virtual text if the setting is on (numbers)):
+  call TestVirtualtext(bufnr(''), 0, 1, 2)
+
+Execute(Enabling ALE should enable virtual text if the setting is on (numeric strings)):
+  call TestVirtualtext(bufnr(''), '0', '1', '2')

--- a/test/vimrc
+++ b/test/vimrc
@@ -40,3 +40,6 @@ execute 'set encoding=utf-8'
 let g:mapleader=','
 
 let g:ale_ignore_2_4_warnings = 1
+
+" Define functions needed only for testing
+let g:ale_private_testing_mode = 1


### PR DESCRIPTION
The change I made for # #4475 did not work correctly because when Vim compares a non-numeric string with a number using `!=`, it converts the string to `0` before comparing.  Thus the second half of the clause (`g:ale_virtualtext_cursor != 0`) was always false if `g:ale_virtualtext_cursor` was `'all'` or `'current'`.  Fix by using `isnot#`, which does not coerce strings to numbers before comparing.

Also update to use `nvim_buf_set_extmark()` when available in preference to the now-deprecated `nvim_buf_set_virtual_text()`.

Finally add some tests to ensure that virtual texts get displayed when ALE is enabled and cleared when ALE is disabled.