### PR TITLE
Adds erb-formatter support

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -615,6 +615,11 @@ let s:default_registry = {
 \       'function': 'ale#fixers#npmgroovylint#Fix',
 \       'suggested_filetypes': ['groovy'],
 \       'description': 'Fix Groovy files with npm-groovy-fix.',
+\   },
+\   'erb-formatter': {
+\       'function': 'ale#fixers#erbformatter#Fix',
+\       'suggested_filetypes': ['eruby'],
+\       'description': 'Apply erb-formatter -w to eruby/erb files.',
 \   }
 \}
 

--- a/autoload/ale/fixers/erbformatter.vim
+++ b/autoload/ale/fixers/erbformatter.vim
@@ -1,0 +1,13 @@
+" Author: Arash Mousavi <arash-m>
+" Description: Support for ERB::Formetter https://github.com/nebulab/erb-formatter
+
+call ale#Set('eruby_erbformatter_executable', 'erb-formatter')
+
+function! ale#fixers#erbformatter#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'eruby_erbformatter_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' -w %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-eruby.txt
+++ b/doc/ale-eruby.txt
@@ -14,6 +14,19 @@ default parser in Rails between 3.0 and 5.1. `erubi` is the default in Rails
 5.1 and later. `ruumba` can extract Ruby from eruby files and run rubocop on
 the result. To selectively enable a subset, see |g:ale_linters|.
 
+
+===============================================================================
+erb-formatter                                          *ale-eruby-erbformatter*
+
+g:ale_eruby_erbformatter_executable       *g:ale_eruby_erbformatter_executable*
+                                          *b:ale_eruby_erbformatter_executable*
+  Type: |String|
+  Default: `'erb-formatter'`
+
+  Override the invoked erb-formatter binary. This is useful for running
+  erb-formatter from binstubs or a bundle.
+
+
 ===============================================================================
 erblint                                                     *ale-eruby-erblint*
 
@@ -40,7 +53,7 @@ ruumba                                                       *ale-eruby-ruumba*
 g:ale_eruby_ruumba_executable                   *g:ale_eruby_ruumba_executable*
                                                 *b:ale_eruby_ruumba_executable*
   Type: |String|
-  Default: `'ruumba`
+  Default: `'ruumba'`
 
   Override the invoked ruumba binary. This is useful for running ruumba
   from binstubs or a bundle.

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -175,6 +175,7 @@ Notes:
   * `elm-make`
 * Erb
   * `erb`
+  * `erb-formatter`
   * `erblint`
   * `erubi`
   * `erubis`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2963,6 +2963,7 @@ documented in additional help files.
     erlfmt................................|ale-erlang-erlfmt|
     syntaxerl.............................|ale-erlang-syntaxerl|
   eruby...................................|ale-eruby-options|
+    erb-formatter.........................|ale-eruby-erbformatter|
     erblint...............................|ale-eruby-erblint|
     ruumba................................|ale-eruby-ruumba|
   fish....................................|ale-fish-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -184,6 +184,7 @@ formatting.
   * [elm-make](https://github.com/elm/compiler)
 * Erb
   * [erb](https://apidock.com/ruby/ERB)
+  * [erb-formatter](https://github.com/nebulab/erb-formatter)
   * [erblint](https://github.com/Shopify/erb-lint)
   * [erubi](https://github.com/jeremyevans/erubi)
   * [erubis](https://github.com/kwatch/erubis)

--- a/test/fixers/test_erbformatter_fixer_callback.vader
+++ b/test/fixers/test_erbformatter_fixer_callback.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpFixerTest('eruby', 'erb-formatter')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The erb-formatter callback should return the correct default values):
+  AssertFixer {
+  \    'command': ale#Escape('erb-formatter') . ' -w %t',
+  \    'read_temporary_file': 1,
+  \}
+
+Execute(The erb-formatter callback should allow custom erb-formatter executables):
+  let g:ale_eruby_erbformatter_executable = 'foo/bar'
+
+  AssertFixer {
+  \    'command': ale#Escape('foo/bar') . ' -w %t',
+  \    'read_temporary_file': 1,
+  \}


### PR DESCRIPTION
Adds support for ERB::Formatter (https://github.com/nebulab/erb-formatter)

Tried to follow other MRs to create tests and relevant documentations.