### PR TITLE
🐛 Fix a Ruby deprecation warning in the ERB linter

### DIFF
--- a/ale_linters/eruby/erb.vim
+++ b/ale_linters/eruby/erb.vim
@@ -11,7 +11,7 @@ function! ale_linters#eruby#erb#GetCommand(buffer) abort
     " Rails-flavored eRuby does not comply with the standard as understood by
     " ERB, so we'll have to do some substitution. This does not reduce the
     " effectiveness of the linter—the translated code is still evaluated.
-    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+    return 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), trim_mode: %{-}).src') . '< %t | ruby -c'
 endfunction
 
 call ale#linter#Define('eruby', {

--- a/test/linter/test_erb.vader
+++ b/test/linter/test_erb.vader
@@ -13,4 +13,4 @@ Execute(Executable should filter invalid eRuby when inside a Rails project):
   call ale#test#SetFilename('../test-files/ruby/valid_rails_app/app/views/my_great_view.html.erb')
 
   AssertLinter 'erb',
-  \ 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), nil, %{-}).src') . '< %t | ruby -c'
+  \ 'ruby -r erb -e ' . ale#Escape('puts ERB.new($stdin.read.gsub(%{<%=},%{<%}), trim_mode: %{-}).src') . '< %t | ruby -c'


### PR DESCRIPTION
Before, the ERB linter used positional arguments. Newer versions of Ruby have deprecated this method signature. We fixed the linter to use keyword arguments.
