### PR TITLE
Add support for Bicep when installed as a plugin to Azure CLI

### DIFF
--- a/ale_linters/bicep/az_bicep.vim
+++ b/ale_linters/bicep/az_bicep.vim
@@ -1,0 +1,57 @@
+" Author: Carl Smedstad <carl.smedstad at protonmail dot com>
+" Description: az_bicep for bicep files
+
+let g:ale_bicep_az_bicep_executable =
+\   get(g:, 'ale_bicep_az_bicep_executable', 'az')
+
+let g:ale_bicep_az_bicep_options =
+\   get(g:, 'ale_bicep_az_bicep_options', '')
+
+function! ale_linters#bicep#az_bicep#Executable(buffer) abort
+    return ale#Var(a:buffer, 'bicep_az_bicep_executable')
+endfunction
+
+function! ale_linters#bicep#az_bicep#Command(buffer) abort
+    let l:executable = ale_linters#bicep#az_bicep#Executable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'bicep_az_bicep_options')
+
+    return ale#Escape(l:executable)
+    \   . ' bicep build --stdout --file '
+    \   . '%s '
+    \   . l:options
+endfunction
+
+function! ale_linters#bicep#az_bicep#Handle(buffer, lines) abort
+    let l:pattern = '\v^(.*)\((\d+),(\d+)\)\s:\s([a-zA-Z]*)\s([-a-zA-Z0-9]*):\s(.*)'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        if l:match[4] is# 'Error'
+            let l:type = 'E'
+        elseif l:match[4] is# 'Warning'
+            let l:type = 'W'
+        else
+            let l:type = 'I'
+        endif
+
+        call add(l:output, {
+        \   'filename': l:match[1],
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
+        \   'type': l:type,
+        \   'code': l:match[5],
+        \   'text': l:match[6],
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('bicep', {
+\   'name': 'az_bicep',
+\   'executable': function('ale_linters#bicep#az_bicep#Executable'),
+\   'command': function('ale_linters#bicep#az_bicep#Command'),
+\   'callback': 'ale_linters#bicep#az_bicep#Handle',
+\   'output_stream': 'both',
+\   'lint_file': 1,
+\})

--- a/ale_linters/bicep/az_bicep.vim
+++ b/ale_linters/bicep/az_bicep.vim
@@ -15,32 +15,44 @@ function! ale_linters#bicep#az_bicep#Command(buffer) abort
     let l:executable = ale_linters#bicep#az_bicep#Executable(a:buffer)
     let l:options = ale#Var(a:buffer, 'bicep_az_bicep_options')
 
+    if has('win32')
+        let l:nullfile = 'NUL'
+    else
+        let l:nullfile = '/dev/null'
+    endif
+
     return ale#Escape(l:executable)
-    \   . ' bicep build --stdout --file '
+    \   . ' bicep build --outfile '
+    \   . l:nullfile
+    \   . ' --file '
     \   . '%s '
     \   . l:options
 endfunction
 
 function! ale_linters#bicep#az_bicep#Handle(buffer, lines) abort
-    let l:pattern = '\v^(.*)\((\d+),(\d+)\)\s:\s([a-zA-Z]*)\s([-a-zA-Z0-9]*):\s(.*)'
+    let l:pattern = '\v^([A-Z]+)?(:\s)?(.*)\((\d+),(\d+)\)\s:\s([a-zA-Z]*)\s([-a-zA-Z0-9]*):\s(.*)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        if l:match[4] is# 'Error'
+        if l:match[1] is# 'ERROR'
             let l:type = 'E'
-        elseif l:match[4] is# 'Warning'
+        elseif l:match[1] is# 'WARNING'
+            let l:type = 'W'
+        elseif l:match[6] is# 'Error'
+            let l:type = 'E'
+        elseif l:match[6] is# 'Warning'
             let l:type = 'W'
         else
             let l:type = 'I'
         endif
 
         call add(l:output, {
-        \   'filename': l:match[1],
-        \   'lnum': l:match[2] + 0,
-        \   'col': l:match[3] + 0,
+        \   'filename': l:match[3],
+        \   'lnum': l:match[4] + 0,
+        \   'col': l:match[5] + 0,
         \   'type': l:type,
-        \   'code': l:match[5],
-        \   'text': l:match[6],
+        \   'code': l:match[7],
+        \   'text': l:match[8],
         \})
     endfor
 
@@ -52,6 +64,6 @@ call ale#linter#Define('bicep', {
 \   'executable': function('ale_linters#bicep#az_bicep#Executable'),
 \   'command': function('ale_linters#bicep#az_bicep#Command'),
 \   'callback': 'ale_linters#bicep#az_bicep#Handle',
-\   'output_stream': 'both',
+\   'output_stream': 'stderr',
 \   'lint_file': 1,
 \})

