### PR TITLE
Update cairo linter to Cairo 1.0

### DIFF
--- a/ale_linters/cairo/sierra.vim
+++ b/ale_linters/cairo/sierra.vim
@@ -1,0 +1,54 @@
+" Author: 0xHyoga <0xHyoga@gmx.com>
+" Description: Report Starknet compile to sierra errors in cairo 1.0 code
+
+call ale#Set('cairo_sierra_executable', 'starknet-compile')
+call ale#Set('cairo_sierra_options', '')
+
+function! ale_linters#cairo#sierra#Handle(buffer, lines) abort
+    " Matches patterns like the following:
+    " Error: Expected ';' but got '('
+    "    --> /path/to/file/file.cairo:1:10:)
+    let l:pattern = '\v(error|warning): (.*)$'
+    let l:line_and_column_pattern = '\v\.cairo:(\d+):(\d+)'
+    let l:output = []
+
+    for l:line in a:lines
+        let l:match = matchlist(l:line, l:pattern)
+
+        if len(l:match) == 0
+            let l:match = matchlist(l:line, l:line_and_column_pattern)
+
+            if len(l:match) > 0
+                let l:index = len(l:output) - 1
+                let l:output[l:index]['lnum'] = l:match[1] + 0
+                let l:output[l:index]['col'] = l:match[2] + 0
+            endif
+        else
+            let l:isError = l:match[1] is? 'Error'
+
+            call add(l:output, {
+            \   'lnum': 0,
+            \   'col': 0,
+            \   'text': l:match[2],
+            \   'type': l:isError ? 'E' : 'W',
+            \})
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+function! ale_linters#cairo#sierra#GetCommand(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'cairo_sierra_executable')
+
+    return l:executable . ale#Pad(ale#Var(a:buffer, 'cairo_sierra_options')) . ' %s'
+endfunction
+
+call ale#linter#Define('cairo', {
+\   'name': 'sierra',
+\   'executable': {b -> ale#Var(b, 'cairo_sierra_executable')},
+\   'command': function('ale_linters#cairo#sierra#GetCommand'),
+\   'callback': 'ale_linters#cairo#sierra#Handle',
+\   'output_stream': 'stderr',
+\})
+

--- a/ale_linters/cairo/starknet.vim
+++ b/ale_linters/cairo/starknet.vim
@@ -1,38 +1,23 @@
 " Author: 0xHyoga <0xHyoga@gmx.com>
-" Description: Report starknet-compile errors in cairo 1.0 code
+" Description: Report starknet-compile errors in cairo code (pre-starknet
+" 1.0). This is deprecated but kept for backwards compatability.
 
 call ale#Set('cairo_starknet_executable', 'starknet-compile')
 call ale#Set('cairo_starknet_options', '')
 
 function! ale_linters#cairo#starknet#Handle(buffer, lines) abort
-    " Matches patterns like the following:
-    " Error: Expected ';' but got '('
-    "    --> /path/to/file/file.cairo:1:10:)
-    let l:pattern = '\v(error|warning): (.*)$'
-    let l:line_and_column_pattern = '\v\.cairo:(\d+):(\d+)'
+    " Error always on the first line
+    " e.g ex01.cairo:20:6: Could not find module 'contracts.utils.ex00_base'. Searched in the following paths:
+    let l:pattern = '\v\.cairo:(\d+):(\d+):+ (.*)'
     let l:output = []
 
-    for l:line in a:lines
-        let l:match = matchlist(l:line, l:pattern)
-
-        if len(l:match) == 0
-            let l:match = matchlist(l:line, l:line_and_column_pattern)
-
-            if len(l:match) > 0
-                let l:index = len(l:output) - 1
-                let l:output[l:index]['lnum'] = l:match[1] + 0
-                let l:output[l:index]['col'] = l:match[2] + 0
-            endif
-        else
-            let l:isError = l:match[1] is? 'Error'
-
-            call add(l:output, {
-            \   'lnum': 0,
-            \   'col': 0,
-            \   'text': l:match[2],
-            \   'type': l:isError ? 'E' : 'W',
-            \})
-        endif
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        call add(l:output, {
+        \   'lnum': str2nr(l:match[1]),
+        \   'col': str2nr(l:match[2]),
+        \   'type': 'E',
+        \   'text': l:match[3],
+        \})
     endfor
 
     return l:output

