### PR TITLE
Actionlint: correctly parse error line when using shellcheck sublinter

### DIFF
--- a/ale_linters/yaml/actionlint.vim
+++ b/ale_linters/yaml/actionlint.vim
@@ -21,15 +21,27 @@ endfunction
 function! ale_linters#yaml#actionlint#Handle(buffer, lines) abort
     " Matches patterns line the following:
     ".github/workflows/main.yml:19:0: could not parse as YAML: yaml: line 19: mapping values are not allowed in this context [yaml-syntax]
-    let l:pattern = '\v^.*:(\d+):(\d+): (.+) \[(.+)\]$'
+    let l:pattern = '\v^.{-}:(\d+):(\d+): (.+) \[(.+)\]$'
     let l:output = []
 
+
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:code = l:match[4]
+        let l:text = l:match[3]
+
+        " Handle sub-linter errors like the following:
+        "validate.yml:19:9: shellcheck reported issue in this script: SC2086:info:1:15: Double quote to prevent globbing and word splitting [shellcheck]
+        if l:code is# 'shellcheck'
+            let l:shellcheck_match = matchlist(l:text, '\v^.+: (SC\d{4}):.+:\d+:\d+: (.+)$')
+            let l:text = l:shellcheck_match[2]
+            let l:code = 'shellcheck ' . l:shellcheck_match[1]
+        endif
+
         let l:item = {
         \   'lnum': l:match[1] + 0,
         \   'col': l:match[2] + 0,
-        \   'text': l:match[3],
-        \   'code': l:match[4],
+        \   'text': l:text,
+        \   'code': l:code,
         \   'type': 'E',
         \}
 

--- a/test/linter/test_yaml_actionlint.vader
+++ b/test/linter/test_yaml_actionlint.vader
@@ -1,9 +1,8 @@
 Before:
-  runtime! ale/handlers/actionlint.vim
+  call ale#assert#SetUpLinterTest('yaml', 'actionlint')
 
 After:
-  unlet! g:ale_yaml_actionlint_options
-  call ale#linter#Reset()
+  call ale#assert#TearDownLinterTest()
 
 Execute(Problems should be parsed correctly for actionlint):
   AssertEqual
@@ -26,6 +25,21 @@ Execute(Problems should be parsed correctly for actionlint):
   \ ale_linters#yaml#actionlint#Handle(bufnr(''), [
   \   '.codecov.yaml:2:1: "jobs" section is missing in workflow [syntax-check]',
   \   'workflow_call_event.yaml:56:23: property "unknown_input" is not defined in object type {input7: bool; input0: any; input1: any; input2: string; input3: any; input4: any; input5: number; input6: number} [expression]',
+  \ ])
+
+Execute(Shellcheck issues should be reported at the line they appear):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 19,
+  \     'col': 9,
+  \     'type': 'E',
+  \     'text': 'Double quote to prevent globbing and word splitting',
+  \     'code': 'shellcheck SC2086',
+  \   },
+  \ ],
+  \ ale_linters#yaml#actionlint#Handle(bufnr(''), [
+  \   'validate.yml:19:9: shellcheck reported issue in this script: SC2086:info:1:15: Double quote to prevent globbing and word splitting [shellcheck]'
   \ ])
 
 Execute(Command should always have -no-color and -oneline options):


### PR DESCRIPTION
`actionlint` is a linter for GitHub Actions workflows. It includes the `shellcheck` linter, for linting `run:` commands inside of GA workflows.

The current Ale implementation was getting confused when parsing the line such an error occurred; it used the line returned by `shellcheck` (most commonly line 1 as `run:` entries are usually one-liners), instead of the line of the parent `.yml` file.

This PR addresses that, by adding a branching path when parsing the linting results. If it is identified as a `shellcheck` linting issue, it will further parse the output to extract the correct `shellcheck` error message and error code, but keep the parent `.yml` line.

This now correctly attributes the error to the line it appears. It sets the column to the beginning of the `run:` key, not to the exact column where the error appears in the value. This could probably be added with a bit of math, but I wanted to keep the PR simple for now.