### PR TITLE
Fix biome formatter

### DIFF
--- a/autoload/ale/fixers/biome.vim
+++ b/autoload/ale/fixers/biome.vim
@@ -3,7 +3,7 @@ function! ale#fixers#biome#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'biome_options')
 
     return {
-    \   'command': '%e format'
+    \   'command': ale#Escape(l:executable) . ' format'
     \       . (!empty(l:options) ? ' ' . l:options : '')
     \       . ' --stdin-file-path=%s',
     \}

--- a/test/fixers/test_biome_fixer_callback.vader
+++ b/test/fixers/test_biome_fixer_callback.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#assert#SetUpFixerTest('typescript', 'biome')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute(The default biome command should be correct):
+  call ale#test#SetFilename('../test-files/typescript/test.ts')
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape('biome')
+  \     . ' format --stdin-file-path=%s'
+  \ }
+


### PR DESCRIPTION
I believe a bug was introduced to the biome fix command in this [PR](https://github.com/dense-analysis/ale/pull/4705/files#diff-619c20c541c9e30cad363d4db4b49a42025ee3dd5bd52703c62b5074f41d76d8R6)

This update adds the correct executable to the biome#Fix command.

* Added a fixer test


