### PR TITLE
Stylelint linter output stream can go to stderr

### DIFF
--- a/ale_linters/css/stylelint.vim
+++ b/ale_linters/css/stylelint.vim
@@ -11,6 +11,7 @@ endfunction
 
 call ale#linter#Define('css', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': {b -> ale#path#FindExecutable(b, 'css_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ])},

--- a/ale_linters/html/stylelint.vim
+++ b/ale_linters/html/stylelint.vim
@@ -21,6 +21,7 @@ endfunction
 
 call ale#linter#Define('html', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': function('ale_linters#html#stylelint#GetExecutable'),
 \   'command': function('ale_linters#html#stylelint#GetCommand'),
 \   'callback': 'ale#handlers#css#HandleStyleLintFormat',

--- a/ale_linters/less/stylelint.vim
+++ b/ale_linters/less/stylelint.vim
@@ -12,6 +12,7 @@ endfunction
 
 call ale#linter#Define('less', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': {b -> ale#path#FindExecutable(b, 'less_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ])},

--- a/ale_linters/sass/stylelint.vim
+++ b/ale_linters/sass/stylelint.vim
@@ -5,6 +5,7 @@ call ale#Set('sass_stylelint_use_global', get(g:, 'ale_use_global_executables', 
 
 call ale#linter#Define('sass', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': {b -> ale#path#FindExecutable(b, 'sass_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ])},

--- a/ale_linters/scss/stylelint.vim
+++ b/ale_linters/scss/stylelint.vim
@@ -11,6 +11,7 @@ endfunction
 
 call ale#linter#Define('scss', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': {b -> ale#path#FindExecutable(b, 'scss_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ])},

--- a/ale_linters/stylus/stylelint.vim
+++ b/ale_linters/stylus/stylelint.vim
@@ -12,6 +12,7 @@ endfunction
 
 call ale#linter#Define('stylus', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': {b -> ale#path#FindExecutable(b, 'stylus_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ])},

--- a/ale_linters/sugarss/stylelint.vim
+++ b/ale_linters/sugarss/stylelint.vim
@@ -13,6 +13,7 @@ endfunction
 
 call ale#linter#Define('sugarss', {
 \   'name': 'stylelint',
+\   'output_stream': 'both',
 \   'executable': {b -> ale#path#FindExecutable(b, 'sugarss_stylelint', [
 \       'node_modules/.bin/stylelint',
 \   ])},


### PR DESCRIPTION
Stylelint linter output stream can go to stderr

Since [version 13.6.0](https://github.com/stylelint/stylelint/blob/804bb24c75248aba55b009994e4bfb561593a990/CHANGELOG.md?plain=1#L654),
following [PR 4799](https://github.com/stylelint/stylelint/pull/4799)
`stylelint` errors are sent to `stderr`. Previous versions where sending
errors to `stdout`. 

This PR set the `output_stream` option to `both` for all the different flavours 
of the `stylelint` linter (`css`, `sass`, ...).

I could not find a way to test for this change. I may have missed
something. I'd be happy to add tests if someone can point me in the right
direction.