### PR TITLE
Fix: Ruff output option

### DIFF
--- a/ale_linters/python/ruff.vim
+++ b/ale_linters/python/ruff.vim
@@ -46,7 +46,7 @@ function! ale_linters#python#ruff#GetCommand(buffer, version) abort
     \   : ''
 
     " NOTE: ruff version `0.0.69` supports liniting input from stdin
-    " NOTE: ruff version `0.1.0` deprecates `--format text` 
+    " NOTE: ruff version `0.1.0` deprecates `--format text`
     return ale#Escape(l:executable) . l:exec_args
     \   . ale#Pad(ale#Var(a:buffer, 'python_ruff_options'))
     \   . (ale#semver#GTE(a:version, [0, 1, 0]) ? ' --output-format text' : ' --format text')

--- a/ale_linters/python/ruff.vim
+++ b/ale_linters/python/ruff.vim
@@ -46,10 +46,11 @@ function! ale_linters#python#ruff#GetCommand(buffer, version) abort
     \   : ''
 
     " NOTE: ruff version `0.0.69` supports liniting input from stdin
+    " NOTE: ruff version `0.1.0` deprecates `--format text` 
     return ale#Escape(l:executable) . l:exec_args
     \   . ale#Pad(ale#Var(a:buffer, 'python_ruff_options'))
-    \   . ' --output-format text'
-    \   .  (ale#semver#GTE(a:version, [0, 0, 69]) ? ' --stdin-filename %s -' : ' %s')
+    \   . (ale#semver#GTE(a:version, [0, 1, 0]) ? ' --output-format text' : ' --format text')
+    \   . (ale#semver#GTE(a:version, [0, 0, 69]) ? ' --stdin-filename %s -' : ' %s')
 endfunction
 
 function! ale_linters#python#ruff#Handle(buffer, lines) abort

--- a/ale_linters/python/ruff.vim
+++ b/ale_linters/python/ruff.vim
@@ -48,7 +48,7 @@ function! ale_linters#python#ruff#GetCommand(buffer, version) abort
     " NOTE: ruff version `0.0.69` supports liniting input from stdin
     return ale#Escape(l:executable) . l:exec_args
     \   . ale#Pad(ale#Var(a:buffer, 'python_ruff_options'))
-    \   . ' --format text'
+    \   . ' --output-format text'
     \   .  (ale#semver#GTE(a:version, [0, 0, 69]) ? ' --stdin-filename %s -' : ' %s')
 endfunction
 

--- a/test/linter/test_ruff.vader
+++ b/test/linter/test_ruff.vader
@@ -6,7 +6,7 @@ Before:
   call ale#assert#SetUpLinterTest('python', 'ruff')
 
   let b:bin_dir = has('win32') ? 'Scripts' : 'bin'
-  let b:command_tail = ' --output-format text --stdin-filename %s -'
+  let b:command_tail = ' --format text --stdin-filename %s -'
 
   GivenCommandOutput ['ruff 0.0.83']
 
@@ -28,12 +28,18 @@ Execute(ruff should run with the file path of buffer in old versions):
   AssertLinterCwd expand('%:p:h')
   AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-23] . ' %s'
 
+Execute(ruff should run with the --output-format flag in new versions):
+  GivenCommandOutput ['ruff 0.1.0']
+
+  AssertLinterCwd expand('%:p:h')
+  AssertLinter 'ruff', ale#Escape('ruff') . ' --output-format text --stdin-filename %s -'
+
 Execute(ruff should run with the stdin in new enough versions):
   GivenCommandOutput ['ruff 0.0.83']
 
   AssertLinterCwd expand('%:p:h')
   AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-3] . ' -'
-  " AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-3] . '--output-format text -'
+  " AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-3] . '--format text -'
 
 Execute(The option for disabling changing directories should work):
   let g:ale_python_ruff_change_directory = 0

--- a/test/linter/test_ruff.vader
+++ b/test/linter/test_ruff.vader
@@ -6,7 +6,7 @@ Before:
   call ale#assert#SetUpLinterTest('python', 'ruff')
 
   let b:bin_dir = has('win32') ? 'Scripts' : 'bin'
-  let b:command_tail = ' --format text --stdin-filename %s -'
+  let b:command_tail = ' --output-format text --stdin-filename %s -'
 
   GivenCommandOutput ['ruff 0.0.83']
 
@@ -33,7 +33,7 @@ Execute(ruff should run with the stdin in new enough versions):
 
   AssertLinterCwd expand('%:p:h')
   AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-3] . ' -'
-  " AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-3] . '--format text -'
+  " AssertLinter 'ruff', ale#Escape('ruff') . b:command_tail[:-3] . '--output-format text -'
 
 Execute(The option for disabling changing directories should work):
   let g:ale_python_ruff_change_directory = 0


### PR DESCRIPTION
Hi. I noticed that one of the hardcoded options for the python linter Ruff is out of date and was causing an "unexpected argument" error in the output when the linter first starts.

I have updated the argument so that it matches the newest documentation. Instead of `--format text` the option is now `--output-format text`. 
 - https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#changelog (see the "Breaking Changes" section)
 - https://docs.astral.sh/ruff/settings/#output-format

Output before fix is shown below:

```
(finished - exit code 2) ['/usr/bin/zsh', '-c', 'cd ''/home/adam'' && ''ruff'' --format text --stdin-filename ''/home/adam/test.py'' - < ''/tmp/vlnWVAc/1/test.py'''] 

<<<OUTPUT STARTS>>>
error: unexpected argument '--format' found

  tip: to pass '--format' as a value, use '-- --format'

Usage: ruff check <FILES|--fix|--no-fix|--unsafe-fixes|--no-unsafe-fixes|--show-source|--no-show-source|--show-fixes|--no-show-fixes|--diff|--watch|--fix-only|--no-fix-only|--ignore-noqa|--output-format <OUTPUT_FORMAT>|--output-file <OUTPUT_FILE>|--target-version <TARGET_VERSION>|--preview|--no-preview|--config <CONFIG>|--select <RULE_CODE>|--ignore <RULE_CODE>|--extend-select <RULE_CODE>|--extend-ignore <RULE_CODE>|--per-file-ignores <PER_FILE_IGNORES>|--extend-per-file-ignores <EXTEND_PER_FILE_IGNORES>|--exclude <FILE_PATTERN>|--extend-exclude <FILE_PATTERN>|--fixable <RULE_CODE>|--unfixable <RULE_CODE>|--extend-fixable <RULE_CODE>|--extend-unfixable <RULE_CODE>|--respect-gitignore|--no-respect-gitignore|--force-exclude|--no-force-exclude|--line-length <LINE_LENGTH>|--dummy-variable-rgx <DUMMY_VARIABLE_RGX>|--no-cache|--isolated|--cache-dir <CACHE_DIR>|--stdin-filename <STDIN_FILENAME>|--exit-zero|--exit-non-zero-on-fix|--statistics|--add-noqa|--show-files|--show-settings|--ecosystem-ci>

For more information, try '--help'.
<<<OUTPUT ENDS>>>
```
Output after fix is shown below:

```
(finished - exit code 0) ['/usr/bin/zsh', '-c', 'cd ''/home/adam'' && ''ruff'' --output-format text --stdin-filename ''/home/adam/test.py'' - < ''/tmp/vHGHOMk/1/test.py''']

<<<NO OUTPUT RETURNED>>>
```

I hope this helps :)
