### PR TITLE
Fix chktex highlighting wrong column when using tabs instead of spaces

### DIFF
--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -16,6 +16,8 @@ function! ale_linters#tex#chktex#GetCommand(buffer) abort
     let l:command = ale#Var(a:buffer, 'tex_chktex_executable')
     " Avoid bug when used without -p (last warning has gibberish for a filename)
     let l:command .= ' -v0 -p stdin -q'
+    " Avoid bug of reporting wrong column when using tabs (issue #723)
+    let l:command .= ' -s TabSize=1'
 
     if !empty(l:chktex_config)
         let l:command .= ' -l ' . ale#Escape(l:chktex_config)

--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -1,11 +1,8 @@
 " Author: Andrew Balmos - <andrew@balmos.org>
 " Description: chktex for LaTeX files
 
-let g:ale_tex_chktex_executable =
-\   get(g:, 'ale_tex_chktex_executable', 'chktex')
-
-let g:ale_tex_chktex_options =
-\   get(g:, 'ale_tex_chktex_options', '-I')
+call ale#Set('tex_chktex_executable', 'chktex')
+call ale#Set('tex_chktex_options', '-I')
 
 function! ale_linters#tex#chktex#GetCommand(buffer) abort
     " Check for optional .chktexrc
@@ -50,7 +47,7 @@ endfunction
 
 call ale#linter#Define('tex', {
 \   'name': 'chktex',
-\   'executable': 'chktex',
+\   'executable': {b -> ale#Var(b, 'tex_chktex_executable')},
 \   'command': function('ale_linters#tex#chktex#GetCommand'),
 \   'callback': 'ale_linters#tex#chktex#Handle'
 \})

--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -5,24 +5,23 @@ call ale#Set('tex_chktex_executable', 'chktex')
 call ale#Set('tex_chktex_options', '-I')
 
 function! ale_linters#tex#chktex#GetCommand(buffer) abort
-    " Check for optional .chktexrc
-    let l:chktex_config = ale#path#FindNearestFile(
-    \   a:buffer,
-    \   '.chktexrc')
+    let l:options = ''
 
-    let l:command = ale#Var(a:buffer, 'tex_chktex_executable')
     " Avoid bug when used without -p (last warning has gibberish for a filename)
-    let l:command .= ' -v0 -p stdin -q'
+    let l:options .= ' -v0 -p stdin -q'
     " Avoid bug of reporting wrong column when using tabs (issue #723)
-    let l:command .= ' -s TabSize=1'
+    let l:options .= ' -s TabSize=1'
+
+    " Check for optional .chktexrc
+    let l:chktex_config = ale#path#FindNearestFile(a:buffer, '.chktexrc')
 
     if !empty(l:chktex_config)
-        let l:command .= ' -l ' . ale#Escape(l:chktex_config)
+        let l:options .= ' -l ' . ale#Escape(l:chktex_config)
     endif
 
-    let l:command .= ' ' . ale#Var(a:buffer, 'tex_chktex_options')
+    let l:options .= ' ' . ale#Var(a:buffer, 'tex_chktex_options')
 
-    return l:command
+    return '%e' . l:options
 endfunction
 
 function! ale_linters#tex#chktex#Handle(buffer, lines) abort

--- a/test/linter/test_tex_chktex.vader
+++ b/test/linter/test_tex_chktex.vader
@@ -1,0 +1,25 @@
+Before:
+  call ale#assert#SetUpLinterTest('tex', 'chktex')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(Executable should default to chktex):
+  AssertLinter 'chktex',
+  \ ale#Escape('chktex')
+  \   . ' -v0 -p stdin -q -s TabSize=1 -I'
+
+Execute(The executable should be configurable):
+  let g:ale_tex_chktex_executable = 'bin/foo'
+
+  AssertLinter 'bin/foo',
+  \ ale#Escape('bin/foo')
+  \   . ' -v0 -p stdin -q -s TabSize=1 -I'
+
+Execute(The options should be configurable):
+  let b:ale_tex_chktex_options = '--something'
+
+  AssertLinter 'chktex',
+  \ ale#Escape('chktex')
+  \   . ' -v0 -p stdin -q -s TabSize=1'
+  \   . ' --something'

--- a/test/linter/test_tex_chktex.vader
+++ b/test/linter/test_tex_chktex.vader
@@ -4,17 +4,19 @@ Before:
 After:
   call ale#assert#TearDownLinterTest()
 
-Execute(Executable should default to chktex):
+Execute(The default command should be correct):
   AssertLinter 'chktex',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q -s TabSize=1 -I'
+  \   . ' -v0 -p stdin -q -s TabSize=1'
+  \   . ' -I'
 
 Execute(The executable should be configurable):
   let g:ale_tex_chktex_executable = 'bin/foo'
 
   AssertLinter 'bin/foo',
   \ ale#Escape('bin/foo')
-  \   . ' -v0 -p stdin -q -s TabSize=1 -I'
+  \   . ' -v0 -p stdin -q -s TabSize=1'
+  \   . ' -I'
 
 Execute(The options should be configurable):
   let b:ale_tex_chktex_options = '--something'


### PR DESCRIPTION
Fixes #723

chktex implemented [bug #56486: Allow setting options on the command line][1]
Thanks to that we can tell it to treat tab character as of one space width, i.e. one char.
That means, after we translate the output back to Vim columns, we get correct numbers.

[1]: https://savannah.nongnu.org/bugs/?56486
