### PR TITLE
Support format xml file which haven't yet persisted at the disk

### DIFF
--- a/autoload/ale/fixers/xmllint.vim
+++ b/autoload/ale/fixers/xmllint.vim
@@ -1,4 +1,4 @@
-" Author: Cyril Roelandt <tipecaml@gmail.com>
+" Author: Cyril Roelandt <tipecaml@gmail.com>, jiz4oh <me@jiz4oh.com>
 " Description: Integration of xmllint with ALE.
 
 call ale#Set('xml_xmllint_executable', 'xmllint')
@@ -7,7 +7,12 @@ call ale#Set('xml_xmllint_indentsize', 2)
 
 function! ale#fixers#xmllint#Fix(buffer) abort
     let l:executable = ale#Escape(ale#Var(a:buffer, 'xml_xmllint_executable'))
-    let l:filename = ale#Escape(bufname(a:buffer))
+    let l:filename = bufname(a:buffer)
+    if empty(l:filename)
+        let l:filename = '%t'
+    else
+        let l:filename = ale#Escape(l:filename)
+    endif
     let l:command = l:executable . ' --format ' . l:filename
 
     let l:indent = ale#Var(a:buffer, 'xml_xmllint_indentsize')

--- a/autoload/ale/fixers/xmllint.vim
+++ b/autoload/ale/fixers/xmllint.vim
@@ -8,11 +8,13 @@ call ale#Set('xml_xmllint_indentsize', 2)
 function! ale#fixers#xmllint#Fix(buffer) abort
     let l:executable = ale#Escape(ale#Var(a:buffer, 'xml_xmllint_executable'))
     let l:filename = bufname(a:buffer)
+
     if empty(l:filename)
         let l:filename = '%t'
     else
         let l:filename = ale#Escape(l:filename)
     endif
+
     let l:command = l:executable . ' --format ' . l:filename
 
     let l:indent = ale#Var(a:buffer, 'xml_xmllint_indentsize')

--- a/test/fixers/test_xmllint_fixer_callback.vader
+++ b/test/fixers/test_xmllint_fixer_callback.vader
@@ -12,6 +12,16 @@ Before:
 After:
   Restore
 
+Execute(The xmllint callback should return the correct default command with unpersisted buffer):
+  new
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('/path/to/xmllint')
+  \     . ' --format %t'
+  \ },
+  \ ale#fixers#xmllint#Fix(bufnr(''))
+
 Execute(The xmllint callback should return the correct default command):
   AssertEqual
   \ {


### PR DESCRIPTION
Hi, xmllint is invalid if the buffer is not saved for now. and the pr can fix it