--- a/ale_linters/bicep/bicep.vim
+++ b/ale_linters/bicep/bicep.vim
@@ -30,24 +30,25 @@ function! ale_linters#bicep#bicep#Command(buffer) abort
 endfunction
 
 function! ale_linters#bicep#bicep#Handle(buffer, lines) abort
-    let l:pattern = '\v^.*\((\d+),(\d+)\)\s:\s([a-zA-Z]*)\s([-a-zA-Z0-9]*):\s(.*)'
+    let l:pattern = '\v^(.*)\((\d+),(\d+)\)\s:\s([a-zA-Z]*)\s([-a-zA-Z0-9]*):\s(.*)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        if l:match[3] is# 'Error'
+        if l:match[4] is# 'Error'
             let l:type = 'E'
-        elseif l:match[3] is# 'Warning'
+        elseif l:match[4] is# 'Warning'
             let l:type = 'W'
         else
             let l:type = 'I'
         endif
 
         call add(l:output, {
-        \   'lnum': l:match[1] + 0,
-        \   'col': l:match[2] + 0,
+        \   'filename': l:match[1],
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
         \   'type': l:type,
-        \   'code': l:match[4],
-        \   'text': l:match[5],
+        \   'code': l:match[5],
+        \   'text': l:match[6],
         \})
     endfor
 

--- a/doc/ale-bicep.txt
+++ b/doc/ale-bicep.txt
@@ -16,7 +16,7 @@ g:ale_bicep_bicep_executable                      *g:ale_bicep_bicep_executable*
 g:ale_bicep_bicep_options                            *g:ale_bicep_bicep_options*
                                                      *b:ale_bicep_bicep_options*
   Type: |String|
-  Default: `'build --outfile /dev/null'`
+  Default: `''`
 
   This variable can be set to pass additional options to bicep.
 
@@ -35,7 +35,7 @@ g:ale_bicep_az_bicep_executable                *g:ale_bicep_az_bicep_executable*
 g:ale_bicep_az_bicep_options                      *g:ale_bicep_az_bicep_options*
                                                   *b:ale_bicep_az_bicep_options*
   Type: |String|
-  Default: `'bicep build --stdout --file '`
+  Default: `''`
 
   This variable can be set to pass additional options to az_bicep.
 

--- a/doc/ale-bicep.txt
+++ b/doc/ale-bicep.txt
@@ -20,5 +20,24 @@ g:ale_bicep_bicep_options                            *g:ale_bicep_bicep_options*
 
   This variable can be set to pass additional options to bicep.
 
+
+===============================================================================
+az_bicep                                                    *ale-bicep-az_bicep*
+
+g:ale_bicep_az_bicep_executable                *g:ale_bicep_az_bicep_executable*
+                                               *b:ale_bicep_az_bicep_executable*
+  Type: |String|
+  Default: `'az'`
+
+  This variable can be set to change the path to az_bicep.
+
+
+g:ale_bicep_az_bicep_options                      *g:ale_bicep_az_bicep_options*
+                                                  *b:ale_bicep_az_bicep_options*
+  Type: |String|
+  Default: `'bicep build --stdout --file '`
+
+  This variable can be set to pass additional options to az_bicep.
+
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2858,6 +2858,7 @@ documented in additional help files.
     bibclean..............................|ale-bib-bibclean|
   bicep...................................|ale-bicep-options|
     bicep.................................|ale-bicep-bicep|
