### PR TITLE
fixed parsing errors when certain options are used in glslangValidator

### DIFF
--- a/ale_linters/glsl/glslang.vim
+++ b/ale_linters/glsl/glslang.vim
@@ -17,13 +17,14 @@ function! ale_linters#glsl#glslang#Handle(buffer, lines) abort
     " Matches patterns like the following:
     "
     " ERROR: 0:5: 'foo' : undeclared identifier
-    let l:pattern = '^\(.\+\): \(\d\+\):\(\d\+\): \(.\+\)'
+    " or when using options like -V or -G or --target-env
+    " ERROR: filename:5: 'foo' : undeclared identifier
+    let l:pattern = '^\(.\+\): \(.\+\):\(\d\+\): \(.\+\)'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'lnum': str2nr(l:match[3]),
-        \   'col': str2nr(l:match[2]),
         \   'text': l:match[4],
         \   'type': l:match[1] is# 'ERROR' ? 'E' : 'W',
         \})

--- a/ale_linters/glsl/glslang.vim
+++ b/ale_linters/glsl/glslang.vim
@@ -25,6 +25,7 @@ function! ale_linters#glsl#glslang#Handle(buffer, lines) abort
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'lnum': str2nr(l:match[3]),
+        \   'col' : 0,
         \   'text': l:match[4],
         \   'type': l:match[1] is# 'ERROR' ? 'E' : 'W',
         \})

--- a/test/handler/test_glslang_handler.vader
+++ b/test/handler/test_glslang_handler.vader
@@ -22,3 +22,27 @@ Execute(The glsl glslang handler should parse lines correctly):
   \ 'WARNING: 0:121: ''switch'' : last case/default label not followed by statements',
   \ 'ERROR: 2 compilation errors.  No code generated.',
   \ ])
+
+Execute(The glsl glslang handler should parse lines with options -V or -G correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 7,
+  \     'col': 0,
+  \     'type': 'E',
+  \     'text': '''non-opaque uniforms outside a block'' : not allowed when using GLSL for Vulkan',
+  \   },
+  \   {
+  \     'lnum': 14,
+  \     'col': 0,
+  \     'type': 'W',
+  \     'text': '''__shininess'' : identifiers containing consecutive underscores ("__") are reserved',
+  \   },
+  \ ],
+  \ ale_linters#glsl#glslang#Handle(bufnr(''), [
+  \ 'shader.vert',
+  \ 'ERROR: shader.vert:7: ''non-opaque uniforms outside a block'' : not allowed when using GLSL for Vulkan',
+  \ 'WARNING: shader.vert:14: ''__shininess'' : identifiers containing consecutive underscores ("__") are reserved',
+  \ 'ERROR: 1 compilation errors.  No code generated.',
+  \ 'SPIR-V is not generated for failed compile or link',
+  \ ])


### PR DESCRIPTION
I noticed that the linter stopped working when I attempted to use the -V option for checking code that will be used with Vulkan. After a bit of testing I realized that the pattern that is currently checked is incompatible with using certain flags. This is because the error reporting by glslangValidator is different when using at least these flags {-V, -G, --target-env}. For example without these flags set, output for error reporting looks like "ERROR: 0:5: 'foo' : undeclared identifier" and with any of the previously mentioned flags it looks like "ERROR: filename:5: 'foo' : undeclared identifier". Similar but not quite accepted by the pattern currently used, one downside is we no longer get a column number provided in the new report, although in my testing the column number reported is always 0 so I don't consider it very valuable as it is. However, with a bit of modification to the pattern matching code and no longer recording column number I managed to get both the, no options report, and the report with the aforementioned options set, to correctly report errors and be useful via ALE. 
