### PR TITLE
feat: enable golangci-lint by default

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -42,7 +42,7 @@ let s:default_ale_linters = {
 \   'apkbuild': ['apkbuild_lint', 'secfixes_check'],
 \   'csh': ['shell'],
 \   'elixir': ['credo', 'dialyxir', 'dogma'],
-\   'go': ['gofmt', 'gopls', 'govet'],
+\   'go': ['gofmt', 'golangci-lint', 'gopls', 'govet'],
 \   'groovy': ['npm-groovy-lint'],
 \   'hack': ['hack'],
 \   'help': [],

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1641,7 +1641,7 @@ g:ale_linters                                                   *g:ale_linters*
   \   'apkbuild': ['apkbuild_lint', 'secfixes_check'],
   \   'csh': ['shell'],
   \   'elixir': ['credo', 'dialyxir', 'dogma'],
-  \   'go': ['gofmt', 'gopls', 'govet'],
+  \   'go': ['gofmt', 'golangci-lint', 'gopls', 'govet'],
   \   'groovy': ['npm-groovy-lint'],
   \   'hack': ['hack'],
   \   'help': [],

--- a/test/test_filetype_linter_defaults.vader
+++ b/test/test_filetype_linter_defaults.vader
@@ -36,7 +36,7 @@ Execute(The defaults for the elixir filetype should be correct):
   AssertEqual [], GetLinterNames('elixir')
 
 Execute(The defaults for the go filetype should be correct):
-  AssertEqual ['gofmt', 'gopls', 'govet'], GetLinterNames('go')
+  AssertEqual ['gofmt', 'golangci-lint', 'gopls', 'govet'], GetLinterNames('go')
 
   let g:ale_linters_explicit = 1
 


### PR DESCRIPTION
This replaces golint and gometalinter which are both deprecated