+    az_bicep..............................|ale-bicep-az_bicep|
   bitbake.................................|ale-bitbake-options|
     oelint-adv............................|ale-bitbake-oelint_adv|
   c.......................................|ale-c-options|

--- a/test/handler/test_bicep_az_bicep_handler.vader
+++ b/test/handler/test_bicep_az_bicep_handler.vader
@@ -25,8 +25,17 @@ Execute(The az_bicep handler should handle basic warnings):
   \     'code': 'BCP019',
   \     'text': 'Expected a new line character at this location.',
   \   },
+  \   {
+  \     'filename': '/tmp/cluster.bicep',
+  \     'lnum': 25,
+  \     'col': 30,
+  \     'type': 'E',
+  \     'code': 'BCP334',
+  \     'text': 'The provided value has no configured minimum length and may be too short to assign to a target with a configured minimum length of 1.',
+  \   },
   \ ],
-  \ ale_linters#bicep#bicep#Handle(1, [
+  \ ale_linters#bicep#az_bicep#Handle(1, [
   \   '/tmp/nvimhxqs5D/1/dns.bicep(7,10) : Warning no-unused-existing-resources: Existing resource "asdasd" is declared but never used. [https://aka.ms/bicep/linter/no-unused-existing-resources]',
   \   '/tmp/nvimhxqs5D/1/dns.bicep(106,6) : Error BCP019: Expected a new line character at this location.',
+  \   'ERROR: /tmp/cluster.bicep(25,30) : Warning BCP334: The provided value has no configured minimum length and may be too short to assign to a target with a configured minimum length of 1.',
   \ ])

--- a/test/handler/test_bicep_az_bicep_handler.vader
+++ b/test/handler/test_bicep_az_bicep_handler.vader
@@ -1,12 +1,12 @@
 Before:
-  runtime ale_linters/bicep/bicep.vim
+  runtime ale_linters/bicep/az_bicep.vim
 
 After:
   Restore
 
   call ale#linter#Reset()
 
-Execute(The bicep handler should handle basic warnings):
+Execute(The az_bicep handler should handle basic warnings):
   AssertEqual
   \ [
   \   {

--- a/test/linter/test_bicep_az_bicep.vader
+++ b/test/linter/test_bicep_az_bicep.vader
@@ -1,0 +1,12 @@
+Before:
+  call ale#assert#SetUpLinterTest('bicep', 'az_bicep')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'az', ale#Escape('az') . ' bicep build --stdout --file %s '
+
+Execute(The executable should be configurable):
+  let g:ale_bicep_az_bicep_executable = 'foobar'
+  AssertLinter 'foobar', ale#Escape('foobar') . ' bicep build --stdout --file %s '

--- a/test/linter/test_bicep_az_bicep.vader
+++ b/test/linter/test_bicep_az_bicep.vader
@@ -5,8 +5,17 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'az', ale#Escape('az') . ' bicep build --stdout --file %s '
+  if has('win32')
+      AssertLinter 'az', ale#Escape('az') . ' bicep build --outfile NUL --file %s '
+  else
+      AssertLinter 'az', ale#Escape('az') . ' bicep build --outfile /dev/null --file %s '
+  endif
 
 Execute(The executable should be configurable):
   let g:ale_bicep_az_bicep_executable = 'foobar'
-  AssertLinter 'foobar', ale#Escape('foobar') . ' bicep build --stdout --file %s '
+
+  if has('win32')
+      AssertLinter 'foobar', ale#Escape('foobar') . ' bicep build --outfile NUL --file %s '
+  else
+      AssertLinter 'foobar', ale#Escape('foobar') . ' bicep build --outfile /dev/null --file %s '
+  endif


### PR DESCRIPTION
The compiler for Microsoft's DSL Bicep can be installed both independently and as a plugin to Azure CLI. The latter is probably how most people install it.

The program output is the same but Azure CLI wraps the arguments and has a slightly different interface, hence I opted to copy the old linter and modify it to match the plugin arguments.

Not entirely sure  this is the right approach to this, feedback appreciated