### PR TITLE
Added fix subcommand options

### DIFF
--- a/autoload/ale/fixers/php_cs_fixer.vim
+++ b/autoload/ale/fixers/php_cs_fixer.vim
@@ -4,6 +4,7 @@
 call ale#Set('php_cs_fixer_executable', 'php-cs-fixer')
 call ale#Set('php_cs_fixer_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('php_cs_fixer_options', '')
+call ale#Set('php_cs_fixer_fix_options', '')
 
 function! ale#fixers#php_cs_fixer#GetExecutable(buffer) abort
     return ale#path#FindExecutable(a:buffer, 'php_cs_fixer', [
@@ -18,7 +19,8 @@ function! ale#fixers#php_cs_fixer#Fix(buffer) abort
     return {
     \   'command': ale#Escape(l:executable)
     \       . ' ' . ale#Var(a:buffer, 'php_cs_fixer_options')
-    \       . ' fix %t',
+    \       . ' fix ' . ale#Var(a:buffer, 'php_cs_fixer_fix_options')
+    \       . ' %t',
     \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_php_cs_fixer.vader
+++ b/test/fixers/test_php_cs_fixer.vader
@@ -1,8 +1,10 @@
 Before:
   Save g:ale_php_cs_fixer_executable
   Save g:ale_php_cs_fixer_options
+  Save g:ale_php_cs_fixer_fix_options
   let g:ale_php_cs_fixer_executable = 'php-cs-fixer'
   let g:ale_php_cs_fixer_options = ''
+  let g:ale_php_cs_fixer_fix_options = ''
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
 
@@ -45,18 +47,20 @@ Execute(The php-cs-fixer callback should return the correct default values):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape('php-cs-fixer')
   \      . ' ' . g:ale_php_cs_fixer_options
-  \      . ' fix %t'
+  \      . ' fix ' . g:ale_php_cs_fixer_fix_options
+  \      . ' %t'
   \ },
   \ ale#fixers#php_cs_fixer#Fix(bufnr(''))
 
 Execute(The php-cs-fixer callback should include custom php-cs-fixer options):
-  let g:ale_php_cs_fixer_options = '--config="$HOME/.php_cs"'
+  let g:ale_php_cs_fixer_options = '-nq'
+  let g:ale_php_cs_fixer_fix_options = '--config="$HOME/.php_cs"'
   call ale#test#SetFilename('../test-files/php/project-without-php-cs-fixer/test.php')
 
   AssertEqual
   \ {
   \   'command': ale#Escape(g:ale_php_cs_fixer_executable)
-  \     . ' --config="$HOME/.php_cs" fix %t',
+  \     . ' -nq fix --config="$HOME/.php_cs" %t',
   \   'read_temporary_file': 1,
   \ },
   \ ale#fixers#php_cs_fixer#Fix(bufnr(''))


### PR DESCRIPTION
php-cs-fixer command line options are ordered. Options that appear after the main command are applied to the main command. Options that appear after the subcommands are applied to the subcommands. Baseline behavior will not apply a custom configuration. 

```
// Does not work
php-cs-fixer --config ./custom-config.php fix target-file.php
```

That option must be applied to the fix subcommand. 

```
// Works!
php-cs-fixer fix --config ./custom-config.php target-file.php
```

This change enables a user to fix options (like --config) in addition to base command options (like -nq).

After this change a user can set:

```
  let g:ale_php_cs_fixer_fix_options = '--config ' . fnamemodify(findfile('.php-cs-fixer.php', './;'), ':p')
```

in `init.vim` and php-cs-fixer will behave like eslint. A more sophisticated fixer definition might try to apply this strategy for finding the configuration before falling back to default behavior if no configuration is found.