### PR TITLE
Add fourmolu fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -561,6 +561,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['haskell'],
 \       'description': 'A formatter for Haskell source code.',
 \   },
+\   'fourmolu': {
+\       'function': 'ale#fixers#fourmolu#Fix',
+\       'suggested_filetypes': ['haskell'],
+\       'description': 'A formatter for Haskell source code.',
+\   },
 \   'jsonnetfmt': {
 \       'function': 'ale#fixers#jsonnetfmt#Fix',
 \       'suggested_filetypes': ['jsonnet'],

--- a/autoload/ale/fixers/fourmolu.vim
+++ b/autoload/ale/fixers/fourmolu.vim
@@ -1,0 +1,20 @@
+call ale#Set('haskell_fourmolu_executable', 'fourmolu')
+call ale#Set('haskell_fourmolu_options', '')
+
+function! ale#fixers#fourmolu#GetExecutable(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'haskell_fourmolu_executable')
+
+    return ale#handlers#haskell_stack#EscapeExecutable(l:executable, 'fourmolu')
+endfunction
+
+function! ale#fixers#fourmolu#Fix(buffer) abort
+    let l:executable = ale#fixers#fourmolu#GetExecutable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'haskell_fourmolu_options')
+
+    return {
+    \   'command': l:executable
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' --stdin-input-file '
+    \       . ale#Escape(@%),
+    \}
+endfunction

--- a/doc/ale-haskell.txt
+++ b/doc/ale-haskell.txt
@@ -225,4 +225,24 @@ g:ale_haskell_ormolu_options                     *g:ale_haskell_ormolu_options*
 
 
 ===============================================================================
+fourmolu                                                 *ale-haskell-fourmolu*
+
+g:ale_haskell_fourmolu_executable           *g:ale_haskell_fourmolu_executable*
+                                            *b:ale_haskell_fourmolu_executable*
+  Type: |String|
+  Default: `'fourmolu'`
+
+  This variable can be changed to use a different executable for fourmolu.
+
+
+g:ale_haskell_fourmolu_options                 *g:ale_haskell_fourmolu_options*
+                                               *b:ale_haskell_fourmolu_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be used to pass extra options to the underlying fourmolu
+  executable.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -245,6 +245,7 @@ Notes:
   * `hlint`
   * `hls`
   * `ormolu`
+  * `fourmolu`
   * `stack-build`!!
   * `stack-ghc`
   * `stylish-haskell`

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -236,6 +236,7 @@ Notes:
   * `cabal-ghc`
   * `cspell`
   * `floskell`
+  * `fourmolu`
   * `ghc`
   * `ghc-mod`
   * `hdevtools`
@@ -245,7 +246,6 @@ Notes:
   * `hlint`
   * `hls`
   * `ormolu`
-  * `fourmolu`
   * `stack-build`!!
   * `stack-ghc`
   * `stylish-haskell`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3018,6 +3018,7 @@ documented in additional help files.
     stylish-haskell.......................|ale-haskell-stylish-haskell|
     hie...................................|ale-haskell-hie|
     ormolu................................|ale-haskell-ormolu|
+    fourmolu..............................|ale-haskell-fourmolu|
   hcl.....................................|ale-hcl-options|
     packer-fmt............................|ale-hcl-packer-fmt|
     terraform-fmt.........................|ale-hcl-terraform-fmt|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -245,6 +245,7 @@ formatting.
   * [cabal-ghc](https://www.haskell.org/cabal/)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)
   * [floskell](https://github.com/ennocramer/floskell)
+  * [fourmolu](https://github.com/fourmolu/fourmolu)
   * [ghc](https://www.haskell.org/ghc/)
   * [ghc-mod](https://github.com/DanielG/ghc-mod)
   * [hdevtools](https://hackage.haskell.org/package/hdevtools)
@@ -254,7 +255,6 @@ formatting.
   * [hlint](https://hackage.haskell.org/package/hlint)
   * [hls](https://github.com/haskell/haskell-language-server)
   * [ormolu](https://github.com/tweag/ormolu)
-  * [fourmolu](https://github.com/fourmolu/fourmolu)
   * [stack-build](https://haskellstack.org/) :floppy_disk:
   * [stack-ghc](https://haskellstack.org/)
   * [stylish-haskell](https://github.com/jaspervdj/stylish-haskell)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -254,6 +254,7 @@ formatting.
   * [hlint](https://hackage.haskell.org/package/hlint)
   * [hls](https://github.com/haskell/haskell-language-server)
   * [ormolu](https://github.com/tweag/ormolu)
+  * [fourmolu](https://github.com/fourmolu/fourmolu)
   * [stack-build](https://haskellstack.org/) :floppy_disk:
   * [stack-ghc](https://haskellstack.org/)
   * [stylish-haskell](https://github.com/jaspervdj/stylish-haskell)

--- a/test/fixers/test_fourmolu_fixer_callback.vader
+++ b/test/fixers/test_fourmolu_fixer_callback.vader
@@ -1,0 +1,29 @@
+Before:
+  Save g:ale_haskell_fourmolu_executable
+  Save g:ale_haskell_fourmolu_options
+
+After:
+  Restore
+
+Execute(The fourmolu callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('fourmolu')
+  \     . ' --stdin-input-file '
+  \     . ale#Escape(@%)
+  \ },
+  \ ale#fixers#fourmolu#Fix(bufnr(''))
+
+Execute(The fourmolu executable and options should be configurable):
+  let g:ale_haskell_fourmolu_executable = '/path/to/fourmolu'
+  let g:ale_haskell_fourmolu_options = '-h'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/fourmolu')
+  \     . ' -h'
+  \     . ' --stdin-input-file '
+  \     . ale#Escape(@%)
+  \ },
+  \ ale#fixers#fourmolu#Fix(bufnr(''))
+


### PR DESCRIPTION
Fourmolu is aversion of Ormolu that supports configuration. This fixer
was modeled after the Ormolu one, but using the "stack executable"
approach of the Brittany and Stylish Haskell fixers.
