### PR TITLE
fix: run opacheck on entire dir for more context

### DIFF
--- a/ale_linters/rego/opacheck.vim
+++ b/ale_linters/rego/opacheck.vim
@@ -11,7 +11,7 @@ function! ale_linters#rego#opacheck#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'rego_opacheck_options')
 
     return ale#Escape(ale_linters#rego#opacheck#GetExecutable(a:buffer))
-    \   . ' check %s --format json '
+    \   . ' check . --format json '
     \   . (!empty(l:options) ? ' ' . l:options : '')
 endfunction
 

--- a/test/linter/test_rego_opacheck.vader
+++ b/test/linter/test_rego_opacheck.vader
@@ -8,9 +8,9 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'opa',
-  \ ale#Escape('opa') . ' check %s --format json '
+  \ ale#Escape('opa') . ' check . --format json '
 
 Execute(The default command should be overridden):
   let b:ale_rego_opacheck_executable = '/bin/other/opa'
   AssertLinter '/bin/other/opa',
-  \ ale#Escape('/bin/other/opa') . ' check %s --format json '
+  \ ale#Escape('/bin/other/opa') . ' check . --format json '


### PR DESCRIPTION
Running `opa check` on a single file can report errors that might not exist when considering other files in the same directory

Adds to #4199 to help close #2531