### PR TITLE
Fix 4721 - force latex language id on cspell for tex filetype

### DIFF
--- a/autoload/ale/handlers/cspell.vim
+++ b/autoload/ale/handlers/cspell.vim
@@ -11,12 +11,27 @@ function! ale#handlers#cspell#GetExecutable(buffer) abort
     \)
 endfunction
 
+function! ale#handlers#cspell#GetLanguageId(buffer) abort
+    let l:filetype = getbufvar(a:buffer, '&filetype')
+
+    if l:filetype is# 'tex'
+        " Vim's tex corresponds to latex language-id in cspell
+        return 'latex'
+    elseif l:filetype is# 'plaintex'
+        " Vim's plaintex corresponds to tex language-id in cspell
+        return 'tex'
+    else
+        " Fallback to filetype for everything else.
+        return l:filetype
+    endif
+endfunction
+
 function! ale#handlers#cspell#GetCommand(buffer) abort
     let l:executable = ale#handlers#cspell#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'cspell_options')
-    let l:filetype = getbufvar(a:buffer, '&filetype')
+    let l:language_id = ale#handlers#cspell#GetLanguageId(a:buffer)
 
-    let l:language_id_option = empty(l:filetype) ? '' : '--language-id="' . l:filetype . '"'
+    let l:language_id_option = empty(l:language_id) ? '' : '--language-id="' . l:language_id . '"'
 
     return ale#node#Executable(a:buffer, l:executable)
     \   . ' lint --no-color --no-progress --no-summary'

--- a/test/linter/test_cspell.vader
+++ b/test/linter/test_cspell.vader
@@ -29,7 +29,7 @@ Execute(The global executable should be used when the local one cannot be found)
   AssertLinter
   \  'cspell',
   \  ale#Escape('cspell')
-  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="latex" -- stdin'
 
 Execute(Should use the node_modules/.bin executable if available):
   call ale#test#SetFilename('../test-files/cspell/node-modules/test.tex')
@@ -39,7 +39,7 @@ Execute(Should use the node_modules/.bin executable if available):
   \    . '/../test-files/cspell/node-modules/node_modules/.bin/cspell'),
   \  ale#Escape(ale#path#Simplify(g:dir
   \    . '/../test-files/cspell/node-modules/node_modules/.bin/cspell'))
-  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="latex" -- stdin'
 
 Execute(Should use the node_modules/cspell executable if available):
   call ale#test#SetFilename('../test-files/cspell/node-modules-2/test.tex')
@@ -50,7 +50,7 @@ Execute(Should use the node_modules/cspell executable if available):
   \  (has('win32') ? 'node.exe ': '')
   \  . ale#Escape(ale#path#Simplify(g:dir
   \    . '/../test-files/cspell/node-modules-2/node_modules/cspell/bin.js'))
-  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="latex" -- stdin'
 
 Execute(Should let users configure a global executable and override local paths):
   let g:ale_cspell_executable = '/path/to/custom/cspell'
@@ -59,7 +59,7 @@ Execute(Should let users configure a global executable and override local paths)
   AssertLinter
   \  '/path/to/custom/cspell',
   \  ale#Escape('/path/to/custom/cspell')
-  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="latex" -- stdin'
 
 Execute(Additional cspell options should be configurable):
   call ale#test#SetFilename('../test-files/dummy')
@@ -69,7 +69,37 @@ Execute(Additional cspell options should be configurable):
   AssertLinter
   \  'cspell',
   \  ale#Escape('cspell')
-  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" --foobar -- stdin'
+  \  . ' lint --no-color --no-progress --no-summary --language-id="latex" --foobar -- stdin'
+
+Execute(The language id should be tex when filetype is plaintex):
+  set filetype=plaintex
+
+  AssertLinter
+  \  'cspell',
+  \  ale#Escape('cspell')
+  \  . ' lint --no-color --no-progress --no-summary --language-id="tex" -- stdin'
+
+Execute(The language id should be equal to filetype when not tex or plaintex):
+  set filetype=markdown
+
+  AssertLinter
+  \  'cspell',
+  \  ale#Escape('cspell')
+  \  . ' lint --no-color --no-progress --no-summary --language-id="markdown" -- stdin'
+
+  set filetype=asciidoc
+
+  AssertLinter
+  \  'cspell',
+  \  ale#Escape('cspell')
+  \  . ' lint --no-color --no-progress --no-summary --language-id="asciidoc" -- stdin'
+
+  set filetype=html
+
+  AssertLinter
+  \  'cspell',
+  \  ale#Escape('cspell')
+  \  . ' lint --no-color --no-progress --no-summary --language-id="html" -- stdin'
 
 Execute(The language id should not specified when filetype is empty):
   set filetype=


### PR DESCRIPTION
This PR forces `latex` language-id in cspell linter when filetype is `tex`.


Fixes #4721
