### PR TITLE
Feature: add `forge fmt` as a fixer for Solidity files

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -286,6 +286,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['fish'],
 \       'description': 'Format fish scripts using fish_indent.',
 \   },
+\   'forge': {
+\       'function': 'ale#fixers#forge#Fix',
+\       'suggested_filetypes': ['solidity'],
+\       'description': 'Fix Solidity files with forge fmt.',
+\   },
 \   'gofmt': {
 \       'function': 'ale#fixers#gofmt#Fix',
 \       'suggested_filetypes': ['go'],

--- a/autoload/ale/fixers/forge.vim
+++ b/autoload/ale/fixers/forge.vim
@@ -1,0 +1,11 @@
+call ale#Set('solidity_forge_executable', 'forge')
+
+function! ale#fixers#forge#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'solidity_forge_executable')
+
+    return {
+    \  'command': ale#Escape(l:executable)
+    \       . ' fmt %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-solidity.txt
+++ b/doc/ale-solidity.txt
@@ -36,6 +36,15 @@ solium                                                    *ale-solidity-solium*
   See the corresponding solium usage for detailed instructions
   (https://github.com/duaraghav8/Solium#usage).
 
+===============================================================================
+forge                                                      *ale-solidity-forge*
+
+  `forge fmt` is not a linter, only a formatter. It should be used only as a
+  fixer.
+
+  `forge fmt` should work out-of-the-box. You can further configure it using
+  `foundry.toml`. See the corresponding documentation for detailed
+  instructions (https://book.getfoundry.sh/reference/config/formatter).
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -586,7 +586,7 @@ Notes:
 * SML
   * `smlnj`
 * Solidity
-  * forge
+  * `forge`
   * `solc`
   * `solhint`
   * `solium`

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -586,6 +586,7 @@ Notes:
 * SML
   * `smlnj`
 * Solidity
+  * forge
   * `solc`
   * `solhint`
   * `solium`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3326,6 +3326,7 @@ documented in additional help files.
     solc..................................|ale-solidity-solc|
     solhint...............................|ale-solidity-solhint|
     solium................................|ale-solidity-solium|
+    forge.................................|ale-solidity-forge|
   spec....................................|ale-spec-options|
     rpmlint...............................|ale-spec-rpmlint|
   sql.....................................|ale-sql-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -598,6 +598,7 @@ formatting.
   * [solc](https://solidity.readthedocs.io/)
   * [solhint](https://github.com/protofire/solhint)
   * [solium](https://github.com/duaraghav8/Solium)
+  * [forge](https://github.com/foundry-rs/forge)
 * SQL
   * [dprint](https://dprint.dev)
   * [pgformatter](https://github.com/darold/pgFormatter)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -595,10 +595,10 @@ formatting.
 * SML
   * [smlnj](http://www.smlnj.org/)
 * Solidity
+  * [forge](https://github.com/foundry-rs/forge)
   * [solc](https://solidity.readthedocs.io/)
   * [solhint](https://github.com/protofire/solhint)
   * [solium](https://github.com/duaraghav8/Solium)
-  * [forge](https://github.com/foundry-rs/forge)
 * SQL
   * [dprint](https://dprint.dev)
   * [pgformatter](https://github.com/darold/pgFormatter)

--- a/test/fixers/test_forge_fixer_callback.vader
+++ b/test/fixers/test_forge_fixer_callback.vader
@@ -1,0 +1,15 @@
+Before:
+  Save g:ale_solidity_forge_executable
+
+After:
+  Restore
+
+Execute(The forge fmt callback should return the correct default values):
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('forge')
+  \     . ' fmt %t',
+  \   'read_temporary_file': 1,
+  \ },
+  \ ale#fixers#forge#Fix(bufnr(''))
+


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Homework:
- [x] Created new fixer
- [x] Added tests
- [x] Updated docs

`forge fmt` is a little bit different than most linters/fixers out there. It does not take any CLI options other than a positional arg with the file name. Configs are set through env vars or the `foundry.toml` file.

`forge` will look for `foundry.toml` files in the root of the project it is running from, but also allows you to set a default one at `${HOME}/foundry.toml`.

There are some outstanding issues that might change this behavior, however I don't believe it will affect the integration with ALE.
