### PR TITLE
fix tempfile for phpmd, to be able to use phpmd 2.14.0

### DIFF
--- a/ale_linters/php/phpmd.vim
+++ b/ale_linters/php/phpmd.vim
@@ -7,9 +7,9 @@ let g:ale_php_phpmd_executable = get(g:, 'ale_php_phpmd_executable', 'phpmd')
 let g:ale_php_phpmd_ruleset = get(g:, 'ale_php_phpmd_ruleset', 'cleancode,codesize,controversial,design,naming,unusedcode')
 
 function! ale_linters#php#phpmd#GetCommand(buffer) abort
-    return '%e %s text'
+    return '%e %t text'
     \   . ale#Pad(ale#Var(a:buffer, 'php_phpmd_ruleset'))
-    \   . ' --ignore-violations-on-exit %t'
+    \   . ' --ignore-violations-on-exit'
 endfunction
 
 function! ale_linters#php#phpmd#Handle(buffer, lines) abort

--- a/test/linter/test_phpmd.vader
+++ b/test/linter/test_phpmd.vader
@@ -9,4 +9,4 @@ Execute(Custom executables should be used for the executable and command):
 
   AssertLinter 'phpmd_test',
   \ ale#Escape('phpmd_test')
-  \ . ' %s text cleancode,codesize,controversial,design,naming,unusedcode --ignore-violations-on-exit %t'
+  \ . ' %t text cleancode,codesize,controversial,design,naming,unusedcode --ignore-violations-on-exit'


### PR DESCRIPTION
phpmd, until version 2.13.0 was taking the file to test as first argument (%s) and ignored the last argument (%t)
since version 2.14.0 if a last argument is given, phpmd exits with this message:
```
Can't find the custom report class: cleancode,codesize,controversial,design,naming,unusedcode
```
Moreover, phpmd is checking the filename hence show diagnostic for saved buffer only.

With this modification, phpmd 2.14.0 is able to run correctly and the diagnostic is done on the temp file provided by Ale and is refreshed even if the buffer is not yet saved.