### PR TITLE
Add support for 'Selene' linter in Luau

### DIFF
--- a/ale_linters/luau/selene.vim
+++ b/ale_linters/luau/selene.vim
@@ -1,0 +1,48 @@
+" Copied from ..\lua\selene.vim
+
+call ale#Set('luau_selene_executable', 'selene')
+call ale#Set('luau_selene_options', '')
+
+function! ale_linters#luau#selene#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'luau_selene_options'))
+    \   . ' --display-style=json -'
+endfunction
+
+function! ale_linters#luau#selene#Handle(buffer, lines) abort
+    let l:output = []
+
+    for l:line in a:lines
+        " as of version 0.17.0, selene has no way to suppress summary
+        " information when outputting json, so stop processing when we hit it
+        " (PR for this here: https://github.com/Kampfkarren/selene/pull/356)
+        if l:line is# 'Results:'
+            break
+        endif
+
+        let l:json = json_decode(l:line)
+        let l:lint = {
+        \   'lnum': l:json.primary_label.span.start_line + 1,
+        \   'end_lnum': l:json.primary_label.span.end_line + 1,
+        \   'col': l:json.primary_label.span.start_column + 1,
+        \   'end_col': l:json.primary_label.span.end_column,
+        \   'text': l:json.message,
+        \   'code': l:json.code,
+        \   'type': l:json.severity is# 'Warning' ? 'W' : 'E',
+        \}
+
+        if has_key(l:json, 'notes') && len(l:json.notes) > 0
+            let l:lint.detail = l:lint.text . "\n\n" . join(l:json.notes, "\n")
+        endif
+
+        call add(l:output, l:lint)
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('luau', {
+\   'name': 'selene',
+\   'executable': {b -> ale#Var(b, 'luau_selene_executable')},
+\   'command': function('ale_linters#luau#selene#GetCommand'),
+\   'callback': 'ale_linters#luau#selene#Handle',
+\})


### PR DESCRIPTION
Adds built-in support for the Selene linter to work with luau as well. Selene allows for linting *.luau files by using "luau" as a base in your Selene configuration.