### PR TITLE
Set working directory for Elvis linter

### DIFF
--- a/ale_linters/erlang/elvis.vim
+++ b/ale_linters/erlang/elvis.vim
@@ -26,9 +26,27 @@ function! s:AbbreviateMessage(text) abort
 endfunction
 
 function! s:GetCommand(buffer) abort
-    let l:file = ale#Escape(expand('#' . a:buffer . ':.'))
+    let l:cwd = s:GetCwd(a:buffer)
 
-    return '%e rock --output-format=parsable ' . l:file
+    let l:file = !empty(l:cwd)
+    \   ? expand('#' . a:buffer . ':p')[len(l:cwd) + 1:]
+    \   : expand('#' . a:buffer . ':.')
+
+    return '%e rock --output-format=parsable ' . ale#Escape(l:file)
+endfunction
+
+function! s:GetCwd(buffer) abort
+    let l:markers = ['elvis.config', 'rebar.lock', 'erlang.mk']
+
+    for l:path in ale#path#Upwards(expand('#' . a:buffer . ':p:h'))
+        for l:marker in l:markers
+            if filereadable(l:path . '/' . l:marker)
+                return l:path
+            endif
+        endfor
+    endfor
+
+    return ''
 endfunction
 
 call ale#linter#Define('erlang', {
@@ -36,5 +54,6 @@ call ale#linter#Define('erlang', {
 \   'callback': 'ale_linters#erlang#elvis#Handle',
 \   'executable': {b -> ale#Var(b, 'erlang_elvis_executable')},
 \   'command': function('s:GetCommand'),
+\   'cwd': function('s:GetCwd'),
 \   'lint_file': 1,
 \})

--- a/test/linter/test_erlang_elvis.vader
+++ b/test/linter/test_erlang_elvis.vader
@@ -1,16 +1,52 @@
 Before:
-  let b:file = fnamemodify(bufname(''), ':.')
   call ale#assert#SetUpLinterTest('erlang', 'elvis')
 
 After:
+  unlet! b:root
+
   call ale#assert#TearDownLinterTest()
 
 Execute(Default command should be correct):
   AssertLinter 'elvis',
-  \ ale#Escape('elvis') . ' rock --output-format=parsable ' . ale#Escape(b:file)
+  \ ale#Escape('elvis') . ' rock --output-format=parsable '
+  \ . ale#Escape(expand('%:.'))
 
 Execute(Executable should be configurable):
   let b:ale_erlang_elvis_executable = '/path/to/elvis'
 
   AssertLinter '/path/to/elvis',
-  \ ale#Escape('/path/to/elvis') . ' rock --output-format=parsable ' . ale#Escape(b:file)
+  \ ale#Escape('/path/to/elvis') . ' rock --output-format=parsable '
+  \ . ale#Escape(expand('%:.'))
+
+Execute(Project root should be detected using elvis.config):
+  let b:root = '../test-files/erlang/app_with_elvis_config'
+
+  call ale#test#SetFilename(b:root . '/src/app.erl')
+  AssertLinter 'elvis',
+  \ ale#Escape('elvis') . ' rock --output-format=parsable '
+  \ . ale#Escape(ale#path#Simplify('src/app.erl'))
+  AssertLinterCwd ale#test#GetFilename(b:root)
+
+Execute(Root of Rebar3 project should be detected):
+  let b:root = '../test-files/erlang/rebar3_app'
+
+  call ale#test#SetFilename(b:root . '/src/app.erl')
+  AssertLinter 'elvis',
+  \ ale#Escape('elvis') . ' rock --output-format=parsable '
+  \ . ale#Escape(ale#path#Simplify('src/app.erl'))
+  AssertLinterCwd ale#test#GetFilename(b:root)
+
+  call ale#test#SetFilename(b:root . '/_checkouts/dep/src/dep.erl')
+  AssertLinter 'elvis',
+  \ ale#Escape('elvis') . ' rock --output-format=parsable '
+  \ . ale#Escape(ale#path#Simplify('src/dep.erl'))
+  AssertLinterCwd ale#test#GetFilename(b:root . '/_checkouts/dep')
+
+Execute(Root of Erlang.mk project should be detected):
+  let b:root = '../test-files/erlang/erlang_mk_app'
+
+  call ale#test#SetFilename(b:root . '/src/app.erl')
+  AssertLinter 'elvis',
+  \ ale#Escape('elvis') . ' rock --output-format=parsable '
+  \ . ale#Escape(ale#path#Simplify('src/app.erl'))
+  AssertLinterCwd ale#test#GetFilename(b:root)


### PR DESCRIPTION
Most of the time it works to assume that the current working directory is the root of the project.  However, this is not the case for Rebar3 checked out dependencies, for example.

It's also worth noting that because of the way Elvis handles file patterns, and because directories in configuration are relative to the project root, the path supplied to command must be also relative.