### PR TITLE
fix(neovim): ignore unrelated diagnostics

### DIFF
--- a/lua/diagnostics.lua
+++ b/lua/diagnostics.lua
@@ -12,7 +12,7 @@ module.sendAleResultsToDiagnostics = function(buffer, loclist)
   -- Convert all the ALE loclist items to the shape that Neovim's diagnostic
   -- API is expecting.
   for _, location in ipairs(loclist) do
-    if location.bufnr == nil or location.bufnr == buffer then
+    if location.bufnr == buffer then
       table.insert(
         diagnostics,
         -- All line numbers from ALE are 1-indexed, but all line numbers

--- a/lua/diagnostics.lua
+++ b/lua/diagnostics.lua
@@ -12,28 +12,30 @@ module.sendAleResultsToDiagnostics = function(buffer, loclist)
   -- Convert all the ALE loclist items to the shape that Neovim's diagnostic
   -- API is expecting.
   for _, location in ipairs(loclist) do
-    table.insert(
-      diagnostics,
-      -- All line numbers from ALE are 1-indexed, but all line numbers
-      -- in the diagnostics API are 0-indexed, so we have to subtract 1
-      -- to make this work.
-      {
-        lnum = location.lnum - 1,
-        -- Ending line number, or if we don't have one, just make it the same
-        -- as the starting line number
-        end_lnum = (location.end_lnum or location.lnum) - 1,
-        -- Which column does the error start on?
-        col = math.max((location.col or 1) - 1, 0),
-        -- end_col does *not* appear to need 1 subtracted, so we don't.
-        end_col = location.end_col,
-        -- Which severity: error, warning, or info?
-        severity = ale_type_to_diagnostic_severity[location.type] or "E",
-        -- The error message
-        message = location.text,
-        -- e.g. "rubocop"
-        source = location.linter_name,
-      }
-    )
+    if location.bufnr == nil or location.bufnr == buffer then
+      table.insert(
+        diagnostics,
+        -- All line numbers from ALE are 1-indexed, but all line numbers
+        -- in the diagnostics API are 0-indexed, so we have to subtract 1
+        -- to make this work.
+        {
+          lnum = location.lnum - 1,
+          -- Ending line number, or if we don't have one, just make it the same
+          -- as the starting line number
+          end_lnum = (location.end_lnum or location.lnum) - 1,
+          -- Which column does the error start on?
+          col = math.max((location.col or 1) - 1, 0),
+          -- end_col does *not* appear to need 1 subtracted, so we don't.
+          end_col = location.end_col,
+          -- Which severity: error, warning, or info?
+          severity = ale_type_to_diagnostic_severity[location.type] or "E",
+          -- The error message
+          message = location.text,
+          -- e.g. "rubocop"
+          source = location.linter_name,
+        }
+      )
+    end
   end
 
   local virtualtext_enabled_set = {['all'] = true, ['2'] = true, [2] = true, ['current'] = true, ['1'] = true, [1] = true}

--- a/test/test_neovim_diagnostics.vader
+++ b/test/test_neovim_diagnostics.vader
@@ -1,0 +1,77 @@
+Before:
+  Save g:ale_use_neovim_diagnostics_api
+
+  function! CollectMessages(buffer)
+    if !has('nvim-0.6')
+        return
+    endif
+
+    let l:messages = []
+    for l:diag in v:lua.vim.diagnostic.get(a:buffer)
+        call add(l:messages, l:diag.message)
+    endfor
+
+    return l:messages
+  endfunction
+
+
+After:
+  unlet! b:other_bufnr
+  delfunction CollectMessages
+  Restore
+
+Execute(Should only set diagnostics belonging to the given buffer):
+  if has('nvim-0.6')
+
+  let b:other_bufnr = bufnr('/foo/bar/baz', 1)
+  " Make sure we actually get another buffer number, or the test is invalid.
+  AssertNotEqual -1, b:other_bufnr
+
+  let g:ale_use_neovim_diagnostics_api = 1
+
+  call ale#engine#SetResults(bufnr('%'), [
+  \  {
+  \    'lnum': 1,
+  \    'col': 10,
+  \    'bufnr': bufnr('%'),
+  \    'vcol': 0,
+  \    'linter_name': 'bettercode',
+  \    'nr': -1,
+  \    'type': 'W',
+  \    'text': 'A',
+  \  },
+  \  {
+  \    'lnum': 2,
+  \    'col': 10,
+  \    'bufnr': b:other_bufnr,
+  \    'vcol': 0,
+  \    'linter_name': 'bettercode',
+  \    'nr': -1,
+  \    'type': 'W',
+  \    'text': 'B',
+  \  },
+  \  {
+  \    'lnum': 3,
+  \    'col': 1,
+  \    'bufnr': bufnr('%'),
+  \    'vcol': 0,
+  \    'linter_name': 'bettercode',
+  \    'nr': -1,
+  \    'type': 'E',
+  \    'text': 'C',
+  \  },
+  \  {
+  \    'lnum': 4,
+  \    'col': 1,
+  \    'bufnr': b:other_bufnr,
+  \    'vcol': 0,
+  \    'linter_name': 'bettercode',
+  \    'nr': -1,
+  \    'type': 'E',
+  \    'text': 'D',
+  \  },
+  \])
+
+  AssertEqual ["A", "C"], CollectMessages(bufnr('%'))
+
+  endif


### PR DESCRIPTION
In some cases, linters may produce unrelated diagnostics for the buffer. For example, when enabling `g:ale_go_golangci_lint_package`, the whole Go package will be checked instead of only the current file.

If `g:ale_use_neovim_diagnostics_api` is enabled, we will see unrelated diagnostics belonging to other files/buffers.

This PR filters out the unrelated diagnostics before calling the `vim.diagnostic.set` api.