### PR TITLE
go/golangci_lint.vim: set package linting to 1

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -3,7 +3,7 @@
 
 call ale#Set('go_golangci_lint_options', '')
 call ale#Set('go_golangci_lint_executable', 'golangci-lint')
-call ale#Set('go_golangci_lint_package', 0)
+call ale#Set('go_golangci_lint_package', 1)
 
 function! ale_linters#go#golangci_lint#GetCommand(buffer) abort
     let l:filename = expand('#' . a:buffer . ':t')


### PR DESCRIPTION
The present default of 0 causes excessive and unnecessary typecheck errors in all but the most trivial (single-file) packages. The standard Go unit of code is a directory, not a file, and optimizing for processing a single file provides negligible savings in processing time for a typical project, yet creates a lot of noise for the user.

Since those users that will specifically want single-file processing are less common, it's arguably reasonable for them to configure this back to zero in their vimrc.