### PR TITLE
Support numhl highlights for vim >= 8.2.3874

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -87,7 +87,7 @@ execute 'sign define ALEInfoSign text=' . s:EscapeSignText(g:ale_sign_info)
 \   . ' texthl=ALEInfoSign linehl=ALEInfoLine'
 sign define ALEDummySign text=\  texthl=SignColumn
 
-if g:ale_sign_highlight_linenrs && has('nvim-0.3.2')
+if g:ale_sign_highlight_linenrs && (has('nvim-0.3.2') || has('patch-8.2.3874'))
     if !hlexists('ALEErrorSignLineNr')
         highlight link ALEErrorSignLineNr CursorLineNr
     endif


### PR DESCRIPTION
Fixes #4579

In #2637, support for numhl highlights was added for nvim.

In the meantime, vim added support for numhl highlights in patch 8.2.3874.

This patch allows numhl highlights to be enabled in ALE for vim >= 8.2.3874 too.