### PR TITLE
Fix chktex highlighting wrong column when using tabs instead of spaces

### DIFF
--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -4,14 +4,18 @@
 call ale#Set('tex_chktex_executable', 'chktex')
 call ale#Set('tex_chktex_options', '-I')
 
-function! ale_linters#tex#chktex#GetCommand(buffer) abort
+function! ale_linters#tex#chktex#GetExecutable(buffer) abort
+    return ale#Var(a:buffer, 'tex_chktex_executable')
+endfunction
+
+function! ale_linters#tex#chktex#GetCommand(buffer, version) abort
     let l:options = ''
 
     " Avoid bug when used without -p (last warning has gibberish for a filename)
     let l:options .= ' -v0 -p stdin -q'
 
     " Avoid bug of reporting wrong column when using tabs (issue #723)
-    if system('chktex -S') !~? 'invalid option'
+    if ale#semver#GTE(a:version, [1, 7, 7])
         let l:options .= ' -S TabSize=1'
     endif
 
@@ -49,7 +53,12 @@ endfunction
 
 call ale#linter#Define('tex', {
 \   'name': 'chktex',
-\   'executable': {b -> ale#Var(b, 'tex_chktex_executable')},
-\   'command': function('ale_linters#tex#chktex#GetCommand'),
+\   'executable': function('ale_linters#tex#chktex#GetExecutable'),
+\   'command': {buffer -> ale#semver#RunWithVersionCheck(
+\       buffer,
+\       ale_linters#tex#chktex#GetExecutable(buffer),
+\       '%e --version',
+\       function('ale_linters#tex#chktex#GetCommand'),
+\   )},
 \   'callback': 'ale_linters#tex#chktex#Handle'
 \})

--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -9,8 +9,11 @@ function! ale_linters#tex#chktex#GetCommand(buffer) abort
 
     " Avoid bug when used without -p (last warning has gibberish for a filename)
     let l:options .= ' -v0 -p stdin -q'
+
     " Avoid bug of reporting wrong column when using tabs (issue #723)
-    let l:options .= ' -S TabSize=1'
+    if system('chktex -S') !~? 'invalid option'
+        let l:options .= ' -S TabSize=1'
+    endif
 
     " Check for optional .chktexrc
     let l:chktex_config = ale#path#FindNearestFile(a:buffer, '.chktexrc')

--- a/ale_linters/tex/chktex.vim
+++ b/ale_linters/tex/chktex.vim
@@ -10,7 +10,7 @@ function! ale_linters#tex#chktex#GetCommand(buffer) abort
     " Avoid bug when used without -p (last warning has gibberish for a filename)
     let l:options .= ' -v0 -p stdin -q'
     " Avoid bug of reporting wrong column when using tabs (issue #723)
-    let l:options .= ' -s TabSize=1'
+    let l:options .= ' -S TabSize=1'
 
     " Check for optional .chktexrc
     let l:chktex_config = ale#path#FindNearestFile(a:buffer, '.chktexrc')

--- a/test/linter/test_tex_chktex.vader
+++ b/test/linter/test_tex_chktex.vader
@@ -1,21 +1,44 @@
 Before:
   call ale#assert#SetUpLinterTest('tex', 'chktex')
 
+  GivenCommandOutput ['ChkTeX v1.7.6 - Copyright 1995-96 Jens T. Berger Thielemann']
+
 After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'chktex',
+  AssertLinter 'chktex', [
+  \ ale#Escape('chktex') . ' --version',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q -S TabSize=1'
-  \   . ' -I'
+  \   . ' -v0 -p stdin -q'
+  \   . ' -I',
+  \]
+
+  " The version check should be cached.
+  GivenCommandOutput []
+  AssertLinter 'chktex', [
+  \ ale#Escape('chktex')
+  \   . ' -v0 -p stdin -q'
+  \   . ' -I',
+  \]
+
+  " Try newer version
+  call ale#semver#ResetVersionCache()
+  GivenCommandOutput ['ChkTeX v1.7.8 - Copyright 1995-96 Jens T. Berger Thielemann']
+  AssertLinter 'chktex', [
+  \ ale#Escape('chktex') . ' --version',
+  \ ale#Escape('chktex')
+  \   . ' -v0 -p stdin -q'
+  \   . ' -S TabSize=1'
+  \   . ' -I',
+  \]
 
 Execute(The executable should be configurable):
   let g:ale_tex_chktex_executable = 'bin/foo'
 
   AssertLinter 'bin/foo',
   \ ale#Escape('bin/foo')
-  \   . ' -v0 -p stdin -q -S TabSize=1'
+  \   . ' -v0 -p stdin -q'
   \   . ' -I'
 
 Execute(The options should be configurable):
@@ -23,5 +46,5 @@ Execute(The options should be configurable):
 
   AssertLinter 'chktex',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q -S TabSize=1'
+  \   . ' -v0 -p stdin -q'
   \   . ' --something'

--- a/test/linter/test_tex_chktex.vader
+++ b/test/linter/test_tex_chktex.vader
@@ -7,7 +7,7 @@ After:
 Execute(The default command should be correct):
   AssertLinter 'chktex',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q -s TabSize=1'
+  \   . ' -v0 -p stdin -q -S TabSize=1'
   \   . ' -I'
 
 Execute(The executable should be configurable):
@@ -15,7 +15,7 @@ Execute(The executable should be configurable):
 
   AssertLinter 'bin/foo',
   \ ale#Escape('bin/foo')
-  \   . ' -v0 -p stdin -q -s TabSize=1'
+  \   . ' -v0 -p stdin -q -S TabSize=1'
   \   . ' -I'
 
 Execute(The options should be configurable):
@@ -23,5 +23,5 @@ Execute(The options should be configurable):
 
   AssertLinter 'chktex',
   \ ale#Escape('chktex')
-  \   . ' -v0 -p stdin -q -s TabSize=1'
+  \   . ' -v0 -p stdin -q -S TabSize=1'
   \   . ' --something'


### PR DESCRIPTION
<sup>Repetition of #4661, taking into account #4712</sup>

Fixes #723

chktex implemented [bug #56486: Allow setting options on the command line][1]
Thanks to that we can tell it to treat tab character as of one space width, i.e. one char.
That means, after we translate the output back to Vim columns, we get correct numbers.

[1]: https://savannah.nongnu.org/bugs/?56486