### PR TITLE
Fix: ruff version `0.3.0` cli breaking changes

### DIFF
--- a/ale_linters/python/ruff.vim
+++ b/ale_linters/python/ruff.vim
@@ -45,6 +45,10 @@ function! ale_linters#python#ruff#GetCommand(buffer, version) abort
     \   ? ' run ruff'
     \   : ''
 
+    " NOTE: ruff 0.3.0 deprecates `ruff <path>` in favor of `ruff check <path>`
+    let l:exec_args = l:exec_args
+    \   . (ale#semver#GTE(a:version, [0, 3, 0]) ? ' check' : '')
+
     " NOTE: ruff version `0.0.69` supports liniting input from stdin
     " NOTE: ruff version `0.1.0` deprecates `--format text`
     return ale#Escape(l:executable) . l:exec_args . ' -q'

--- a/test/linter/test_ruff.vader
+++ b/test/linter/test_ruff.vader
@@ -42,6 +42,13 @@ Execute(ruff should run with the stdin in new enough versions):
   AssertLinter 'ruff', b:command_head . b:command_tail[:-3] . ' -'
   " AssertLinter 'ruff', b:command_head . b:command_tail[:-3] . '--format json-lines -'
 
+Execute(ruff should run with the check subcmd in versions >= 0.3.0):
+  GivenCommandOutput ['ruff 0.3.0']
+
+  AssertLinterCwd expand('%:p:h')
+  let b:cmd_head = ale#Escape('ruff') . ' check -q'
+  AssertLinter 'ruff', b:cmd_head . ' --output-format json-lines --stdin-filename %s -'
+
 Execute(The option for disabling changing directories should work):
   let g:ale_python_ruff_change_directory = 0
 


### PR DESCRIPTION
This commit appends `check` to the ruff executable if the version of specified ruff executable is `>= 0.3.0`, as ruff version `0.3.0` deprecates `ruff <path>` in favor of `ruff check <path>`:

https://github.com/astral-sh/ruff/releases/tag/v0.3.0

