### PR TITLE
Add wiki link to ShellCheck linting

### DIFF
--- a/autoload/ale/handlers/shellcheck.vim
+++ b/autoload/ale/handlers/shellcheck.vim
@@ -140,6 +140,7 @@ function! s:HandleShellcheckGCC(buffer, lines) abort
         \   'type': l:type,
         \   'text': l:match[5],
         \   'code': l:match[6],
+        \   'detail': l:match[5] . "\n\nFor more information:\n  https://www.shellcheck.net/wiki/" . l:match[6],
         \}
 
         if !empty(l:match[3])

--- a/test/handler/test_shellcheck_handler.vader
+++ b/test/handler/test_shellcheck_handler.vader
@@ -13,6 +13,7 @@ Execute(The shellcheck handler should handle basic errors or warnings <0.7.0):
   \     'type': 'W',
   \     'text': 'In POSIX sh, ''let'' is not supported.',
   \     'code': 'SC2039',
+  \     'detail': 'In POSIX sh, ''let'' is not supported.' . "\n\nFor more information:\n  https://www.shellcheck.net/wiki/" . 'SC2039',
   \   },
   \   {
   \     'lnum': 2,
@@ -20,6 +21,7 @@ Execute(The shellcheck handler should handle basic errors or warnings <0.7.0):
   \     'type': 'E',
   \     'text': 'Don''t put spaces around the = in assignments.',
   \     'code': 'SC1068',
+  \     'detail': 'Don''t put spaces around the = in assignments.' . "\n\nFor more information:\n  https://www.shellcheck.net/wiki/" . 'SC1068',
   \   },
   \ ],
   \ ale#handlers#shellcheck#Handle(bufnr(''), [0, 6, 0], [
@@ -36,6 +38,7 @@ Execute(The shellcheck handler should handle notes <0.7.0):
   \     'type': 'I',
   \     'text': 'Double quote to prevent globbing and word splitting.',
   \     'code': 'SC2086',
+  \     'detail': 'Double quote to prevent globbing and word splitting.' . "\n\nFor more information:\n  https://www.shellcheck.net/wiki/" . 'SC2086',
   \   },
   \ ],
   \ ale#handlers#shellcheck#Handle(bufnr(''), [0, 6, 0], [


### PR DESCRIPTION
The ShellCheck integrations wiki suggests providing users with more info by linking back to the ShellCheck wiki.

https://www.shellcheck.net/wiki/Integration#linking-to-the-wiki
