### PR TITLE
Gleam: Support 'gleam format' as fixer

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -291,6 +291,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['solidity'],
 \       'description': 'Fix Solidity files with forge fmt.',
 \   },
+\   'gleam_format': {
+\       'function': 'ale#fixers#gleam_format#Fix',
+\       'suggested_filetypes': ['gleam'],
+\       'description': 'Fix Gleam files with gleam format.',
+\   },
 \   'gofmt': {
 \       'function': 'ale#fixers#gofmt#Fix',
 \       'suggested_filetypes': ['go'],

--- a/autoload/ale/fixers/gleam_format.vim
+++ b/autoload/ale/fixers/gleam_format.vim
@@ -1,0 +1,19 @@
+" Author: Jonathan Palardt https://github.com/jpalardy
+" Description: Integration of 'gleam format' with ALE.
+
+call ale#Set('gleam_format_executable', 'gleam')
+
+function! ale#fixers#gleam_format#GetExecutable(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'gleam_format_executable')
+
+    return ale#Escape(l:executable)
+endfunction
+
+function! ale#fixers#gleam_format#Fix(buffer) abort
+    let l:executable = ale#fixers#gleam_format#GetExecutable(a:buffer)
+
+    return {
+    \   'command': l:executable . ' format %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-gleam.txt
+++ b/doc/ale-gleam.txt
@@ -2,10 +2,17 @@
 ALE Gleam Integration                                       *ale-gleam-options*
                                                         *ale-integration-gleam*
 
-===============================================================================
-Integration Information
 
-  Currently, the only supported linter for gleam is gleamlsp.
+===============================================================================
+gleam_format                                           *ale-gleam-gleam_format*
+
+g:ale_gleam_gleam_format_executable       *g:ale_gleam_gleam_format_executable*
+                                          *b:ale_gleam_gleam_format_executable*
+  Type: |String|
+  Default: `'gleam'`
+
+  This variable can be modified to change the executable path for
+  `gleam format`.
 
 
 ===============================================================================

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -203,6 +203,7 @@ Notes:
 * Git Commit Messages
   * `gitlint`
 * Gleam
+  * `gleam_format`
   * `gleamlsp`
 * GLSL
   * `glslang`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3032,6 +3032,7 @@ documented in additional help files.
   git commit..............................|ale-gitcommit-options|
     gitlint...............................|ale-gitcommit-gitlint|
   gleam...................................|ale-gleam-options|
+    gleam_format..........................|ale-gleam-gleam_format|
     gleamlsp..............................|ale-gleam-gleamlsp|
   glsl....................................|ale-glsl-options|
     glslang...............................|ale-glsl-glslang|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -212,6 +212,7 @@ formatting.
 * Git Commit Messages
   * [gitlint](https://github.com/jorisroovers/gitlint)
 * Gleam
+  * [gleam_format](https://github.com/gleam-lang/gleam)
   * [gleamlsp](https://github.com/gleam-lang/gleam)
 * GLSL
   * [glslang](https://github.com/KhronosGroup/glslang)

--- a/test/fixers/test_gleam_format_fixer_callback.vader
+++ b/test/fixers/test_gleam_format_fixer_callback.vader
@@ -1,0 +1,28 @@
+Before:
+  call ale#test#SetDirectory('/testplugin/test/fixers')
+
+After:
+  Restore
+
+  call ale#test#RestoreDirectory()
+
+Execute(The gleam_format command should have default values):
+  call ale#test#SetFilename('../test-files/elixir/testfile.gleam')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('gleam') . ' format %t',
+  \ },
+  \ ale#fixers#gleam_format#Fix(bufnr(''))
+
+Execute(The gleam_format executable should be configurable):
+  let g:ale_gleam_format_executable = 'xxxinvalid'
+  call ale#test#SetFilename('../test-files/elixir/testfile.gleam')
+
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('xxxinvalid') . ' format %t',
+  \ },
+  \ ale#fixers#gleam_format#Fix(bufnr(''))


### PR DESCRIPTION
This PR adds support for [gleam format](https://gleam.run/writing-gleam/command-line-reference/#format) which is shipped with the Gleam compiler/executable.

This is a follow up to #4696

