### PR TITLE
floatwin: use win_execute in NeoVim for commands when it exists

### DIFF
--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -37,15 +37,21 @@ function! s:NvimShow(lines, options) abort
     endif
 
     " Execute commands in window context
-    let l:parent_window = nvim_get_current_win()
+    if exists('*win_execute')
+        for l:command in get(a:options, 'commands', [])
+            call win_execute(w:preview['id'], l:command)
+        endfor
+    else
+        let l:parent_window = nvim_get_current_win()
 
-    call nvim_set_current_win(w:preview['id'])
+        call nvim_set_current_win(w:preview['id'])
 
-    for l:command in get(a:options, 'commands', [])
-        call execute(l:command)
-    endfor
+        for l:command in get(a:options, 'commands', [])
+            call execute(l:command)
+        endfor
 
-    call nvim_set_current_win(l:parent_window)
+        call nvim_set_current_win(l:parent_window)
+    endif
 
     " Return to parent context on move
     augroup ale_floating_preview_window


### PR DESCRIPTION
ALEs floating windows are broken in NeoVim 0.10 after https://github.com/neovim/neovim/pull/23711.
The `CursorMoved` event from switching windows is now sent after `s:NvimShow` exits, which triggers the autocommand to close the window.
`win_execute` is available in NeoVim, so we can use a similar approach as the one used in `s:VimShow` to avoid switching windows altogether.

