### PR TITLE
Mention deadnix in supported tools

### DIFF
--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -386,6 +386,7 @@ Notes:
   * `nimpretty`
 * nix
   * `alejandra`
+  * `deadnix`
   * `nix-instantiate`
   * `nixfmt`
   * `nixpkgs-fmt`

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -395,6 +395,7 @@ formatting.
   * nimpretty
 * nix
   * [alejandra](https://github.com/kamadorueda/alejandra)
+  * [deadnix](https://github.com/astro/deadnix)
   * [nix-instantiate](http://nixos.org/nix/manual/#sec-nix-instantiate)
   * [nixfmt](https://github.com/serokell/nixfmt)
   * [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)


### PR DESCRIPTION
Deadnix support was added in
https://github.com/dense-analysis/ale/pull/4443 but it seems not to have
been mentioned in the lists of supported tools.
