### PR TITLE
Update zls.vim

### DIFF
--- a/ale_linters/zig/zls.vim
+++ b/ale_linters/zig/zls.vim
@@ -12,7 +12,7 @@ endfunction
 
 call ale#linter#Define('zig', {
 \   'name': 'zls',
-\   'lsp': 'stdio',
+\   'lsp': 'zls',
 \   'lsp_config': {b -> ale#Var(b, 'zig_zls_config')},
 \   'executable': {b -> ale#Var(b, 'zig_zls_executable')},
 \   'command': '%e',


### PR DESCRIPTION
I was playing around with zig, and noticed that completion suggestion/hover do not work in ALE.

 I have not read ale-dev, and don't know how to run a plug .vim plugin locally, however based on looking at tsserver this might work. My thought process was that zls did not originally have this functionality when the initial zig linter was added.
 
 Please approve at your own risk. I won't have time to run tests, or figure out how to do this all locally for a while.
