### PR TITLE
add: support for `rubyfmt` as `ruby` fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -641,6 +641,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['nickel'],
 \       'description': 'Fix nickel files with nickel format',
 \   },
+\   'rubyfmt': {
+\       'function': 'ale#fixers#rubyfmt#Fix',
+\       'suggested_filetypes': ['ruby'],
+\       'description': 'A formatter for Ruby source code',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/rubyfmt.vim
+++ b/autoload/ale/fixers/rubyfmt.vim
@@ -1,0 +1,16 @@
+" Author: Yining <zhang.yining@gmail.com>
+" Description: support rubyfmt as ALE fixer for Ruby files
+
+call ale#Set('ruby_rubyfmt_executable', 'rubyfmt')
+call ale#Set('ruby_rubyfmt_options', '')
+
+function! ale#fixers#rubyfmt#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'ruby_rubyfmt_executable')
+    let l:options = ale#Var(a:buffer, 'ruby_rubyfmt_options')
+
+    return {
+    \   'command': ale#Escape(l:executable)
+    \       . (empty(l:options) ? '' : ' ' . l:options)
+    \}
+endfunction
+

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -258,6 +258,24 @@ g:ale_ruby_syntax_tree_options                 *g:ale_ruby_syntax_tree_options*
 
   This variable can be changed to modify flags given to SyntaxTree.
 
+===============================================================================
+rubyfmt                                                       *ale-ruby-rubyfmt*
+
+g:ale_ruby_rubyfmt_executable                    *g:ale_ruby_rubyfmt_executable*
+                                                 *b:ale_ruby_rubyfmt_executable*
+  Type: |String|
+  Default: `'rubyfmt'`
+
+  This option can be changed to change the path for `rubyfmt`.
+
+
+g:ale_ruby_rubyfmt_options                          *g:ale_ruby_rubyfmt_options*
+                                                    *b:ale_ruby_rubyfmt_options*
+  Type: |String|
+  Default: `''`
+
+  This option can be changed to pass extra options to `'rubyfmt'`.
+
 
 ===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -558,6 +558,7 @@ Notes:
   * `reek`
   * `rubocop`
   * `ruby`
+  * `rubyfmt`
   * `rufo`
   * `solargraph`
   * `sorbet`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3350,6 +3350,7 @@ documented in additional help files.
     sorbet................................|ale-ruby-sorbet|
     standardrb............................|ale-ruby-standardrb|
     syntax_tree...........................|ale-ruby-syntax_tree|
+    rubyfmt...............................|ale-ruby-rubyfmt|
   rust....................................|ale-rust-options|
     analyzer..............................|ale-rust-analyzer|
     cargo.................................|ale-rust-cargo|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -567,6 +567,7 @@ formatting.
   * [reek](https://github.com/troessner/reek)
   * [rubocop](https://github.com/bbatsov/rubocop)
   * [ruby](https://www.ruby-lang.org)
+  * [rubyfmt](https://github.com/fables-tales/rubyfmt)
   * [rufo](https://github.com/ruby-formatter/rufo)
   * [solargraph](https://solargraph.org)
   * [sorbet](https://github.com/sorbet/sorbet)

--- a/test/fixers/test_rubyfmt_fixer_callback.vader
+++ b/test/fixers/test_rubyfmt_fixer_callback.vader
@@ -1,0 +1,26 @@
+Before:
+  Save g:ale_ruby_rubyfmt_executable
+  Save g:ale_ruby_rubyfmt_options
+  Save &l:expandtab
+  Save &l:shiftwidth
+  Save &l:tabstop
+
+After:
+  Restore
+
+Execute(The rubyfmt callback should return 'rubyfmt' as default command):
+  setlocal noexpandtab
+  Assert
+  \ ale#fixers#rubyfmt#Fix(bufnr('')).command =~# '^' . ale#Escape('rubyfmt'),
+  \ "Default command name is expected to be 'rubyfmt'"
+
+Execute(The ruby executable and options should be configurable):
+  let g:ale_ruby_rubyfmt_executable = 'foobar'
+  let g:ale_ruby_rubyfmt_options = '--some-option'
+
+  AssertEqual
+  \ {
+  \   'command': ale#Escape('foobar')
+  \     . ' --some-option',
+  \ },
+  \ ale#fixers#rubyfmt#Fix(bufnr(''))


### PR DESCRIPTION
[rubyfmt](https://github.com/fables-tales/rubyfmt) is a formatter for
 `ruby` code.

This commit adds support for `rubyfmt` as a `ruby` fixer (#2991), together with some tests and documentation.

