### PR TITLE
Slang linter for Verilog/SystemVerilog.

### DIFF
--- a/ale_linters/verilog/slang.vim
+++ b/ale_linters/verilog/slang.vim
@@ -1,0 +1,53 @@
+" Author: Alvin Rolling <alvinrolling@gmail.com>
+" Description: slang for verilog files
+
+" Set this option to change Slang lint options
+if !exists('g:ale_verilog_slang_options')
+    let g:ale_verilog_slang_options = ''
+endif
+
+" --lint-only
+function! ale_linters#verilog#slang#GetCommand(buffer) abort
+    return 'slang -Weverything '
+    \   . '-I%s:h '
+    \   . ale#Var(a:buffer, 'verilog_slang_options') .' '
+    \   . '%t'
+endfunction
+
+function! s:RemoveUnicodeQuotes(text) abort
+    let l:text = a:text
+    let l:text = substitute(l:text, '[`´‘’]', '''', 'g')
+    let l:text = substitute(l:text, '[“”]', '"', 'g')
+
+    return l:text
+endfunction
+
+function! ale_linters#verilog#slang#Handle(buffer, lines) abort
+    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+)?:?(\d+)?:? ([^:]+): (.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:item = {
+        \   'lnum': str2nr(l:match[2]),
+        \   'type': (l:match[4] is# 'error') ? 'E' : 'W',
+        \   'text': s:RemoveUnicodeQuotes(l:match[5]),
+        \}
+
+        if !empty(l:match[3])
+            let l:item.col = str2nr(l:match[3])
+        endif
+
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('verilog', {
+\   'name': 'slang',
+\   'output_stream': 'stderr',
+\   'executable': 'slang',
+\   'command': function('ale_linters#verilog#slang#GetCommand'),
+\   'callback': 'ale_linters#verilog#slang#Handle',
+\   'read_buffer': 0,
+\})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -674,6 +674,7 @@ Notes:
 * Verilog
   * `hdl-checker`
   * `iverilog`
+  * slang
   * `verilator`
   * `vlog`
   * `xvlog`

--- a/doc/ale-verilog.txt
+++ b/doc/ale-verilog.txt
@@ -3,13 +3,16 @@ ALE Verilog/SystemVerilog Integration                     *ale-verilog-options*
 
 
 ===============================================================================
-ALE can use six different linters for Verilog HDL:
+ALE can use seven different linters for Verilog HDL:
 
   HDL Checker
     Using `hdl_checker --lsp`
 
   iverilog:
     Using `iverilog -t null -Wall`
+
+  slang:
+    Using `slang -Weverything`
 
   verilator
     Using `verilator --lint-only -Wall`
@@ -21,7 +24,7 @@ ALE can use six different linters for Verilog HDL:
     Using `xvlog`
 
   Yosys
-    Using `ysoys -Q -T -p 'read_verilog'`
+    Using `yosys -Q -T -p 'read_verilog'`
 
 By default, both 'verilog' and 'systemverilog' filetypes are checked.
 
@@ -64,6 +67,15 @@ iverilog                                                 *ale-verilog-iverilog*
 
   No additional options
 
+===============================================================================
+slang                                                       *ale-verilog-slang*
+
+g:ale_verilog_slang_option                        *g:ale_verilog_slang_options*
+                                                  *b:ale_verilog_slang_options*
+  Type: String
+  Default: ''
+
+  This variable can be changed to modify 'slang' command arguments.
 
 ===============================================================================
 verilator                                               *ale-verilog-verilator*
@@ -73,7 +85,7 @@ g:ale_verilog_verilator_options               *g:ale_verilog_verilator_options*
   Type: |String|
   Default: `''`
 
-  This variable can be changed to modify 'verilator' command arguments
+  This variable can be changed to modify 'verilator' command arguments.
 
   For example `'-sv --default-language "1800-2012"'` if you want to enable
   SystemVerilog parsing and select the 2012 version of the language.

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3458,6 +3458,7 @@ documented in additional help files.
   verilog/systemverilog...................|ale-verilog-options|
     hdl-checker...........................|ale-verilog-hdl-checker|
     iverilog..............................|ale-verilog-iverilog|
+    slang.................................|ale-verilog-slang|
     verilator.............................|ale-verilog-verilator|
     vlog..................................|ale-verilog-vlog|
     xvlog.................................|ale-verilog-xvlog|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -683,6 +683,7 @@ formatting.
 * Verilog
   * [hdl-checker](https://pypi.org/project/hdl-checker)
   * [iverilog](https://github.com/steveicarus/iverilog)
+  * [slang](https://github.com/MikePopoloski/slang)
   * [verilator](http://www.veripool.org/projects/verilator/wiki/Intro)
   * [vlog](https://www.mentor.com/products/fv/questa/)
   * [xvlog](https://www.xilinx.com/products/design-tools/vivado.html)

--- a/test/handler/test_slang_handler.vader
+++ b/test/handler/test_slang_handler.vader
@@ -1,0 +1,26 @@
+Before:
+  runtime ale_linters/verilog/slang.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The slang handler should parse lines correctly):
+  AssertEqual
+  \ [
+  \    {
+  \      'lnum': 11,
+  \      'col': 1,
+  \      'type': 'W',
+  \      'text': 'extra '';'' has no effect [-Wempty-member]',
+  \    },
+  \    {
+  \      'lnum': 24,
+  \      'col': 12,
+  \      'type': 'E',
+  \      'text': 'cannot mix continuous and procedural assignments to variable ''data_o''',
+  \    },
+  \ ],
+  \ ale_linters#verilog#slang#Handle(bufnr(''), [
+  \ 'foo.sv:11:1: warning: extra '';'' has no effect [-Wempty-member]',
+  \ 'foo.sv:24:12: error: cannot mix continuous and procedural assignments to variable ''data_o''',
+  \ ])

