### PR TITLE
[hover] ParseLSPResult sets language 'text' for missing spec

### DIFF
--- a/autoload/ale/hover.vim
+++ b/autoload/ale/hover.vim
@@ -117,10 +117,10 @@ function! ale#hover#ParseLSPResult(contents) abort
             for l:line in split(l:item, "\n")
                 if l:fence_language is v:null
                     " Look for the start of a code fence. (```python, etc.)
-                    let l:match = matchlist(l:line, '^``` *\([^ ]\+\) *$')
+                    let l:match = matchlist(l:line, '^``` *\([^ ]\+\)\? *$')
 
                     if !empty(l:match)
-                        let l:fence_language = l:match[1]
+                        let l:fence_language = len(l:match) > 1 ? l:match[1] : 'text'
 
                         if !empty(l:marked_list)
                             call add(l:fence_lines, '')

--- a/test/test_hover_parsing.vader
+++ b/test/test_hover_parsing.vader
@@ -15,6 +15,22 @@ Execute(A string with a code fence should be handled):
   AssertEqual
   \ [
   \   [
+  \   ],
+  \   [
+  \     'def foo():',
+  \     '    pass',
+  \   ],
+  \ ],
+  \ ale#hover#ParseLSPResult(join([
+  \   '```',
+  \   'def foo():',
+  \   '    pass',
+  \   '```',
+  \ ], "\n"))
+
+  AssertEqual
+  \ [
+  \   [
   \     'unlet! b:current_syntax',
   \     'syntax include @ALE_hover_python syntax/python.vim',
   \     'syntax region ALE_hover_1 start=/\%1l/ end=/\%3l/ contains=@ALE_hover_python',


### PR DESCRIPTION
I have an LSP that is returning markdown code blocks on Hover with no language specified, e.g.

````
```
Foobar
```
````

As a result, you get "```" in the message line which is not that useful.

I made the regex to catch the first code fence accept empty language as well, and if it's empty, we set it to "text".

This makes it so that LSPs that return no language still produce legible restuls on the message line.

Fixes dense-analysis/ale#4698