### PR TITLE
Fix Haskell `ormolu` fixer

### DIFF
--- a/autoload/ale/fixers/ormolu.vim
+++ b/autoload/ale/fixers/ormolu.vim
@@ -11,7 +11,7 @@ function! ale#fixers#ormolu#ApplyFixForVersion(buffer, version) abort
     let l:executable = ale#fixers#ormolu#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'haskell_ormolu_options')
 
-    if ale#semver#GTE(a:version, [0, 3, 0])
+    if ale#semver#GTE(a:version, [0, 8, 0])
         let l:args = ' --stdin-input-file %s'
     else
         let l:args = ' %s'

--- a/autoload/ale/fixers/ormolu.vim
+++ b/autoload/ale/fixers/ormolu.vim
@@ -1,12 +1,20 @@
 call ale#Set('haskell_ormolu_executable', 'ormolu')
 call ale#Set('haskell_ormolu_options', '')
 
-function! ale#fixers#ormolu#Fix(buffer) abort
+function! ale#fixers#ormolu#GetExecutable(buffer) abort
     let l:executable = ale#Var(a:buffer, 'haskell_ormolu_executable')
+
+    return ale#handlers#haskell_stack#EscapeExecutable(l:executable, 'ormolu')
+endfunction
+
+function! ale#fixers#ormolu#Fix(buffer) abort
+    let l:executable = ale#fixers#ormolu#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'haskell_ormolu_options')
 
     return {
-    \   'command': ale#Escape(l:executable)
-    \       . (empty(l:options) ? '' : ' ' . l:options),
+    \   'command': l:executable
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \       . ' --stdin-input-file '
+    \       . ale#Escape(@%),
     \}
 endfunction

--- a/autoload/ale/fixers/ormolu.vim
+++ b/autoload/ale/fixers/ormolu.vim
@@ -11,10 +11,15 @@ function! ale#fixers#ormolu#Fix(buffer) abort
     let l:executable = ale#fixers#ormolu#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'haskell_ormolu_options')
 
+    if ale#semver#GTE(a:version, [0, 3, 0])
+        let l:args = ' --stdin-input-file %s'
+    else
+        let l:args = ' %s'
+    endif
+
     return {
     \   'command': l:executable
     \       . (empty(l:options) ? '' : ' ' . l:options)
-    \       . ' --stdin-input-file '
-    \       . ale#Escape(@%),
+    \       . l:args
     \}
 endfunction

--- a/autoload/ale/fixers/ormolu.vim
+++ b/autoload/ale/fixers/ormolu.vim
@@ -7,7 +7,7 @@ function! ale#fixers#ormolu#GetExecutable(buffer) abort
     return ale#handlers#haskell_stack#EscapeExecutable(l:executable, 'ormolu')
 endfunction
 
-function! ale#fixers#ormolu#Fix(buffer) abort
+function! ale#fixers#ormolu#ApplyFixForVersion(buffer, version) abort
     let l:executable = ale#fixers#ormolu#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'haskell_ormolu_options')
 
@@ -22,4 +22,13 @@ function! ale#fixers#ormolu#Fix(buffer) abort
     \       . (empty(l:options) ? '' : ' ' . l:options)
     \       . l:args
     \}
+endfunction
+
+function! ale#fixers#ormolu#Fix(buffer) abort
+    return ale#semver#RunWithVersionCheck(
+    \   a:buffer,
+    \   ale#fixers#ormolu#GetExecutable(a:buffer),
+    \   '%e --version',
+    \   function('ale#fixers#ormolu#ApplyFixForVersion'),
+    \)
 endfunction

--- a/test/fixers/test_ormolu_fixer_callback.vader
+++ b/test/fixers/test_ormolu_fixer_callback.vader
@@ -13,12 +13,12 @@ Execute(The ormolu callback should return the correct default values):
   \ ale#fixers#ormolu#Fix(bufnr(''))
 
 Execute(The ormolu executable and options should be configurable):
-  let g:ale_nix_nixpkgsfmt_executable = '/path/to/ormolu'
-  let g:ale_nix_nixpkgsfmt_options = '-h'
+  let g:ale_haskell_ormolu_executable = '/path/to/ormolu'
+  let g:ale_haskell_ormolu_options = '-h'
 
   AssertEqual
   \ {
   \   'command': ale#Escape('/path/to/ormolu')
   \     . ' -h',
   \ },
-  \ ale#fixers#nixpkgsfmt#Fix(bufnr(''))
+  \ ale#fixers#ormolu#Fix(bufnr(''))

--- a/test/fixers/test_ormolu_fixer_callback.vader
+++ b/test/fixers/test_ormolu_fixer_callback.vader
@@ -9,6 +9,8 @@ Execute(The ormolu callback should return the correct default values):
   AssertEqual
   \ {
   \   'command': ale#Escape('ormolu')
+  \     . ' --stdin-input-file '
+  \     . ale#Escape(@%)
   \ },
   \ ale#fixers#ormolu#Fix(bufnr(''))
 
@@ -19,6 +21,8 @@ Execute(The ormolu executable and options should be configurable):
   AssertEqual
   \ {
   \   'command': ale#Escape('/path/to/ormolu')
-  \     . ' -h',
+  \     . ' -h'
+  \     . ' --stdin-input-file '
+  \     . ale#Escape(@%)
   \ },
   \ ale#fixers#ormolu#Fix(bufnr(''))


### PR DESCRIPTION
1. Fix https://github.com/dense-analysis/ale/issues/4593 by enabling `ormolu`'s `--stdin-input-file` option by default.
2. Switch to the same design as other Haskell fixers (see https://github.com/dense-analysis/ale/pull/1851), which AFAIU is to improve support for `stack`. Note: I haven't been able to test this since I haven't found a way to make `stack` work on my setup (`NixOS` and `cabal`).