### PR TITLE
Use different group names for signs and virtual text

### DIFF
--- a/autoload/ale/sign.vim
+++ b/autoload/ale/sign.vim
@@ -161,7 +161,7 @@ endfunction
 
 function! s:GroupCmd() abort
     if s:supports_sign_groups
-        return ' group=ale '
+        return ' group=ale_signs '
     else
         return ' '
     endif
@@ -180,13 +180,13 @@ endfunction
 function! ale#sign#ParsePattern() abort
     if s:supports_sign_groups
         " Matches output like :
-        " line=4  id=1  group=ale  name=ALEErrorSign
-        " строка=1  id=1000001  группа=ale  имя=ALEErrorSign
-        " 行=1  識別子=1000001  グループ=ale  名前=ALEWarningSign
-        " línea=12 id=1000001 grupo=ale  nombre=ALEWarningSign
-        " riga=1 id=1000001  gruppo=ale   nome=ALEWarningSign
-        " Zeile=235  id=1000001 Gruppe=ale  Name=ALEErrorSign
-        let l:pattern = '\v^.*\=(\d+).*\=(\d+).*\=ale>.*\=(ALE[a-zA-Z]+Sign)'
+        " line=4  id=1  group=ale_signs  name=ALEErrorSign
+        " строка=1  id=1000001  группа=ale_signs  имя=ALEErrorSign
+        " 行=1  識別子=1000001  グループ=ale_signs  名前=ALEWarningSign
+        " línea=12 id=1000001 grupo=ale_signs  nombre=ALEWarningSign
+        " riga=1 id=1000001  gruppo=ale_signs   nome=ALEWarningSign
+        " Zeile=235  id=1000001 Gruppe=ale_signs  Name=ALEErrorSign
+        let l:pattern = '\v^.*\=(\d+).*\=(\d+).*\=ale_signs>.*\=(ALE[a-zA-Z]+Sign)'
     else
         " Matches output like :
         " line=4  id=1  name=ALEErrorSign
@@ -203,7 +203,7 @@ endfunction
 
 " Given a buffer number, return a List of placed signs [line, id, group]
 function! ale#sign#ParseSignsWithGetPlaced(buffer) abort
-    let l:signs = sign_getplaced(a:buffer, { 'group': s:supports_sign_groups ? 'ale' : '' })[0].signs
+    let l:signs = sign_getplaced(a:buffer, { 'group': s:supports_sign_groups ? 'ale_signs' : '' })[0].signs
     let l:result = []
     let l:is_dummy_sign_set = 0
 
@@ -489,7 +489,7 @@ endfunction
 " Remove all signs.
 function! ale#sign#Clear() abort
     if s:supports_sign_groups
-        sign unplace group=ale *
+        sign unplace group=ale_signs *
     else
         sign unplace *
     endif

--- a/test/sign/test_linting_sets_signs.vader
+++ b/test/sign/test_linting_sets_signs.vader
@@ -37,7 +37,7 @@ Before:
   function! CollectSigns()
     redir => l:output
       if has('nvim-0.4.2') || has('patch-8.1.614')
-        silent exec 'sign place group=ale'
+        silent exec 'sign place group=ale_signs'
       else
         silent exec 'sign place'
       endif

--- a/test/sign/test_sign_parsing.vader
+++ b/test/sign/test_sign_parsing.vader
@@ -4,7 +4,7 @@ Execute (Parsing English signs should work):
     \ [0, [[9, 1000001, 'ALEWarningSign']]],
     \ ale#sign#ParseSigns([
     \   'Signs for app.js:',
-    \   '    line=9  id=1000001  group=ale  name=ALEWarningSign',
+    \   '    line=9  id=1000001  group=ale_signs  name=ALEWarningSign',
     \ ])
   else
     AssertEqual
@@ -19,7 +19,7 @@ Execute (Parsing Russian signs should work):
   if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[1, 1000001, 'ALEErrorSign']]],
-    \ ale#sign#ParseSigns(['    строка=1  id=1000001  группа=ale  имя=ALEErrorSign'])
+    \ ale#sign#ParseSigns(['    строка=1  id=1000001  группа=ale_signs  имя=ALEErrorSign'])
   else
     AssertEqual
     \ [0, [[1, 1000001, 'ALEErrorSign']]],
@@ -30,7 +30,7 @@ Execute (Parsing Japanese signs should work):
   if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
-    \ ale#sign#ParseSigns(['    行=1  識別子=1000001  グループ=ale  名前=ALEWarningSign'])
+    \ ale#sign#ParseSigns(['    行=1  識別子=1000001  グループ=ale_signs  名前=ALEWarningSign'])
   else
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
@@ -41,7 +41,7 @@ Execute (Parsing Spanish signs should work):
   if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[12, 1000001, 'ALEWarningSign']]],
-    \ ale#sign#ParseSigns(['    línea=12 id=1000001  grupo=ale  nombre=ALEWarningSign'])
+    \ ale#sign#ParseSigns(['    línea=12 id=1000001  grupo=ale_signs  nombre=ALEWarningSign'])
   else
     AssertEqual
     \ [0, [[12, 1000001, 'ALEWarningSign']]],
