### PR TITLE
Gleam: Support for gleam language server

### DIFF
--- a/ale_linters/gleam/gleamlsp.vim
+++ b/ale_linters/gleam/gleamlsp.vim
@@ -1,0 +1,18 @@
+" Author: Jonathan Palardt https://github.com/jpalardy
+" Description: Support for Gleam Language Server
+
+call ale#Set('gleam_gleamlsp_executable', 'gleam')
+
+function! ale_linters#gleam#gleamlsp#GetProjectRoot(buffer) abort
+    let l:gleam_toml = ale#path#FindNearestFile(a:buffer, 'gleam.toml')
+
+    return !empty(l:gleam_toml) ? fnamemodify(l:gleam_toml, ':p:h') : ''
+endfunction
+
+call ale#linter#Define('gleam', {
+\   'name': 'gleamlsp',
+\   'lsp': 'stdio',
+\   'executable': {buffer -> ale#Var(buffer, 'gleam_gleamlsp_executable')},
+\   'command': '%e lsp',
+\   'project_root': function('ale_linters#gleam#gleamlsp#GetProjectRoot'),
+\})

--- a/doc/ale-gleam.txt
+++ b/doc/ale-gleam.txt
@@ -1,0 +1,23 @@
+===============================================================================
+ALE Gleam Integration                                       *ale-gleam-options*
+                                                        *ale-integration-gleam*
+
+===============================================================================
+Integration Information
+
+  Currently, the only supported linter for gleam is gleamlsp.
+
+
+===============================================================================
+gleamlsp                                                   *ale-gleam-gleamlsp*
+
+g:ale_gleam_gleamlsp_executable               *g:ale_gleam_gleamlsp_executable*
+                                              *b:ale_gleam_gleamlsp_executable*
+  Type: |String|
+  Default: `'gleam'`
+
+  This variable can be modified to change the executable path for `gleamlsp`.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -202,6 +202,8 @@ Notes:
   * `fusion-lint`
 * Git Commit Messages
   * `gitlint`
+* Gleam
+  * `gleamlsp`
 * GLSL
   * `glslang`
   * `glslls`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3031,6 +3031,8 @@ documented in additional help files.
     fusion-lint...........................|ale-fuse-fusionlint|
   git commit..............................|ale-gitcommit-options|
     gitlint...............................|ale-gitcommit-gitlint|
+  gleam...................................|ale-gleam-options|
+    gleamlsp..............................|ale-gleam-gleamlsp|
   glsl....................................|ale-glsl-options|
     glslang...............................|ale-glsl-glslang|
     glslls................................|ale-glsl-glslls|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -211,6 +211,8 @@ formatting.
   * [fusion-lint](https://github.com/RyanSquared/fusionscript)
 * Git Commit Messages
   * [gitlint](https://github.com/jorisroovers/gitlint)
+* Gleam
+  * [gleamlsp](https://github.com/gleam-lang/gleam)
 * GLSL
   * [glslang](https://github.com/KhronosGroup/glslang)
   * [glslls](https://github.com/svenstaro/glsl-language-server)

--- a/test/linter/test_gleam_gleamlsp.vader
+++ b/test/linter/test_gleam_gleamlsp.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#assert#SetUpLinterTest('gleam', 'gleamlsp')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  AssertLinter 'gleam', ale#Escape('gleam') . ' lsp'
+
+Execute(The project root should be detected correctly):
+  AssertLSPProject ''
+
+  call ale#test#SetFilename('../test-files/gleam/gleam.toml')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/../test-files/gleam')


### PR DESCRIPTION
This adds support for [gleamlsp](https://github.com/gleam-lang/gleam), which is shipped with the Gleam compiler/executable.

This PR is heavily influenced by other similar PRs for simple LSPs.

This is also my first PR for ALE, so I'm willing to fix and iterate as needed.