### PR TITLE
Adding support for Odin language server -- `ols`

### DIFF
--- a/ale_linters/odin/ols.vim
+++ b/ale_linters/odin/ols.vim
@@ -1,0 +1,19 @@
+" Author: Benjamin Block <https://github.com/benjamindblock>
+" Description: A language server for Odin.
+
+function! ale_linters#odin#ols#GetProjectRoot(buffer) abort
+    return fnamemodify('', ':h')
+endfunction
+
+call ale#Set('odin_ols_executable', 'ols')
+call ale#Set('odin_ols_config', {})
+
+call ale#linter#Define('odin', {
+\   'name': 'ols',
+\   'lsp': 'stdio',
+\   'language': 'odin',
+\   'lsp_config': {b -> ale#Var(b, 'odin_ols_config')},
+\   'executable': {b -> ale#Var(b, 'odin_ols_executable')},
+\   'command': '%e',
+\   'project_root': function('ale_linters#odin#ols#GetProjectRoot'),
+\})

--- a/doc/ale-odin.txt
+++ b/doc/ale-odin.txt
@@ -1,0 +1,29 @@
+===============================================================================
+ALE Odin Integration                                         *ale-odin-options*
+                                                         *ale-integration-odin*
+
+===============================================================================
+Integration Information
+
+  Currently, the only supported linter for Odin is ols.
+
+===============================================================================
+ols                                                              *ale-odin-ols*
+
+g:ale_odin_ols_executable                           *g:ale_odin_ols_executable*
+                                                    *b:ale_odin_ols_executable*
+  Type: |String|
+  Default: `'ols'`
+
+  This variable can be modified to change the executable path for `ols`.
+
+
+g:ale_odin_ols_config                                   *g:ale_odin_ols_config*
+                                                        *b:ale_odin_ols_config*
+  Type: |Dictionary|
+  Default: `{}`
+
+  Dictionary with configuration settings for ols.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -418,6 +418,8 @@ Notes:
   * `ocamllsp`
   * `ocp-indent`
   * `ols`
+* Odin
+  * `ols`
 * OpenApi
   * `ibm_validator`
   * `prettier`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3220,6 +3220,8 @@ documented in additional help files.
     ols...................................|ale-ocaml-ols|
     ocamlformat...........................|ale-ocaml-ocamlformat|
     ocp-indent............................|ale-ocaml-ocp-indent|
+  odin....................................|ale-odin-options|
+    ols...................................|ale-odin-ols|
   openapi.................................|ale-openapi-options|
     ibm_validator.........................|ale-openapi-ibm-validator|
     prettier..............................|ale-openapi-prettier|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -427,6 +427,8 @@ formatting.
   * [ocamllsp](https://github.com/ocaml/ocaml-lsp)
   * [ocp-indent](https://github.com/OCamlPro/ocp-indent)
   * [ols](https://github.com/freebroccolo/ocaml-language-server)
+* Odin
+  * [ols](https://github.com/DanielGavin/ols)
 * OpenApi
   * [ibm_validator](https://github.com/IBM/openapi-validator)
   * [prettier](https://github.com/prettier/prettier)

--- a/test/linter/test_odin_ols.vader
+++ b/test/linter/test_odin_ols.vader
@@ -1,0 +1,16 @@
+Before:
+  call ale#assert#SetUpLinterTest('odin', 'ols')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  AssertLinter 'ols', ale#Escape('ols')
+
+Execute(The LSP values should be set correctly):
+  call ale#test#SetFilename('../test-files/odin/main.odin')
+
+  AssertLSPLanguage 'odin'
+  AssertLSPOptions {}
+  AssertLSPConfig {}
+  AssertLSPProject '.'


### PR DESCRIPTION
Adding support for [ols](https://github.com/DanielGavin/ols), the language server for the [Odin programming language.](https://odin-lang.org)