### PR TITLE
fix(vue): volar v1 support

### DIFF
--- a/ale_linters/vue/volar.vim
+++ b/ale_linters/vue/volar.vim
@@ -33,9 +33,12 @@ endfunction
 function! ale_linters#vue#volar#GetInitializationOptions(buffer) abort
     let l:tsserver_path = ale#path#FindNearestDirectory(a:buffer, 'node_modules/typescript/lib')
 
-    if l:tsserver_path == ''
+    if l:tsserver_path is# ''
+        " no-custom-checks
         echohl WarningMsg
+        " no-custom-checks
         echom '[volar] Must have typescript installed in project, please install via `npm install -D typescript`.'
+        " no-custom-checks
         echohl None
     endif
 

--- a/ale_linters/vue/volar.vim
+++ b/ale_linters/vue/volar.vim
@@ -3,50 +3,21 @@
 "              nvim-lspconfig and volar/packages/shared/src/types.ts
 
 call ale#Set('vue_volar_executable', 'vue-language-server')
-call ale#Set('vue_volar_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('vue_volar_use_global', 1)
 call ale#Set('vue_volar_init_options', {
-\   'documentFeatures': {
-\       'documentColor': v:false,
-\       'documentFormatting': {
-\           'defaultPrintWidth': 100,
-\       },
-\       'documentSymbol': v:true,
-\       'foldingRange': v:true,
-\       'linkedEditingRange': v:true,
-\       'selectionRange': v:true,
-\   },
-\   'languageFeatures': {
-\       'callHierarchy': v:true,
-\       'codeAction': v:true,
-\       'codeLens': v:true,
-\       'completion': {
-\           'defaultAttrNameCase': 'kebabCase',
-\           'defaultTagNameCase': 'both',
-\           'getDocumentNameCaseRequest': v:false,
-\           'getDocumentSelectionRequest': v:false,
-\       },
-\       'definition': v:true,
-\       'diagnostics': v:true,
-\       'documentHighlight': v:true,
-\       'documentLink': v:true,
-\       'hover': v:true,
-\       'references': v:true,
-\       'rename': v:true,
-\       'renameFileRefactoring': v:true,
-\       'schemaRequestService': v:true,
-\       'semanticTokens': v:false,
-\       'signatureHelp': v:true,
-\       'typeDefinition': v:true,
-\       'workspaceSymbol': v:false,
-\   },
-\   'typescript': {
-\       'serverPath': '',
-\       'localizedPath': v:null,
-\   },
+\   'typescript': { 'tsdk': '' },
 \})
 
 function! ale_linters#vue#volar#GetProjectRoot(buffer) abort
-    let l:project_roots = ['package.json', 'vite.config.js', '.git', bufname(a:buffer)]
+    let l:project_roots = [
+    \   'package.json',
+    \   'vite.config.js',
+    \   'vite.config.mjs',
+    \   'vite.config.cjs',
+    \   'vite.config.ts',
+    \   '.git',
+    \   bufname(a:buffer)
+    \]
 
     for l:project_root in l:project_roots
         let l:nearest_filepath = ale#path#FindNearestFile(a:buffer, l:project_root)
@@ -60,11 +31,16 @@ function! ale_linters#vue#volar#GetProjectRoot(buffer) abort
 endfunction
 
 function! ale_linters#vue#volar#GetInitializationOptions(buffer) abort
-    let l:tsserver_path = ale#path#FindNearestExecutable(a:buffer, [
-    \   'node_modules/typescript/lib/tsserverlibrary.js'
-    \ ])
+    let l:tsserver_path = ale#path#FindNearestDirectory(a:buffer, 'node_modules/typescript/lib')
+
+    if l:tsserver_path == ''
+        echohl WarningMsg
+        echom '[volar] Must have typescript installed in project, please install via `npm install -D typescript`.'
+        echohl None
+    endif
+
     let l:init_options = ale#Var(a:buffer, 'vue_volar_init_options')
-    let l:init_options.typescript.serverPath = l:tsserver_path
+    let l:init_options.typescript.tsdk = l:tsserver_path
 
     return l:init_options
 endfunction

--- a/doc/ale-vue.txt
+++ b/doc/ale-vue.txt
@@ -50,7 +50,7 @@ g:ale_vue_volar_executable                         *g:ale_vue_volar_executable*
 g:ale_vue_volar_use_global                         *g:ale_vue_volar_use_global*
                                                    *b:ale_vue_volar_use_global*
   Type: |Number|
-  Default: `get(g:, 'ale_use_global_executables', 0)`
+  Default: `1`
 
   See |ale-integrations-local-executables|
 
@@ -58,7 +58,7 @@ g:ale_vue_volar_use_global                         *g:ale_vue_volar_use_global*
 g:vue_volar_init_options                         *g:ale_vue_volar_init_options*
                                                  *b:ale_vue_volar_init_options*
   Type: |Dictionary|
-  Default: `{ ... }`
+  Default: `{ 'typescript': 'tsdk': '' }`
 
   Default is too long to show here, take a look at it over
   `ale_linters/vue/volar.vim`

--- a/test/linter/test_volar.vader
+++ b/test/linter/test_volar.vader
@@ -21,7 +21,7 @@ Execute(Assert proper tsserverlibrary for Volar LSP):
     call ale#test#SetFilename('../test-files/volar/src/App.vue')
 
     let g:init_opts = ale_linters#vue#volar#GetInitializationOptions(bufnr(''))
-    let g:tsserver_path = init_opts.typescript.serverPath
-    let g:actual_path = ale#path#Simplify(g:dir . '/../test-files/volar/node_modules/typescript/lib/tsserverlibrary.js')
+    let g:tsserver_path = init_opts.typescript.tsdk
+    let g:actual_path = ale#path#Simplify(g:dir . '/../test-files/volar/node_modules/typescript/lib/')
 
     AssertEqual g:tsserver_path, g:actual_path


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

According to the discussion over on https://github.com/dense-analysis/ale/discussions/4460#discussioncomment-6431665

I've identified that volar v1 does have breaking changes.

Following the volar discussion (https://github.com/vuejs/language-tools/discussions/2279) I've adjusted the initialization options and added a warning message instructing the user to install `typescript` in the project in order for volar to work.