### PR TITLE
fix: sqlfluff to allow config file other than .sqlfluff

### DIFF
--- a/ale_linters/sql/sqlfluff.vim
+++ b/ale_linters/sql/sqlfluff.vim
@@ -7,6 +7,9 @@ let g:ale_sql_sqlfluff_executable =
 let g:ale_sql_sqlfluff_options =
 \   get(g:, 'ale_sql_sqlfluff_options', '')
 
+let g:ale_sql_sqlfluff_config_file =
+\   get(g:, 'ale_sql_sqlfluff_config_file', '.sqlfluff')
+
 function! ale_linters#sql#sqlfluff#Executable(buffer) abort
     return ale#Var(a:buffer, 'sql_sqlfluff_executable')
 endfunction
@@ -19,7 +22,7 @@ function! ale_linters#sql#sqlfluff#Command(buffer) abort
     \    ale#Escape(l:executable)
     \    . ' lint'
 
-    let l:config_file = ale#path#FindNearestFile(a:buffer, '.sqlfluff')
+    let l:config_file = ale#path#FindNearestFile(a:buffer, ale#Var(a:buffer, 'sql_sqlfluff_config_file'))
 
     if !empty(l:config_file)
         let l:cmd .= ' --config ' . ale#Escape(l:config_file)

--- a/autoload/ale/fixers/sqlfluff.vim
+++ b/autoload/ale/fixers/sqlfluff.vim
@@ -5,12 +5,14 @@ call ale#Set('sql_sqlfluff_executable', 'sqlfluff')
 
 function! ale#fixers#sqlfluff#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'sql_sqlfluff_executable')
+    let l:options = ale#Var(a:buffer, 'sql_sqlfluff_options')
 
     let l:cmd =
     \    ale#Escape(l:executable)
-    \    . ' fix --force'
+    \    . ' fix --force '
+    \    . l:options
 
-    let l:config_file = ale#path#FindNearestFile(a:buffer, '.sqlfluff')
+    let l:config_file = ale#path#FindNearestFile(a:buffer, ale#Var(a:buffer, 'sql_sqlfluff_config_file'))
 
     if !empty(l:config_file)
         let l:cmd .= ' --config ' . ale#Escape(l:config_file)

--- a/doc/ale-sql.txt
+++ b/doc/ale-sql.txt
@@ -44,6 +44,13 @@ g:ale_sql_sqlfluff_options                         *g:ale_sql_sqlfluff_options*
 
   This variable can be set to pass additional options to the sqlfluff linter.
 
+g:ale_sql_sqlfluff_config_file                *g:ale_sql_sqlfluff_config_file*
+                                              *b:ale_sql_sqlfluff_config_file*
+  Type: |String|
+  Default: `'.sqlfluff'`
+
+  This variable can be set to pass config file type to sqlfluff.
+  Either pyproject.toml, setup.cfg, tox.ini, or pep8.ini.
 
 ===============================================================================
 

--- a/doc/ale-sql.txt
+++ b/doc/ale-sql.txt
@@ -44,8 +44,8 @@ g:ale_sql_sqlfluff_options                         *g:ale_sql_sqlfluff_options*
 
   This variable can be set to pass additional options to the sqlfluff linter.
 
-g:ale_sql_sqlfluff_config_file                *g:ale_sql_sqlfluff_config_file*
-                                              *b:ale_sql_sqlfluff_config_file*
+g:ale_sql_sqlfluff_config_file                 *g:ale_sql_sqlfluff_config_file*
+                                               *b:ale_sql_sqlfluff_config_file*
   Type: |String|
   Default: `'.sqlfluff'`
 


### PR DESCRIPTION
Closes https://github.com/dense-analysis/ale/issues/4554

This PR allows config file other than `.sqlfluff` to be used as listed:  
- setup.cfg
- tox.ini
- pep8.ini
- pyproject.toml

Adding a new variable `ale_sql_sqlfluff_config_file` to be added to allow sqlfluff to use config file nearest to the buffer. 