--- a/test/linter/test_slang.vader
+++ b/test/linter/test_slang.vader
@@ -1,0 +1,14 @@
+Before:
+  call ale#assert#SetUpLinterTest('verilog', 'slang')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default slang command should be correct):
+  AssertLinter 'slang', 'slang -Weverything -I%s:h  %t'
+
+Execute(slang options should be configurable):
+  " Additional args for the linter
+  let g:ale_verilog_slang_options = '--define-macro DWIDTH=12'
+
+  AssertLinter 'slang', 'slang -Weverything -I%s:h --define-macro DWIDTH=12 %t'

--- a/test/test_filetype_linter_defaults.vader
+++ b/test/test_filetype_linter_defaults.vader
@@ -119,7 +119,7 @@ Execute(The defaults for the zsh filetype should be correct):
 Execute(The defaults for the verilog filetype should be correct):
   " This filetype isn't configured with default, so we can test loading all
   " available linters with this.
-  AssertEqual ['hdl_checker', 'iverilog', 'verilator', 'vlog', 'xvlog', 'yosys'], GetLinterNames('verilog')
+  AssertEqual ['hdl_checker', 'iverilog', 'slang', 'verilator', 'vlog', 'xvlog', 'yosys'], GetLinterNames('verilog')
 
   let g:ale_linters_explicit = 1
 


### PR DESCRIPTION
This contribution incorporates the [slang](https://github.com/MikePopoloski/slang) linting tools for **Verilog/SystemVerilog**.

The contribution here follows the `ale-development` guidelines. Two linter tests have been added, and all tests have passed.

Details about the changes are described in [this article](https://alvinrolling.github.io/vim/Slang-Linter-for-Vim-Ale/).

An example of the results in Vim is shown below:
<img width="723" alt="slang_vim_ale" src="https://github.com/dense-analysis/ale/assets/13283410/b8da4437-98df-4f50-9533-7e282ce81486">
