### PR TITLE
Add end_col of matched forbidden word

### DIFF
--- a/autoload/ale/handlers/cspell.vim
+++ b/autoload/ale/handlers/cspell.vim
@@ -24,14 +24,19 @@ endfunction
 function! ale#handlers#cspell#Handle(buffer, lines) abort
     " Look for lines like the following:
     "
-    " /home/user/repos/ale/README.md:723:48 - Unknown word (stylelint)
-    let l:pattern = '\v^.*:(\d+):(\d+) - (.*)$'
+    " /home/user/repos/ale/README.md:3:128 - Unknown word (Neovim)
+    " match1: 3
+    " match2: 128
+    " match3: Unknown word (Neovim)
+    " match4: Neovim
+    let l:pattern = '\v^.*:(\d+):(\d+) - ([^\(]+\(([^\)]+)\).*)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
         call add(l:output, {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 0,
+        \   'end_col': l:match[2] + len(l:match[4]) - 1,
         \   'text': l:match[3],
         \   'type': 'W',
         \})

--- a/test/handler/test_cspell_handler.vader
+++ b/test/handler/test_cspell_handler.vader
@@ -2,12 +2,13 @@ Execute(The cspell handler should handle cspell output):
   AssertEqual
   \ [
   \   {
-  \     'lnum': 721,
-  \     'col': 18,
+  \     'lnum': 3,
+  \     'col': 128,
+  \     'end_col': 133,
   \     'type': 'W',
-  \     'text': 'Unknown word (stylelint)',
+  \     'text': 'Unknown word (Neovim)',
   \   },
   \ ],
   \ ale#handlers#cspell#Handle(bufnr(''),
-  \   '/:721:18 - Unknown word (stylelint)'
+  \   '/:3:128 - Unknown word (Neovim)'
   \)


### PR DESCRIPTION
Add `end_col` match of `cspell` linter. For highlight whole words by ALEWarning.

before:
![image](https://github.com/dense-analysis/ale/assets/4227425/76a1e9b1-494b-4502-addf-d56e45eeefcc)


after:
![image](https://github.com/dense-analysis/ale/assets/4227425/ca0f2374-bf8a-493b-85e9-56d9ed6025ee)
