### PR TITLE
Add fixer for toml using taplo

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -656,6 +656,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['javascript', 'typescript'],
 \       'description': 'Apply biome (ex. rome) check to a file.',
 \   },
+\   'taplo': {
+\       'function': 'ale#fixers#taplo#Fix',
+\       'suggested_filetypes': ['toml'],
+\       'description': 'Fix TOML files using taplo.',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/taplo.vim
+++ b/autoload/ale/fixers/taplo.vim
@@ -1,0 +1,10 @@
+" Author: Jeremy Cantrell <jmcantrell@gmail.com>
+" Description: A versatile, feature-rich TOML toolkit
+
+function! ale#fixers#taplo#Fix(buffer) abort
+    let l:executable = ale#handlers#taplo#GetExecutable(a:buffer)
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' format -'
+    \}
+endfunction

--- a/autoload/ale/handlers/taplo.vim
+++ b/autoload/ale/handlers/taplo.vim
@@ -1,0 +1,8 @@
+" Author: Jeremy Cantrell <jmcantrell@gmail.com>
+" Description: A versatile, feature-rich TOML toolkit
+
+call ale#Set('taplo_executable', 'taplo')
+
+function! ale#handlers#taplo#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'taplo_executable')
+endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -654,6 +654,7 @@ Notes:
   * `thriftcheck`
 * TOML
   * `dprint`
+  * `taplo`
 * TypeScript
   * `biome`
   * `cspell`

--- a/doc/ale-toml.txt
+++ b/doc/ale-toml.txt
@@ -9,4 +9,10 @@ See |ale-dprint-options| and https://dprint.dev/plugins/toml
 
 
 ===============================================================================
+taplo                                                        *ale-toml-taplo*
+
+See https://taplo.tamasfe.dev/
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-toml.txt
+++ b/doc/ale-toml.txt
@@ -9,7 +9,7 @@ See |ale-dprint-options| and https://dprint.dev/plugins/toml
 
 
 ===============================================================================
-taplo                                                        *ale-toml-taplo*
+taplo                                                         *ale-toml-taplo*
 
 See https://taplo.tamasfe.dev/
 

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3440,6 +3440,7 @@ documented in additional help files.
     thriftcheck...........................|ale-thrift-thriftcheck|
   toml....................................|ale-toml-options|
     dprint................................|ale-toml-dprint|
+    taplo.................................|ale-toml-taplo|
   typescript..............................|ale-typescript-options|
     biome.................................|ale-typescript-biome|
     cspell................................|ale-typescript-cspell|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -663,6 +663,7 @@ formatting.
   * [thriftcheck](https://github.com/pinterest/thriftcheck)
 * TOML
   * [dprint](https://dprint.dev)
+  * [taplo](https://taplo.tamasfe.dev)
 * TypeScript
   * [biome](http://biomejs.dev)
   * [cspell](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)

--- a/test/fixers/test_taplo_fixer.vader
+++ b/test/fixers/test_taplo_fixer.vader
@@ -1,0 +1,12 @@
+Before:
+  Save g:ale_taplo_executable
+
+After:
+  Restore
+
+Execute(The taplo fixer should use the options you set):
+  let g:ale_taplo_executable = 'foo'
+
+  AssertEqual
+  \ {'command': ale#Escape('foo') . ' format -'},
+  \ ale#fixers#taplo#Fix(bufnr(''))


### PR DESCRIPTION
This adds basic support for formatting TOML files using taplo.

Eventually, I would like to add support for taplo's linting, if I can figure out how to parse the output correctly.

Taplo also has an lsp, and when I added it, ale didn't complain and it appeared to be running, but I couldn't tell if it was doing anything.