### PR TITLE
remove `--enable-all` from golangci-lint options

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -1,7 +1,7 @@
 " Author: Sascha Grunert <mail@saschagrunert.de>
 " Description: Adds support of golangci-lint
 
-call ale#Set('go_golangci_lint_options', '--enable-all')
+call ale#Set('go_golangci_lint_options', '')
 call ale#Set('go_golangci_lint_executable', 'golangci-lint')
 call ale#Set('go_golangci_lint_package', 0)
 

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -120,7 +120,7 @@ g:ale_go_golangci_lint_executable           *g:ale_go_golangci_lint_executable*
 g:ale_go_golangci_lint_options                 *g:ale_go_golangci_lint_options*
                                                *b:ale_go_golangci_lint_options*
   Type: |String|
-  Default: `'--enable-all'`
+  Default: `''`
 
   This variable can be changed to alter the command-line arguments to the
   golangci-lint invocation.

--- a/test/linter/test_golangci_lint.vader
+++ b/test/linter/test_golangci_lint.vader
@@ -16,7 +16,7 @@ Execute(The golangci-lint defaults should be correct):
   AssertLinter 'golangci-lint',
   \ ale#Escape('golangci-lint')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
-  \   . ' --enable-all'
+  \   . ' '
 
 Execute(The golangci-lint callback should use a configured executable):
   let b:ale_go_golangci_lint_executable = 'something else'
@@ -24,7 +24,7 @@ Execute(The golangci-lint callback should use a configured executable):
   AssertLinter 'something else',
   \ ale#Escape('something else')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
-  \   . ' --enable-all'
+  \   . ' '
 
 Execute(The golangci-lint callback should use configured options):
   let b:ale_go_golangci_lint_options = '--foobar'
@@ -41,10 +41,10 @@ Execute(The golangci-lint callback should support environment variables):
   \ ale#Env('GO111MODULE', 'on')
   \   . ale#Escape('golangci-lint')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
-  \   . ' --enable-all'
+  \   . ' '
 
 Execute(The golangci-lint `lint_package` option should use the correct command):
   let b:ale_go_golangci_lint_package = 1
 
   AssertLinter 'golangci-lint',
-  \ ale#Escape('golangci-lint') . ' run --enable-all'
+  \ ale#Escape('golangci-lint') . ' run '


### PR DESCRIPTION
When using `golangci-lint`, configured via `.golangci.yml` with a custom ruleset, ALE does not report any errors and the command it executes exits with exit code 3:

```
Command History:
(executable check - success) golangci-lint
(finished - exit code 3) ['/Users/user/.vim/shell', '-c', 'cd ''/path'' && ''golangci-lint'' run ''file.go'' --enable-all']
<<<NO OUTPUT RETURNED>>>
```

The reasoning behind the exit code is that `--enable-all` cannot be combined with a `.golangci.yml` file that defines its own ruleset:

```
$ cd /path && golangci-lint run file.go --enable-all
ERRO Running error: can't combine options --enable-all and --enable errcheck
```

The proposed change is to remove the default `--enable-all` because every project uses different rules.