### PR TITLE
Fix erb linter warnings

### DIFF
--- a/ale_linters/eruby/erb.vim
+++ b/ale_linters/eruby/erb.vim
@@ -11,7 +11,7 @@ function! ale_linters#eruby#erb#GetCommand(buffer) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " ERB, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter—the translated code is still evaluated.
-    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), trim_mode: %{-}).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {

--- a/test/linter/test_erb.vader
+++ b/test/linter/test_erb.vader
@@ -13,4 +13,4 @@ Execute(Executable should filter invalid eRuby when inside a Rails project):
   call ale#test#SetFilename('../test-files/ruby/valid_rails_app/app/views/my_great_view.html.erb')
 
   AssertLinter 'erb',
-  \ 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+  \ 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), trim_mode: %{-}).src') . '< %t | ruby -c'


### PR DESCRIPTION
Adding this as a draft initially, as I'm unsure if I'm missing something.

---

# Problem description
When linting in a rails project using the erb library, the following errors were emitted:

```
-e:1: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-e:1: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```
# 

This fix 1) completely removes passing the `safe_level` parameter and 2) passes `trim_mode` as a keyword parameter.

I think this fixes #4167