### PR TITLE
add: support for `nickel format` as `Nickel` fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -635,7 +635,12 @@ let s:default_registry = {
 \       'function': 'ale#fixers#erbformatter#Fix',
 \       'suggested_filetypes': ['eruby'],
 \       'description': 'Apply erb-formatter -w to eruby/erb files.',
-\   }
+\   },
+\   'nickel_format': {
+\       'function': 'ale#fixers#nickel_format#Fix',
+\       'suggested_filetypes': ['nickel'],
+\       'description': 'Fix nickel files with nickel format',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/nickel_format.vim
+++ b/autoload/ale/fixers/nickel_format.vim
@@ -1,0 +1,16 @@
+" Author: Yining <zhang.yining@gmail.com>
+" Description: nickel format as ALE fixer for Nickel files
+
+call ale#Set('nickel_nickel_format_executable', 'nickel')
+call ale#Set('nickel_nickel_format_options', '')
+
+function! ale#fixers#nickel_format#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'nickel_nickel_format_executable')
+    let l:options = ale#Var(a:buffer, 'nickel_nickel_format_options')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' format'
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \}
+endfunction
+

--- a/doc/ale-nickel.txt
+++ b/doc/ale-nickel.txt
@@ -1,0 +1,25 @@
+===============================================================================
+ALE Nickel Integration                                      *ale-nickel-options*
+
+
+===============================================================================
+nickel_format                                         *ale-nickel-nickel-format*
+
+g:ale_nickel_nickel_format_executable    *g:ale_nickel_nickel_format_executable*
+                                         *b:ale_nickel_nickel_format_executable*
+  Type: |String|
+  Default: `'nickel'`
+
+  This option can be changed to change the path for `nickel`.
+
+
+g:ale_nickel_nickel_format_options          *g:ale_nickel_nickel_format_options*
+                                            *b:ale_nickel_nickel_format_options*
+  Type: |String|
+  Default: `''`
+
+  This option can be changed to pass extra options to `'nickel format'`
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -381,6 +381,8 @@ Notes:
   * `mmc`!!
 * NASM
   * `nasm`!!
+* Nickel
+  * `nickel_format`
 * Nim
   * `nim check`!!
   * `nimlsp`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3187,6 +3187,8 @@ documented in additional help files.
     mmc...................................|ale-mercury-mmc|
   nasm....................................|ale-nasm-options|
     nasm..................................|ale-nasm-nasm|
+  nickel..................................|ale-nickel-options|
+    nickel_format.........................|ale-nickel-nickel-format|
   nim.....................................|ale-nim-options|
     nimcheck..............................|ale-nim-nimcheck|
     nimlsp................................|ale-nim-nimlsp|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -390,6 +390,8 @@ formatting.
   * [mmc](http://mercurylang.org) :floppy_disk:
 * NASM
   * [nasm](https://www.nasm.us/) :floppy_disk:
+* Nickel
+  * [nickel_format](https://github.com/tweag/nickel#formatting)
 * Nim
   * [nim check](https://nim-lang.org/docs/nimc.html) :floppy_disk:
   * [nimlsp](https://github.com/PMunch/nimlsp)

--- a/test/fixers/test_nickel_format_fixer_callback.vader
+++ b/test/fixers/test_nickel_format_fixer_callback.vader
@@ -1,0 +1,27 @@
+Before:
+  Save g:ale_nickel_nickel_format_executable
+  Save g:ale_nickel_nickel_format_options
+  Save &l:expandtab
+  Save &l:shiftwidth
+  Save &l:tabstop
+
+After:
+  Restore
+
+Execute(The nickel_format callback should return 'nickel format' as default command):
+  setlocal noexpandtab
+  Assert
+  \ ale#fixers#nickel_format#Fix(bufnr('')).command =~# '^' . ale#Escape('nickel') . ' format',
+  \ "Default command name is expected to be 'nickel format'"
+
+Execute(The nickel executable and options should be configurable):
+  let g:ale_nickel_nickel_format_executable = 'foobar'
+  let g:ale_nickel_nickel_format_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('foobar')
+  \     . ' format'
+  \     . ' --some-option',
+  \ },
+  \ ale#fixers#nickel_format#Fix(bufnr(''))


### PR DESCRIPTION
Nickel(https://nickel-lang.org/) is a configuration language, like Jsonnet, Cue, Dhall.

`nickel`(https://github.com/tweag/nickel) is the main command to run, export and also format Nickel code.

this commit adds `nickel format` as a Nickel fixer, together with some tests and documentation.

