### PR TITLE
Don't echom if not in normal mode

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -12,8 +12,10 @@ let s:cursor_timer = -1
 
 " A wrapper for echon so we can test messages we echo in Vader tests.
 function! ale#cursor#Echom(message) abort
-    " no-custom-checks
-    exec "norm! :echom a:message\n"
+    if mode() is# 'n'
+        " no-custom-checks
+        exec "norm! :echom a:message\n"
+    endif
 endfunction
 
 function! ale#cursor#TruncatedEcho(original_message) abort


### PR DESCRIPTION
I've been running into this issue for a couple years now: https://github.com/dense-analysis/ale/issues/3621 where often times I would make a visual selection only to be interrupted and booted out of visual mode back into normal mode and finally decided to do some digging into how to fix it. 

w0rp suggested a fix which I've attempted to apply to the `ale#cursor#Echom` method. Not entirely sure if this is the right way to fix it, but using it for a day it definitely hasn't repro'd for me since