### PR TITLE
feat: support Bazel `buildifier` linter

### DIFF
--- a/ale_linters/bzl/buildifier.vim
+++ b/ale_linters/bzl/buildifier.vim
@@ -1,0 +1,40 @@
+" Author: Chuck Grindel <chuck.grindel@gmail.com>
+" Description: Bazel Starlark lint support using buildifier.
+
+function! ale_linters#bzl#buildifier#GetCommand(buffer) abort
+    let l:executable = ale#Escape(ale#fixers#buildifier#GetExecutable(a:buffer))
+    let l:options = ale#Var(a:buffer, 'bazel_buildifier_options')
+    let l:filename = ale#Escape(bufname(a:buffer))
+
+    let l:command = l:executable . ' -mode check -lint warn -path %s'
+
+    if l:options isnot# ''
+        let l:command .= ' ' . l:options
+    endif
+
+    return l:command
+endfunction
+
+function! ale_linters#bzl#buildifier#Handle(buffer, lines) abort
+    let l:pattern = '\v^[^:]+:(\d+):(\d+)?:?\s+(syntax error near)?(.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': l:match[1] + 0,
+        \   'col': l:match[2] + 0,
+        \   'text': l:match[3] . l:match[4],
+        \   'type': l:match[3] is# 'syntax error near' ? 'E' : 'W',
+        \})
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('bzl', {
+\   'name': 'buildifier',
+\   'output_stream': 'both',
+\   'executable': function('ale#fixers#buildifier#GetExecutable'),
+\   'command': function('ale_linters#bzl#buildifier#GetCommand'),
+\   'callback': function('ale_linters#bzl#buildifier#Handle'),
+\})

--- a/test/handler/test_buildifier_handler.vader
+++ b/test/handler/test_buildifier_handler.vader
@@ -1,0 +1,26 @@
+Before:
+  runtime ale_linters/bzl/buildifier.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The buildifier handler should parse lines correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 26,
+  \     'col': 1,
+  \     'type': 'E',
+  \     'text': 'syntax error near'';'' and move the next statement to the new line',
+  \   },
+  \   {
+  \     'lnum': 7,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': 'unused-variable: Variable "foo" is unused. Please remove it. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unused-variable)'
+  \   },
+  \ ],
+  \ ale_linters#bzl#buildifier#Handle(bufnr(''), [
+  \   'swiftformat/toolchains/assets.bzl:26:1: syntax error near'';'' and move the next statement to the new line',
+  \   'swiftformat/toolchains/assets.bzl:7: unused-variable: Variable "foo" is unused. Please remove it. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#unused-variable)',
+  \ ])

--- a/test/linter/test_bzl_buildifier.vader
+++ b/test/linter/test_bzl_buildifier.vader
@@ -10,6 +10,7 @@ Execute(Should use default command when bazel_buildifier_options are not set):
   call ale#test#SetFilename('BUILD.bazel')
 
   let g:ale_bazel_buildifier_executable = 'buildifier'
+  let g:ale_bazel_buildifier_options = ''
 
   AssertLinter 'buildifier',
   \ ale#Escape('buildifier') . ' -mode check -lint warn -path %s'

--- a/test/linter/test_bzl_buildifier.vader
+++ b/test/linter/test_bzl_buildifier.vader
@@ -1,0 +1,29 @@
+Before:
+  call ale#assert#SetUpLinterTest('bzl', 'buildifier')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+
+Execute(Should use default command when bazel_buildifier_options are not set):
+  call ale#test#SetDirectory('/testplugin/test/test-files/bzl/bazel-package')
+  call ale#test#SetFilename('BUILD.bazel')
+
+  let g:ale_bazel_buildifier_executable = 'buildifier'
+
+  AssertLinter 'buildifier',
+  \ ale#Escape('buildifier') . ' -mode check -lint warn -path %s'
+
+  call ale#test#RestoreDirectory()
+
+Execute(Should use custom buildifier options when bazel_buildifier_options are set):
+  call ale#test#SetDirectory('/testplugin/test/test-files/bzl/bazel-package')
+  call ale#test#SetFilename('BUILD.bazel')
+
+  let g:ale_bazel_buildifier_executable = 'buildifier'
+  let g:ale_bazel_buildifier_options = '-v'
+
+  AssertLinter 'buildifier',
+  \ ale#Escape('buildifier') . ' -mode check -lint warn -path %s -v'
+
+  call ale#test#RestoreDirectory()


### PR DESCRIPTION
Support linter messages using Bazel `buildifier`. The linter support leverages existing capabilities introduced with the fixer implementation.