### PR TITLE
Fix #4251 --file-filter option removed for cppcheck handler

### DIFF
--- a/autoload/ale/handlers/cppcheck.vim
+++ b/autoload/ale/handlers/cppcheck.vim
@@ -48,9 +48,8 @@ function! ale#handlers#cppcheck#GetCompileCommandsOptions(buffer) abort
     let [l:dir, l:json_path] = ale#c#FindCompileCommands(a:buffer)
 
     " By default, cppcheck processes every config in compile_commands.json.
-    " Use --file-filter to limit to just the buffer file.
     return !empty(l:json_path)
-    \   ? '--project=' . ale#Escape(l:json_path[len(l:dir) + 1: ]) . ' --file-filter=' . ale#Escape(bufname(a:buffer))
+    \   ? '--project=' . ale#Escape(l:json_path[len(l:dir) + 1: ])
     \   : ''
 endfunction
 

--- a/test/linter/test_c_cppcheck.vader
+++ b/test/linter/test_c_cppcheck.vader
@@ -24,7 +24,6 @@ Execute(cppcheck for C should detect compile_commands.json files):
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
-  \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should detect compile_commands.json files in build directories):
@@ -36,7 +35,6 @@ Execute(cppcheck for C should detect compile_commands.json files in build direct
   \   . ' -q --language=c'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
-  \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C should include file dir if compile_commands.json file is not found):

--- a/test/linter/test_cpp_cppcheck.vader
+++ b/test/linter/test_cpp_cppcheck.vader
@@ -30,7 +30,6 @@ Execute(cppcheck for C++ should detect compile_commands.json files):
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape('compile_commands.json')
-  \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should detect compile_commands.json files in build directories):
@@ -42,7 +41,6 @@ Execute(cppcheck for C++ should detect compile_commands.json files in build dire
   \   . ' -q --language=c++'
   \   . ' --template=' . ale#Escape('{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}')
   \   . ' --project=' . ale#Escape(ale#path#Simplify('build/compile_commands.json'))
-  \   . ' --file-filter=' . ale#Escape(ale#test#GetFilename(b:rel_file_path))
   \   . ' --enable=style %t'
 
 Execute(cppcheck for C++ should include file dir if compile_commands.json file is not found):


### PR DESCRIPTION
--file-filter option has been removed because using it prevents cppcheck from processing the file if it is in a different path