### PR TITLE
Fix E1085: Not a callable type: elm_ls#GetOptions

### DIFF
--- a/ale_linters/elm/ls.vim
+++ b/ale_linters/elm/ls.vim
@@ -16,7 +16,7 @@ function! ale_linters#elm#ls#GetProjectRoot(buffer) abort
     return !empty(l:elm_json) ? fnamemodify(l:elm_json, ':p:h') : ''
 endfunction
 
-function! ale_linters#elm#ls#GetOptions(buffer) abort
+function! ale_linters#elm#ls#GetInitializationOptions(buffer) abort
     return {
     \   'elmPath': ale#Var(a:buffer, 'elm_ls_elm_path'),
     \   'elmFormatPath': ale#Var(a:buffer, 'elm_ls_elm_format_path'),
@@ -37,5 +37,5 @@ call ale#linter#Define('elm', {
 \   'command': '%e --stdio',
 \   'project_root': function('ale_linters#elm#ls#GetProjectRoot'),
 \   'language': 'elm',
-\   'initialization_options': function('elm_ls#GetOptions')
+\   'initialization_options': function('ale_linters#elm#ls#GetInitializationOptions')
 \})


### PR DESCRIPTION
- Make elm linting not display an error all the time
- Additionally change the name GetOptions to GetInitializationOptions for consistency with other files.

My motivation for these changes as an end user:
    Error detected while processing BufWinEnter Autocommands for "*"..function 
    ale#events#LintOnEnter[5]..ale#Queue[33]..<SNR>59_Lint[37]..ale#engine
    #RunLinters[4]..<SNR>64_GetLintFileValues[27]..<lambda>2[1]..<SNR>64_RunLinters[18].. 
    <SNR>64_RunLinter[2]..ale#lsp_linter#CheckWithLSP[1]..ale#ls
    p_linter#StartLSP[28]..<SNR>66_StartIfExecutable[15]..<SNR>66_StartWithCommand[13].. 
   <SNR>66_StartLSP[6]..ale#lsp_linter#GetOptions:
    line    9:
    E1085: Not a callable type: elm_ls#GetOptions

I searched quickly through the issues and pull requests with "elm" and didn't find the same.
