### PR TITLE
Replace `solhint` default formatter

### DIFF
--- a/autoload/ale/handlers/solhint.vim
+++ b/autoload/ale/handlers/solhint.vim
@@ -18,29 +18,30 @@ function! ale#handlers#solhint#Handle(buffer, lines) abort
     " /path/to/file/file.sol: line 1, col 10, Error - 'addOne' is defined but never used. (no-unused-vars)
     let l:output = []
 
-    let l:lint_pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (.*) \((.*)\)$'
+    " let l:lint_pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (.*) \((.*)\)$'
+    let l:lint_pattern = '\v^[^:]+:(\d+):(\d+): %(Parse error: )@<!\ze(.*)\s+\[(Error|Warning)\/([^\]]+)\]$'
 
     for l:match in ale#util#GetMatches(a:lines, l:lint_pattern)
-        let l:isError = l:match[3] is? 'error'
+        let l:isError = l:match[4] is? 'error'
         call add(l:output, {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 0,
-        \   'text': l:match[4],
+        \   'text': l:match[3],
         \   'code': l:match[5],
         \   'type': l:isError ? 'E' : 'W',
         \})
     endfor
 
-    let l:syntax_pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (Parse error): (.*)$'
+    " let l:syntax_pattern = '\v^[^:]+: line (\d+), col (\d+), (Error|Warning) - (Parse error): (.*)$'
+    let l:syntax_pattern = '\v^[^:]+:(\d+):(\d+): Parse error: (.*)\s+\[Error\]$'
 
     for l:match in ale#util#GetMatches(a:lines, l:syntax_pattern)
-        let l:isError = l:match[3] is? 'error'
         call add(l:output, {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 0,
-        \   'text': l:match[5],
-        \   'code': l:match[4],
-        \   'type': l:isError ? 'E' : 'W',
+        \   'text': l:match[3],
+        \   'code': 'Parse error',
+        \   'type': 'E',
         \})
     endfor
 
@@ -94,5 +95,5 @@ function! ale#handlers#solhint#GetCommand(buffer) abort
 
     return ale#node#Executable(a:buffer, l:executable)
     \   . (!empty(l:options) ? ' ' . l:options : '')
-    \   . ' --formatter compact %s'
+    \   . ' --formatter unix %s'
 endfunction

--- a/test/handler/test_solhint_handler.vader
+++ b/test/handler/test_solhint_handler.vader
@@ -51,14 +51,13 @@ Execute(The solhint handler should parse linter error messages correctly):
   \   },
   \ ],
   \ ale#handlers#solhint#Handle(bufnr(''), [
-  \   'contracts/Bounty.sol: line 1, col 17, Warning - Compiler version must be fixed (compiler-fixed)',
-  \   'contracts/Bounty.sol: line 4, col 8, Error - Use double quotes for string literals (quotes)',
-  \   'contracts/Bounty.sol: line 5, col 8, Error - Use double quotes for string literals (quotes)',
-  \   'contracts/Bounty.sol: line 13, col 3, Error - Expected indentation of 4 spaces but found 2 (indent)',
-  \   'contracts/Bounty.sol: line 14, col 3, Error - Expected indentation of 4 spaces but found 2 (indent)',
-  \   'contracts/Bounty.sol: line 47, col 3, Error - Function order is incorrect, public function can not go after internal function. (func-order)',
+  \   'contracts/Bounty.sol:1:17: Compiler version must be fixed [Warning/compiler-fixed]',
+  \   'contracts/Bounty.sol:4:8: Use double quotes for string literals [Error/quotes]',
+  \   'contracts/Bounty.sol:5:8: Use double quotes for string literals [Error/quotes]',
+  \   'contracts/Bounty.sol:13:3: Expected indentation of 4 spaces but found 2 [Error/indent]',
+  \   'contracts/Bounty.sol:14:3: Expected indentation of 4 spaces but found 2 [Error/indent]',
+  \   'contracts/Bounty.sol:47:3: Function order is incorrect, public function can not go after internal function. [Error/func-order]',
   \ ])
-
 
 Execute(The solhint handler should parse syntax error messages correctly):
   AssertEqual
@@ -79,6 +78,6 @@ Execute(The solhint handler should parse syntax error messages correctly):
   \   },
   \ ],
   \ ale#handlers#solhint#Handle(bufnr(''), [
-  \   "contracts/Bounty.sol: line 30, col 4, Error - Parse error: missing ';' at 'uint248'",
-  \   "contracts/Bounty.sol: line 203, col 4, Error - Parse error: no viable alternative at input '_loserStakeMultiplier}'",
+  \   "contracts/Bounty.sol:30:4: Parse error: missing ';' at 'uint248' [Error]",
+  \   "contracts/Bounty.sol:203:4: Parse error: no viable alternative at input '_loserStakeMultiplier}' [Error]",
   \ ])

--- a/test/linter/test_solhint.vader
+++ b/test/linter/test_solhint.vader
@@ -2,7 +2,7 @@ Before:
   call ale#assert#SetUpLinterTest('solidity', 'solhint')
   runtime autoload/ale/handlers/solhint.vim
 
-  let b:args = ' --formatter compact %s'
+  let b:args = ' --formatter unix %s'
 
 After:
   unlet! b:args


### PR DESCRIPTION
# TL;DR

`solhint` dropped the `compact` formatter. Use `unix` formatter instead.

# Investigation

A [recent change](https://github.com/protofire/solhint/blob/master/CHANGELOG.md#340---2023-02-17) in `solhint` dropped the built-in `eslint` formatters in favor of their own.

I am not a maintainer of `solhint`, so I don't have the full context, but apparently [they decided to not include the `compact` formatter](https://github.com/juanpcapurro/solhint/tree/4bd4d1f7cada0f30f691cb8e833816183dcc1491/lib/formatters), which was used in ALE.

Looking at the available formatters, I decided to stick with `unix`, since it's a well known format. There was a small issue differentiating linter issues from syntax errors, because the outputs are pretty similar.

I had to resort to ~dark sorcery,~ a negative look-behind for "Parse error" in the message to be able to distinguish between them. If I'm being honest, the parsing regexes are a bit frail right now, but they do the job.


