### PR TITLE
Make cmake-lint read .cmake-format config file

### DIFF
--- a/ale_linters/cmake/cmake_lint.vim
+++ b/ale_linters/cmake/cmake_lint.vim
@@ -15,7 +15,7 @@ function! ale_linters#cmake#cmake_lint#Command(buffer) abort
     let l:executable = ale_linters#cmake#cmake_lint#Executable(a:buffer)
     let l:options = ale#Var(a:buffer, 'cmake_cmake_lint_options')
 
-    return ale#Escape(l:executable) . ' ' . l:options . ' %t'
+    return ale#Escape(l:executable) . ' ' . l:options . ' %s'
 endfunction
 
 function! ale_linters#cmake#cmake_lint#Handle(buffer, lines) abort

--- a/test/linter/test_cmake_cmake_lint.vader
+++ b/test/linter/test_cmake_cmake_lint.vader
@@ -5,9 +5,9 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default command should be correct):
-  AssertLinter 'cmake-lint', ale#Escape('cmake-lint') . '  %t'
+  AssertLinter 'cmake-lint', ale#Escape('cmake-lint') . '  %s'
 
 Execute(The executable should be configurable):
   let g:ale_cmake_cmake_lint_executable = 'foobar'
 
-  AssertLinter 'foobar', ale#Escape('foobar') . '  %t'
+  AssertLinter 'foobar', ale#Escape('foobar') . '  %s'


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

`cmake-lint` reads config file based on passed filepaths, so when `%t` is used, `cmake-lint` won't read `$PWD/.cmake-format`. So using `%s` will fix it.

Like #3725, `cmake-lint` seems to support `-` for input, but its implementation has a bug caused by [these lines](https://github.com/cheshirekow/cmake_format/blob/v0.6.13/cmakelang/lint/__main__.py#L147-L148), so we can't use it now.

``` console
$ cmake-lint - < CMakeLists.txt
ERROR An internal error occured. Please consider filing a bug report at github.com/cheshirekow/cmakelang/issues
Traceback (most recent call last):
  File "/Users/yous/.local/share/mise/installs/python/3.12.2/lib/python3.12/site-packages/cmakelang/lint/__main__.py", line 185, in main
    return inner_main()
           ^^^^^^^^^^^^
  File "/Users/yous/.local/share/mise/installs/python/3.12.2/lib/python3.12/site-packages/cmakelang/lint/__main__.py", line 170, in inner_main
    outfile.write("{}\n{}\n".format(infile_path, "=" * len(infile_path)))
                                                       ^^^^^^^^^^^^^^^^
TypeError: object of type 'int' has no len()
$ cmake-lint --suppress-decoration - < CMakeLists.txt
ERROR An internal error occured. Please consider filing a bug report at github.com/cheshirekow/cmakelang/issues
Traceback (most recent call last):
  File "/Users/yous/.local/share/mise/installs/python/3.12.2/lib/python3.12/site-packages/cmakelang/lint/__main__.py", line 185, in main
    return inner_main()
           ^^^^^^^^^^^^
  File "/Users/yous/.local/share/mise/installs/python/3.12.2/lib/python3.12/site-packages/cmakelang/lint/__main__.py", line 171, in inner_main
    local_ctx.writeout(outfile)
  File "/Users/yous/.local/share/mise/installs/python/3.12.2/lib/python3.12/site-packages/cmakelang/lint/lint_util.py", line 127, in writeout
    outfile.write("{:s}:{}\n".format(self.infile_path, record))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Unknown format code 's' for object of type 'int'
```