### PR TITLE
Add language id option of CSpell

### DIFF
--- a/autoload/ale/handlers/cspell.vim
+++ b/autoload/ale/handlers/cspell.vim
@@ -14,9 +14,13 @@ endfunction
 function! ale#handlers#cspell#GetCommand(buffer) abort
     let l:executable = ale#handlers#cspell#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'cspell_options')
+    let l:filetype = getbufvar(a:buffer, '&filetype')
+
+    let l:language_id_option = empty(l:filetype) ? '' : '--language-id="' . l:filetype . '"'
 
     return ale#node#Executable(a:buffer, l:executable)
     \   . ' lint --no-color --no-progress --no-summary'
+    \   . ale#Pad(l:language_id_option)
     \   . ale#Pad(l:options)
     \   . ' -- stdin'
 endfunction

--- a/test/linter/test_cspell.vader
+++ b/test/linter/test_cspell.vader
@@ -20,6 +20,8 @@ Before:
   let g:ale_cspell_use_global = 0
   let g:ale_cspell_options = ''
 
+  set filetype=tex
+
 After:
   call ale#assert#TearDownLinterTest()
 
@@ -27,7 +29,7 @@ Execute(The global executable should be used when the local one cannot be found)
   AssertLinter
   \  'cspell',
   \  ale#Escape('cspell')
-  \  . ' lint --no-color --no-progress --no-summary -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
 
 Execute(Should use the node_modules/.bin executable if available):
   call ale#test#SetFilename('../test-files/cspell/node-modules/test.tex')
@@ -37,7 +39,7 @@ Execute(Should use the node_modules/.bin executable if available):
   \    . '/../test-files/cspell/node-modules/node_modules/.bin/cspell'),
   \  ale#Escape(ale#path#Simplify(g:dir
   \    . '/../test-files/cspell/node-modules/node_modules/.bin/cspell'))
-  \  . ' lint --no-color --no-progress --no-summary -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
 
 Execute(Should use the node_modules/cspell executable if available):
   call ale#test#SetFilename('../test-files/cspell/node-modules-2/test.tex')
@@ -48,7 +50,7 @@ Execute(Should use the node_modules/cspell executable if available):
   \  (has('win32') ? 'node.exe ': '')
   \  . ale#Escape(ale#path#Simplify(g:dir
   \    . '/../test-files/cspell/node-modules-2/node_modules/cspell/bin.js'))
-  \  . ' lint --no-color --no-progress --no-summary -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
 
 Execute(Should let users configure a global executable and override local paths):
   let g:ale_cspell_executable = '/path/to/custom/cspell'
@@ -57,7 +59,7 @@ Execute(Should let users configure a global executable and override local paths)
   AssertLinter
   \  '/path/to/custom/cspell',
   \  ale#Escape('/path/to/custom/cspell')
-  \  . ' lint --no-color --no-progress --no-summary -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
 
 Execute(Additional cspell options should be configurable):
   call ale#test#SetFilename('../test-files/dummy')
@@ -67,4 +69,12 @@ Execute(Additional cspell options should be configurable):
   AssertLinter
   \  'cspell',
   \  ale#Escape('cspell')
-  \  . ' lint --no-color --no-progress --no-summary --foobar -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" --foobar -- stdin'
+
+Execute(The language id should not specified when filetype is empty):
+  set filetype=
+
+  AssertLinter
+  \  'cspell',
+  \  ale#Escape('cspell')
+  \  . ' lint --no-color --no-progress --no-summary -- stdin'


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!


Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
-->

## What

Fixed issue where adjustments to language-specific settings in cspell.json weren't being applied.

## How

When using stdin, it appears that cspell is unable to detect the file type correctly. Therefore, I have modified it to explicitly specify the file type.

```console
$ cat main.rb
1.upto(10) do |i|
  puts i
end

$ cat cspell.json
{
  "languageSettings": [
    {
      "languageId": "ruby",
      "dictionaries": ["ruby"]
    }
  ]
}
```

```console
$ cspell lint --verbose main.rb
cspell;
Date: Thu, 28 Dec 2023 15:19:36 GMT
Options:
    verbose:   Yes
    config:    default
    exclude:   node_modules/**
    files:     main.rb
    wordsOnly: No
    unique:    No

Config Files Found:
    /path/to/cspell.json

Exclusion Globs:
    Glob: node_modules/** from command line

1/1 ./main.rbChecking: /path/to/main.rb, File type: auto, Language: default
Checked: /path/to/main.rb, File type: ruby, Language: en ... Issues: 0 209.35ms
Config file Used: /path/to/cspell.json
Dictionaries Used: companies, filetypes, public-licenses, softwareTerms, computing-acronyms, web-services, aws, cryptocurrencies, en_us, en-common-misspellings, fullstack, ruby
 209.35ms
CSpell: Files checked: 1, Issues found: 0 in 0 files

$ cat main.rb | cspell lint --verbose -- stdin
cspell;
Date: Thu, 28 Dec 2023 15:19:41 GMT
Options:
    verbose:   Yes
    config:    default
    exclude:   node_modules/**
    files:     stdin
    wordsOnly: No
    unique:    No

Config Files Found:
    /path/to/cspell.json

Exclusion Globs:
    Glob: node_modules/** from command line

1/1 ./stdin:Checking: stdin://, File type: auto, Language: default
Checked: stdin://, File type: text, Language: en ... Issues: 1 216.86ms
Config file Used: /path/to/cspell.json
Dictionaries Used: companies, filetypes, public-licenses, softwareTerms, computing-acronyms, web-services, aws, cryptocurrencies, en_us, en-common-misspellings
 216.86ms X
./:1:3 - Unknown word (upto) fix: (up to)
CSpell: Files checked: 1, Issues found: 1 in 1 files
```
