### PR TITLE
Add lexical for linting elixir projects

### DIFF
--- a/ale_linters/elixir/lexical.vim
+++ b/ale_linters/elixir/lexical.vim
@@ -1,0 +1,19 @@
+" Author: Axel Clark <axelclark@pm.me>
+" Description: Lexical integration (https://github.com/lexical-lsp/lexical)
+
+call ale#Set('elixir_lexical_release', 'lexical')
+
+function! ale_linters#elixir#lexical#GetExecutable(buffer) abort
+    let l:dir = ale#path#Simplify(ale#Var(a:buffer, 'elixir_lexical_release'))
+    let l:cmd = has('win32') ? '\start_lexical.bat' : '/start_lexical.sh'
+
+    return l:dir . l:cmd
+endfunction
+
+call ale#linter#Define('elixir', {
+\   'name': 'lexical',
+\   'lsp': 'stdio',
+\   'executable': function('ale_linters#elixir#lexical#GetExecutable'),
+\   'command': function('ale_linters#elixir#lexical#GetExecutable'),
+\   'project_root': function('ale#handlers#elixir#FindMixUmbrellaRoot'),
+\})

--- a/doc/ale-elixir.txt
+++ b/doc/ale-elixir.txt
@@ -109,8 +109,8 @@ lexical                                                    *ale-elixir-lexical*
 
 Lexical (https://github.com/lexical-lsp/lexical)
 
-g:ale_elixir_lexical_release                   *g:ale_elixir_lexical_release*
-                                               *b:ale_elixir_lexical_release*
+g:ale_elixir_lexical_release                     *g:ale_elixir_lexical_release*
+                                                 *b:ale_elixir_lexical_release*
   Type: |String|
   Default: `'lexical'`
 

--- a/doc/ale-elixir.txt
+++ b/doc/ale-elixir.txt
@@ -105,4 +105,22 @@ See |ale-cspell-options|
 
 
 ===============================================================================
+lexical                                                    *ale-elixir-lexical*
+
+Lexical (https://github.com/lexical-lsp/lexical)
+
+g:ale_elixir_lexical_release                   *g:ale_elixir_lexical_release*
+                                               *b:ale_elixir_lexical_release*
+  Type: |String|
+  Default: `'lexical'`
+
+  Location of the lexical release directory. This directory must contain
+  the language server scripts (start_lexical.sh and start_lexical.bat).
+
+  For example, set release to: `/home/projects/lexical/_build/dev/rel/lexical`
+
+  There are currnetly no configuration options for lexical.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -168,8 +168,8 @@ Notes:
   * `dialyxir`
   * `dogma`!!
   * `elixir-ls`
-  * `mix`!!
   * `lexical`
+  * `mix`!!
 * Elm
   * `elm-format`
   * `elm-ls`

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -169,6 +169,7 @@ Notes:
   * `dogma`!!
   * `elixir-ls`
   * `mix`!!
+  * `lexical`
 * Elm
   * `elm-format`
   * `elm-ls`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -2951,6 +2951,7 @@ documented in additional help files.
     elixir-ls.............................|ale-elixir-elixir-ls|
     credo.................................|ale-elixir-credo|
     cspell................................|ale-elixir-cspell|
+    lexical...............................|ale-elixir-lexical|
   elm.....................................|ale-elm-options|
     elm-format............................|ale-elm-elm-format|
     elm-ls................................|ale-elm-elm-ls|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -178,6 +178,7 @@ formatting.
   * [dogma](https://github.com/lpil/dogma) :floppy_disk:
   * [elixir-ls](https://github.com/elixir-lsp/elixir-ls) :warning:
   * [mix](https://hexdocs.pm/mix/Mix.html) :warning: :floppy_disk:
+  * [lexical](https://github.com/lexical-lsp/lexical) :warning:
 * Elm
   * [elm-format](https://github.com/avh4/elm-format)
   * [elm-ls](https://github.com/elm-tooling/elm-language-server)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -177,8 +177,8 @@ formatting.
   * [dialyxir](https://github.com/jeremyjh/dialyxir)
   * [dogma](https://github.com/lpil/dogma) :floppy_disk:
   * [elixir-ls](https://github.com/elixir-lsp/elixir-ls) :warning:
-  * [mix](https://hexdocs.pm/mix/Mix.html) :warning: :floppy_disk:
   * [lexical](https://github.com/lexical-lsp/lexical) :warning:
+  * [mix](https://hexdocs.pm/mix/Mix.html) :warning: :floppy_disk:
 * Elm
   * [elm-format](https://github.com/avh4/elm-format)
   * [elm-ls](https://github.com/elm-tooling/elm-language-server)

--- a/test/linter/test_lexical.vader
+++ b/test/linter/test_lexical.vader
@@ -1,0 +1,28 @@
+Before:
+  call ale#assert#SetUpLinterTest('elixir', 'lexical')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(should set correct defaults):
+  if has('win32')
+    AssertLinter 'lexical\start_lexical.bat', 'lexical\start_lexical.bat'
+  else
+    AssertLinter 'lexical/start_lexical.sh', 'lexical/start_lexical.sh'
+  endif
+
+Execute(should configure lexical release location):
+  let b:ale_elixir_lexical_release = 'boo'
+
+  if has('win32')
+    AssertLinter 'boo\start_lexical.bat', 'boo\start_lexical.bat'
+  else
+    AssertLinter 'boo/start_lexical.sh', 'boo/start_lexical.sh'
+  endif
+
+Execute(should set correct LSP values):
+  call ale#test#SetFilename('../test-files/elixir/umbrella_project/apps/app1/lib/app.ex')
+
+  AssertLSPLanguage 'elixir'
+  AssertLSPOptions {}
+  AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/elixir/umbrella_project')


### PR DESCRIPTION
Add linter support for Elixir using [Lexical](https://github.com/lexical-lsp/lexical).  I followed the existing elixir linters as a template.  Let me know if I need to make changes.