--- a/test/handler/test_sierra_handler.vader
+++ b/test/handler/test_sierra_handler.vader
@@ -1,0 +1,20 @@
+Before:
+  runtime ale_linters/cairo/sierra.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The starknet handler should handle error messages correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 16,
+  \     'col': 25,
+  \     'text': 'Plugin diagnostic: Type not found',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#cairo#sierra#Handle(bufnr(''), [
+  \   'error: Plugin diagnostic: Type not found',
+  \   '  --> lib.cairo:16:25',
+  \ ])

--- a/test/handler/test_starknet_handler.vader
+++ b/test/handler/test_starknet_handler.vader
@@ -8,13 +8,29 @@ Execute(The starknet handler should handle error messages correctly):
   AssertEqual
   \ [
   \   {
-  \     'lnum': 16,
-  \     'col': 25,
-  \     'text': 'Plugin diagnostic: Type not found',
+  \     'lnum': 3,
+  \     'col': 6,
+  \     'text': 'Could not find module "starkware.cairo.commo.cairo_builtins". Searched in the following paths:',
   \     'type': 'E',
   \   },
   \ ],
   \ ale_linters#cairo#starknet#Handle(bufnr(''), [
-  \   'error: Plugin diagnostic: Type not found',
-  \   '  --> lib.cairo:16:25',
+  \   'contract.cairo:3:6: Could not find module "starkware.cairo.commo.cairo_builtins". Searched in the following paths:',
+  \   'from starkware.cairo.commo.cairo_builtins import HashBuiltin',
+  \   '     ^**********************************^',
+  \ ])
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 21,
+  \     'col': 2,
+  \     'text': 'Unsupported decorator: "vie".',
+  \     'type': 'E',
+  \   },
+  \ ],
+  \ ale_linters#cairo#starknet#Handle(bufnr(''), [
+  \   'contract.cairo:21:2: Unsupported decorator: "vie".',
+  \   '@vie',
+  \   ' ^*^',
   \ ])

--- a/test/handler/test_starknet_handler.vader
+++ b/test/handler/test_starknet_handler.vader
@@ -8,29 +8,13 @@ Execute(The starknet handler should handle error messages correctly):
   AssertEqual
   \ [
   \   {
-  \     'lnum': 3,
-  \     'col': 6,
-  \     'text': 'Could not find module "starkware.cairo.commo.cairo_builtins". Searched in the following paths:',
+  \     'lnum': 16,
+  \     'col': 25,
+  \     'text': 'Plugin diagnostic: Type not found',
   \     'type': 'E',
   \   },
   \ ],
   \ ale_linters#cairo#starknet#Handle(bufnr(''), [
-  \   'contract.cairo:3:6: Could not find module "starkware.cairo.commo.cairo_builtins". Searched in the following paths:',
-  \   'from starkware.cairo.commo.cairo_builtins import HashBuiltin',
-  \   '     ^**********************************^',
-  \ ])
-
-  AssertEqual
-  \ [
-  \   {
-  \     'lnum': 21,
-  \     'col': 2,
-  \     'text': 'Unsupported decorator: "vie".',
-  \     'type': 'E',
-  \   },
-  \ ],
-  \ ale_linters#cairo#starknet#Handle(bufnr(''), [
-  \   'contract.cairo:21:2: Unsupported decorator: "vie".',
-  \   '@vie',
-  \   ' ^*^',
+  \   'error: Plugin diagnostic: Type not found',
+  \   '  --> lib.cairo:16:25',
   \ ])


### PR DESCRIPTION
Updated handler test for Cairo. This new version is compatible with the latest Cairo 1.0 release. Recently the language got upgraded and there is no point including the old Cairo, so i just replaced the whole ale_linters/cairo/starknet.vim file. Thanks!