### PR TITLE
fix #4687 - only lint one file with actionlint instead of whole directory

### DIFF
--- a/ale_linters/yaml/actionlint.vim
+++ b/ale_linters/yaml/actionlint.vim
@@ -15,7 +15,7 @@ function! ale_linters#yaml#actionlint#GetCommand(buffer) abort
         let l:options .= ale#Pad('-oneline')
     endif
 
-    return '%e' . ale#Pad(l:options)
+    return '%e' . ale#Pad(l:options) . ' - '
 endfunction
 
 function! ale_linters#yaml#actionlint#Handle(buffer, lines) abort

--- a/test/linter/test_yaml_actionlint.vader
+++ b/test/linter/test_yaml_actionlint.vader
@@ -42,16 +42,16 @@ Execute(Shellcheck issues should be reported at the line they appear):
   \   'validate.yml:19:9: shellcheck reported issue in this script: SC2086:info:1:15: Double quote to prevent globbing and word splitting [shellcheck]'
   \ ])
 
-Execute(Command should always have -no-color and -oneline options):
+Execute(Command should always have -no-color, -oneline and - options):
   let g:ale_yaml_actionlint_options = ''
 
   AssertEqual
-  \   '%e  -no-color -oneline',
+  \   '%e  -no-color -oneline - ',
   \ ale_linters#yaml#actionlint#GetCommand(bufnr(''))
 
 Execute(Options should be added to command):
   let g:ale_yaml_actionlint_options = '-shellcheck= -pyflakes='
 
   AssertEqual
-  \   '%e -shellcheck= -pyflakes= -no-color -oneline',
+  \   '%e -shellcheck= -pyflakes= -no-color -oneline - ',
   \ ale_linters#yaml#actionlint#GetCommand(bufnr(''))


### PR DESCRIPTION
This solves #4687 by always prepending ` - ` to the `actionlint` command run, so it correctly reads the file passed as stdin, instead of linting all files in the current directory.