### PR TITLE
Fix error loading "text" syntax for hover

### DIFF
--- a/test/test_hover.vader
+++ b/test/test_hover.vader
@@ -168,7 +168,7 @@ Execute(LSP hover response with lists of strings should be handled):
 
 Execute(LSP hover response with lists of strings and marked strings should be handled):
   call HandleValidLSPResult({'contents': [
-  \  {'language': 'rust', 'value': 'foo'},
+  \  {'language': 'python', 'value': 'foo'},
   \  "bar\n",
   \]})
 
@@ -178,8 +178,8 @@ Execute(LSP hover response with lists of strings and marked strings should be ha
   \   {
   \     'commands': [
   \       'unlet! b:current_syntax',
-  \       'syntax include @ALE_hover_rust syntax/rust.vim',
-  \       'syntax region ALE_hover_1 start=/\%1l/ end=/\%2l/ contains=@ALE_hover_rust',
+  \       'syntax include @ALE_hover_python syntax/python.vim',
+  \       'syntax region ALE_hover_1 start=/\%1l/ end=/\%2l/ contains=@ALE_hover_python',
   \     ],
   \   },
   \ ],

--- a/test/test_hover_parsing.vader
+++ b/test/test_hover_parsing.vader
@@ -35,12 +35,12 @@ Execute(A string with a code fence should be handled):
   \ [
   \   [
   \     'unlet! b:current_syntax',
-  \     'syntax include @ALE_hover_python syntax/python.vim',
+  \     'syntax include @ALE_hover_javascript syntax/javascript.vim',
   \     'unlet! b:current_syntax',
-  \     'syntax include @ALE_hover_typescript syntax/typescript.vim',
+  \     'syntax include @ALE_hover_python syntax/python.vim',
   \     'syntax region ALE_hover_1 start=/\%1l/ end=/\%3l/ contains=@ALE_hover_python',
   \     'syntax region ALE_hover_2 start=/\%5l/ end=/\%8l/ contains=@ALE_hover_python',
-  \     'syntax region ALE_hover_3 start=/\%8l/ end=/\%10l/ contains=@ALE_hover_typescript',
+  \     'syntax region ALE_hover_3 start=/\%8l/ end=/\%10l/ contains=@ALE_hover_javascript',
   \   ],
   \   [
   \     'def foo():',
@@ -64,7 +64,7 @@ Execute(A string with a code fence should be handled):
   \   'def bar():',
   \   '    pass',
   \   '```',
-  \   '```typescript',
+  \   '```javascript',
   \   'const baz = () => undefined',
   \   '```',
   \ ], "\n"))
@@ -74,12 +74,12 @@ Execute(Multiple strings with fences should be handled):
   \ [
   \   [
   \     'unlet! b:current_syntax',
-  \     'syntax include @ALE_hover_python syntax/python.vim',
+  \     'syntax include @ALE_hover_javascript syntax/javascript.vim',
   \     'unlet! b:current_syntax',
-  \     'syntax include @ALE_hover_typescript syntax/typescript.vim',
+  \     'syntax include @ALE_hover_python syntax/python.vim',
   \     'syntax region ALE_hover_1 start=/\%1l/ end=/\%3l/ contains=@ALE_hover_python',
   \     'syntax region ALE_hover_2 start=/\%5l/ end=/\%8l/ contains=@ALE_hover_python',
-  \     'syntax region ALE_hover_3 start=/\%8l/ end=/\%10l/ contains=@ALE_hover_typescript',
+  \     'syntax region ALE_hover_3 start=/\%8l/ end=/\%10l/ contains=@ALE_hover_javascript',
   \   ],
   \   [
   \     'def foo():',
@@ -106,7 +106,7 @@ Execute(Multiple strings with fences should be handled):
   \     'def bar():',
   \     '    pass',
   \     '```',
-  \     '```typescript',
+  \     '```javascript',
   \     'const baz = () => undefined',
   \     '```',
   \   ], "\n"),
@@ -124,7 +124,7 @@ Execute(Objects with kinds should be handled):
   \     'def foo():',
   \     '    pass',
   \     '',
-  \     '```typescript',
+  \     '```javascript',
   \     'const baz = () => undefined',
   \     '```',
   \   ],
@@ -142,7 +142,7 @@ Execute(Objects with kinds should be handled):
   \   {
   \     'kind': 'plaintext',
   \     'value': join([
-  \       '```typescript',
+  \       '```javascript',
   \       'const baz = () => undefined',
   \       '```',
   \     ], "\n"),
@@ -170,4 +170,20 @@ Execute(Simple markdown formatting should be handled):
   \   '    pass',
   \   '```',
   \   'formatted \_ line \_',
+  \ ], "\n"))
+
+Execute(Non-existent syntax files shouldn't be loaded):
+  AssertEqual
+  \ [
+  \   [
+  \     'syntax region ALE_hover_1 start=/\%1l/ end=/\%2l/ contains=@ALE_hover_text',
+  \   ],
+  \   [
+  \     'hello',
+  \   ],
+  \ ],
+  \ ale#hover#ParseLSPResult(join([
+  \   '```text',
+  \   'hello',
+  \   '```',
   \ ], "\n"))


### PR DESCRIPTION
rust-analyzer sometimes returns a hover result with language being "text", but there's no syntax/text.vim, so this would fail with:

    Error detected while processing function <SNR>150_VimOutputCallback[6]..<lambda>8[1]..ale#lsp#HandleMessage[30]..ale#hover#HandleLSPResponse[42]..ale#floating_preview#Show[13]..<SNR>161_VimShow:
    line   13:
    E484: Cannot open file syntax/text.vim

Only including the file when it actually exists fixes this.

(Note that I had to substitute javascript for typescript in `test/test_hover_parsing.vader` because there's no `syntax/typescript.vim` in vim 8.0 and neovim 0.2.)

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

> Where are the tests? Have you added tests? Have you updated the tests? Read the
> comment above and the documentation referenced in it first. Write tests!
>
> Seriously, read `:help ale-dev` and write tests.

There are some, yeah.
