### PR TITLE
fix: resolve eslint working directory by looking up config files

### DIFF
--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -18,6 +18,7 @@ call ale#Set('javascript_eslint_suppress_missing_config', 0)
 function! ale#handlers#eslint#FindConfig(buffer) abort
     for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))
         for l:basename in [
+        \   'eslint.config.js',
         \   '.eslintrc.js',
         \   '.eslintrc.yaml',
         \   '.eslintrc.yml',
@@ -49,23 +50,25 @@ function! ale#handlers#eslint#GetCwd(buffer) abort
     " If eslint is installed in a directory which contains the buffer, assume
     " it is the ESLint project root.  Otherwise, use nearest node_modules.
     " Note: If node_modules not present yet, can't load local deps anyway.
-    let l:executable = ale#path#FindNearestExecutable(a:buffer, s:executables)
+    " let l:executable = ale#path#FindNearestExecutable(a:buffer, s:executables)
+    let l:nearest_config = ale#handlers#eslint#FindConfig(a:buffer)
+    return fnamemodify(l:nearest_config, ':p:h')
 
-    if !empty(l:executable)
-        let l:modules_index = strridx(l:executable, 'node_modules')
-        let l:modules_root = l:modules_index > -1 ? l:executable[0:l:modules_index - 2] : ''
+    " if !empty(l:executable)
+    "     let l:modules_index = strridx(l:executable, 'node_modules')
+    "     let l:modules_root = l:modules_index > -1 ? l:executable[0:l:modules_index - 2] : ''
 
-        let l:sdks_index = strridx(l:executable, ale#path#Simplify('.yarn/sdks'))
-        let l:sdks_root = l:sdks_index > -1 ? l:executable[0:l:sdks_index - 2] : ''
-    else
-        let l:modules_dir = ale#path#FindNearestDirectory(a:buffer, 'node_modules')
-        let l:modules_root = !empty(l:modules_dir) ? fnamemodify(l:modules_dir, ':h:h') : ''
+    "     let l:sdks_index = strridx(l:executable, ale#path#Simplify('.yarn/sdks'))
+    "     let l:sdks_root = l:sdks_index > -1 ? l:executable[0:l:sdks_index - 2] : ''
+    " else
+    "     let l:modules_dir = ale#path#FindNearestDirectory(a:buffer, 'node_modules')
+    "     let l:modules_root = !empty(l:modules_dir) ? fnamemodify(l:modules_dir, ':h:h') : ''
 
-        let l:sdks_dir = ale#path#FindNearestDirectory(a:buffer, ale#path#Simplify('.yarn/sdks'))
-        let l:sdks_root = !empty(l:sdks_dir) ? fnamemodify(l:sdks_dir, ':h:h:h') : ''
-    endif
+    "     let l:sdks_dir = ale#path#FindNearestDirectory(a:buffer, ale#path#Simplify('.yarn/sdks'))
+    "     let l:sdks_root = !empty(l:sdks_dir) ? fnamemodify(l:sdks_dir, ':h:h:h') : ''
+    " endif
 
-    return strlen(l:modules_root) > strlen(l:sdks_root) ? l:modules_root : l:sdks_root
+    " return strlen(l:modules_root) > strlen(l:sdks_root) ? l:modules_root : l:sdks_root
 endfunction
 
 function! ale#handlers#eslint#GetCommand(buffer) abort

--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -42,33 +42,10 @@ endfunction
 
 " Given a buffer, return an appropriate working directory for ESLint.
 function! ale#handlers#eslint#GetCwd(buffer) abort
-    " ESLint 6 loads plugins/configs/parsers from the project root
-    " By default, the project root is simply the CWD of the running process.
-    " https://github.com/eslint/rfcs/blob/master/designs/2018-simplified-package-loading/README.md
-    " https://github.com/dense-analysis/ale/issues/2787
-    "
-    " If eslint is installed in a directory which contains the buffer, assume
-    " it is the ESLint project root.  Otherwise, use nearest node_modules.
-    " Note: If node_modules not present yet, can't load local deps anyway.
-    " let l:executable = ale#path#FindNearestExecutable(a:buffer, s:executables)
+    " find the nearest eslint config file to the given buffer
     let l:nearest_config = ale#handlers#eslint#FindConfig(a:buffer)
+
     return fnamemodify(l:nearest_config, ':p:h')
-
-    " if !empty(l:executable)
-    "     let l:modules_index = strridx(l:executable, 'node_modules')
-    "     let l:modules_root = l:modules_index > -1 ? l:executable[0:l:modules_index - 2] : ''
-
-    "     let l:sdks_index = strridx(l:executable, ale#path#Simplify('.yarn/sdks'))
-    "     let l:sdks_root = l:sdks_index > -1 ? l:executable[0:l:sdks_index - 2] : ''
-    " else
-    "     let l:modules_dir = ale#path#FindNearestDirectory(a:buffer, 'node_modules')
-    "     let l:modules_root = !empty(l:modules_dir) ? fnamemodify(l:modules_dir, ':h:h') : ''
-
-    "     let l:sdks_dir = ale#path#FindNearestDirectory(a:buffer, ale#path#Simplify('.yarn/sdks'))
-    "     let l:sdks_root = !empty(l:sdks_dir) ? fnamemodify(l:sdks_dir, ':h:h:h') : ''
-    " endif
-
-    " return strlen(l:modules_root) > strlen(l:sdks_root) ? l:modules_root : l:sdks_root
 endfunction
 
 function! ale#handlers#eslint#GetCommand(buffer) abort

--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -47,6 +47,8 @@ function! ale#handlers#eslint#GetCwd(buffer) abort
 
     if l:cwd isnot# '.'
         return l:cwd
+    else
+        return ''
     endif
 endfunction
 

--- a/autoload/ale/handlers/eslint.vim
+++ b/autoload/ale/handlers/eslint.vim
@@ -43,9 +43,11 @@ endfunction
 " Given a buffer, return an appropriate working directory for ESLint.
 function! ale#handlers#eslint#GetCwd(buffer) abort
     " find the nearest eslint config file to the given buffer
-    let l:nearest_config = ale#handlers#eslint#FindConfig(a:buffer)
+    let l:cwd = fnamemodify(ale#handlers#eslint#FindConfig(a:buffer), ':h')
 
-    return fnamemodify(l:nearest_config, ':p:h')
+    if l:cwd isnot# '.'
+        return l:cwd
+    endif
 endfunction
 
 function! ale#handlers#eslint#GetCommand(buffer) abort


### PR DESCRIPTION
Closes #4487

This PR changes eslint working directory resolution based on eslint config file markers and adds support for the [new `eslint.config.js` config file](https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-file-resolution)

The previous behavior was to resolve eslint working directory based on `node_modules` (or default to project root).

This change should not break previous behavior since children `node_modules` will always be accompanied by `package.json` in the same locations, which the `ale#handlers#eslint#FindConfig` looks for in the absence of an eslint config file.