@@ -52,7 +52,7 @@ Execute (Parsing Italian signs should work):
   if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
-    \ ale#sign#ParseSigns(['    riga=1 id=1000001, gruppo=ale  nome=ALEWarningSign'])
+    \ ale#sign#ParseSigns(['    riga=1 id=1000001, gruppo=ale_signs  nome=ALEWarningSign'])
   else
     AssertEqual
     \ [0, [[1, 1000001, 'ALEWarningSign']]],
@@ -63,7 +63,7 @@ Execute (Parsing German signs should work):
   if has('nvim-0.4.2') || has('patch-8.1.614')
     AssertEqual
     \ [0, [[235, 1000001, 'ALEErrorSign']]],
-    \ ale#sign#ParseSigns(['    Zeile=235  id=1000001 Gruppe=ale  Name=ALEErrorSign'])
+    \ ale#sign#ParseSigns(['    Zeile=235  id=1000001 Gruppe=ale_signs  Name=ALEErrorSign'])
   else
     AssertEqual
     \ [0, [[235, 1000001, 'ALEErrorSign']]],
@@ -75,8 +75,8 @@ Execute (The sign parser should indicate if the dummy sign is set):
     AssertEqual
     \ [1, [[1, 1000001, 'ALEErrorSign']]],
     \ ale#sign#ParseSigns([
-    \   '    строка=1  id=1000001  group=ale  имя=ALEErrorSign',
-    \   '    line=1  id=1000000  group=ale  name=ALEDummySign',
+    \   '    строка=1  id=1000001  group=ale_signs  имя=ALEErrorSign',
+    \   '    line=1  id=1000000  group=ale_signs  name=ALEDummySign',
     \ ])
   else
     AssertEqual

--- a/test/sign/test_sign_placement.vader
+++ b/test/sign/test_sign_placement.vader
@@ -71,7 +71,7 @@ Before:
   function! ParseSigns()
     redir => l:output
       if has('nvim-0.4.2') || has('patch-8.1.614')
-        silent sign place group=ale
+        silent sign place group=ale_signs
       else
         silent sign place
       endif
@@ -155,9 +155,9 @@ Execute(The current signs should be set for running a job):
 
 Execute(Loclist items with sign_id values should be kept):
   if has('nvim-0.4.2') || has('patch-8.1.614')
-    exec 'sign place 1000347 group=ale line=3 name=ALEErrorSign buffer=' . bufnr('')
-    exec 'sign place 1000348 group=ale line=15 name=ALEErrorSign buffer=' . bufnr('')
-    exec 'sign place 1000349 group=ale line=16 name=ALEWarningSign buffer=' . bufnr('')
+    exec 'sign place 1000347 group=ale_signs line=3 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000348 group=ale_signs line=15 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000349 group=ale_signs line=16 name=ALEWarningSign buffer=' . bufnr('')
   else
     exec 'sign place 1000347 line=3 name=ALEErrorSign buffer=' . bufnr('')
     exec 'sign place 1000348 line=15 name=ALEErrorSign buffer=' . bufnr('')
@@ -280,10 +280,10 @@ Execute(It should be possible to clear signs with empty lists):
   " We can fail to remove signs if there are multiple signs on one line,
   " say after deleting lines in Vim, etc.
   if has('nvim-0.4.2') || has('patch-8.1.614')
-    exec 'sign place 1000347 group=ale line=3 name=ALEErrorSign buffer=' . bufnr('')
-    exec 'sign place 1000348 group=ale line=3 name=ALEWarningSign buffer=' . bufnr('')
-    exec 'sign place 1000349 group=ale line=10 name=ALEErrorSign buffer=' . bufnr('')
-    exec 'sign place 1000350 group=ale line=10 name=ALEWarningSign buffer=' . bufnr('')
+    exec 'sign place 1000347 group=ale_signs line=3 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000348 group=ale_signs line=3 name=ALEWarningSign buffer=' . bufnr('')
+    exec 'sign place 1000349 group=ale_signs line=10 name=ALEErrorSign buffer=' . bufnr('')
+    exec 'sign place 1000350 group=ale_signs line=10 name=ALEWarningSign buffer=' . bufnr('')
   else
     exec 'sign place 1000347 line=3 name=ALEErrorSign buffer=' . bufnr('')
     exec 'sign place 1000348 line=3 name=ALEWarningSign buffer=' . bufnr('')


### PR DESCRIPTION
Since Neovim commit [c4afb9788c4f139eb2e3b7aa4d6a6a20b67ba156](https://github.com/neovim/neovim/commit/c4afb9788c4f139eb2e3b7aa4d6a6a20b67ba156), the sign API uses extmarks internally. Virtual text is already rendered using extmarks. ALE uses the same group name for both signs and virtual text and as a result, both are placed in the same extmark group. Since ALE deletes all extmarks in the virtual text group after all signs have been placed, no signs are ever shown. This PR fixes this by renaming the sign group from `ale` to `ale_signs`.

Fixes issue #4657.