### PR TITLE
Implement listing all returned results for LSP textDocument/implements

### DIFF
--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -68,6 +68,15 @@ function! ale#definition#HandleTSServerResponse(conn_id, response) abort
             if empty(l:item_list)
                 call ale#util#Execute('echom ''No definitions found''')
             elseif len(l:item_list) == 1
+                let l:filename = l:item_list[0].filename
+                if get(l:options, 'open_in') is# 'quickfix'
+                    let l:line = l:item_list[0].lnum
+                    let l:column = l:item_list[0].col
+                else
+                    let l:line = l:item_list[0].line
+                    let l:column = l:item_list[0].column
+                endif
+
                 call ale#definition#UpdateTagStack()
                 call ale#util#Open(l:filename, l:line, l:column, l:options)
             else
@@ -138,6 +147,15 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
         elseif len(l:item_list) == 1
             call ale#definition#UpdateTagStack()
 
+            let l:uri = ale#util#ToURI(l:item_list[0].filename)
+            if get(l:options, 'open_in') is# 'quickfix'
+                let l:line = l:item_list[0].lnum
+                let l:column = l:item_list[0].col
+            else
+                let l:line = l:item_list[0].line
+                let l:column = l:item_list[0].column
+            endif
+
             let l:uri_handler = ale#uri#GetURIHandler(l:uri)
 
             if l:uri_handler is# v:null
@@ -152,6 +170,7 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
                 call setqflist(l:item_list, 'a')
                 call ale#util#Execute('cc 1')
             else
+                call ale#definition#UpdateTagStack()
                 call ale#preview#ShowSelection(l:item_list, l:options)
             endif
         endif

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -85,6 +85,7 @@ function! ale#definition#HandleTSServerResponse(conn_id, response) abort
                     call setqflist(l:item_list, 'a')
                     call ale#util#Execute('cc 1')
                 else
+                    call ale#definition#UpdateTagStack()
                     call ale#preview#ShowSelection(l:item_list, l:options)
                 endif
             endif

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -35,19 +35,79 @@ function! ale#definition#UpdateTagStack() abort
     endif
 endfunction
 
+function! ale#definition#FormatTSServerResponse(response_item, options) abort
+    if get(a:options, 'open_in') is# 'quickfix'
+        return {
+            \ 'filename': a:response_item.file,
+            \ 'lnum': a:response_item.start.line,
+            \ 'col': a:response_item.start.offset,
+            \}
+    else
+        return {
+            \ 'filename': a:response_item.file,
+            \ 'line': a:response_item.start.line,
+            \ 'column': a:response_item.start.offset,
+            \}
+    endif
+endfunction
+
 function! ale#definition#HandleTSServerResponse(conn_id, response) abort
     if has_key(a:response, 'request_seq')
     \&& has_key(s:go_to_definition_map, a:response.request_seq)
         let l:options = remove(s:go_to_definition_map, a:response.request_seq)
 
         if get(a:response, 'success', v:false) is v:true && !empty(a:response.body)
-            let l:filename = a:response.body[0].file
-            let l:line = a:response.body[0].start.line
-            let l:column = a:response.body[0].start.offset
+            let l:item_list = []
 
-            call ale#definition#UpdateTagStack()
-            call ale#util#Open(l:filename, l:line, l:column, l:options)
+            for l:response_item in a:response.body.refs
+                call add(l:item_list,
+                            \ ale#definition#FormatTSServerResponse(l:response_item, l:options)
+                            \)
+            endfor
+
+            if empty(l:item_list)
+                call ale#util#Execute('echom ''No definitions found''')
+            elseif len(l:item_list) == 1
+                call ale#definition#UpdateTagStack()
+                call ale#util#Open(l:filename, l:line, l:column, l:options)
+            else
+                if get(l:options, 'open_in') is# 'quickfix'
+                    call setqflist([], 'r')
+                    call setqflist(l:item_list, 'a')
+                    call ale#util#Execute('cc 1')
+                else
+                    call ale#preview#ShowSelection(l:item_list, l:options)
+                endif
+            endif
         endif
+    endif
+endfunction
+
+function! ale#definition#FormatLSPResponse(response_item, options) abort
+    if has_key(a:response_item, 'targetUri')
+        " LocationLink items use targetUri
+        let l:uri = a:response_item.targetUri
+        let l:line = a:response_item.targetRange.start.line + 1
+        let l:column = a:response_item.targetRange.start.character + 1
+    else
+        " LocationLink items use uri
+        let l:uri = a:response_item.uri
+        let l:line = a:response_item.range.start.line + 1
+        let l:column = a:response_item.range.start.character + 1
+    endif
+
+    if get(a:options, 'open_in') is# 'quickfix'
+        return {
+            \ 'filename': ale#util#ToResource(l:uri),
+            \ 'lnum': l:line,
+            \ 'col': l:column,
+            \}
+    else
+        return {
+            \ 'filename': ale#util#ToResource(l:uri),
+            \ 'line': l:line,
+            \ 'column': l:column,
+            \}
     endif
 endfunction
 
@@ -65,19 +125,17 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
             let l:result = []
         endif
 
-        for l:item in l:result
-            if has_key(l:item, 'targetUri')
-                " LocationLink items use targetUri
-                let l:uri = l:item.targetUri
-                let l:line = l:item.targetRange.start.line + 1
-                let l:column = l:item.targetRange.start.character + 1
-            else
-                " LocationLink items use uri
-                let l:uri = l:item.uri
-                let l:line = l:item.range.start.line + 1
-                let l:column = l:item.range.start.character + 1
-            endif
+        let l:item_list = []
 
+        for l:response_item in l:result
+            call add(l:item_list,
+                        \ ale#definition#FormatLSPResponse(l:response_item, l:options)
+                        \)
+        endfor
+
+        if empty(l:item_list)
+            call ale#util#Execute('echom ''No definitions found''')
+        elseif len(l:item_list) == 1
             call ale#definition#UpdateTagStack()
 
             let l:uri_handler = ale#uri#GetURIHandler(l:uri)
@@ -88,9 +146,15 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
             else
                 call l:uri_handler.OpenURILink(l:uri, l:line, l:column, l:options, a:conn_id)
             endif
-
-            break
-        endfor
+        else
+            if get(l:options, 'open_in') is# 'quickfix'
+                call setqflist([], 'r')
+                call setqflist(l:item_list, 'a')
+                call ale#util#Execute('cc 1')
+            else
+                call ale#preview#ShowSelection(l:item_list, l:options)
+            endif
+        endif
     endif
 endfunction
 

--- a/autoload/ale/definition.vim
+++ b/autoload/ale/definition.vim
@@ -38,16 +38,16 @@ endfunction
 function! ale#definition#FormatTSServerResponse(response_item, options) abort
     if get(a:options, 'open_in') is# 'quickfix'
         return {
-            \ 'filename': a:response_item.file,
-            \ 'lnum': a:response_item.start.line,
-            \ 'col': a:response_item.start.offset,
-            \}
+        \ 'filename': a:response_item.file,
+        \ 'lnum': a:response_item.start.line,
+        \ 'col': a:response_item.start.offset,
+        \}
     else
         return {
-            \ 'filename': a:response_item.file,
-            \ 'line': a:response_item.start.line,
-            \ 'column': a:response_item.start.offset,
-            \}
+        \ 'filename': a:response_item.file,
+        \ 'line': a:response_item.start.line,
+        \ 'column': a:response_item.start.offset,
+        \}
     endif
 endfunction
 
@@ -59,16 +59,18 @@ function! ale#definition#HandleTSServerResponse(conn_id, response) abort
         if get(a:response, 'success', v:false) is v:true && !empty(a:response.body)
             let l:item_list = []
 
-            for l:response_item in a:response.body.refs
-                call add(l:item_list,
-                            \ ale#definition#FormatTSServerResponse(l:response_item, l:options)
-                            \)
+            for l:response_item in a:response.body
+                call add(
+                \ l:item_list,
+                \ ale#definition#FormatTSServerResponse(l:response_item, l:options)
+                \)
             endfor
 
             if empty(l:item_list)
                 call ale#util#Execute('echom ''No definitions found''')
             elseif len(l:item_list) == 1
                 let l:filename = l:item_list[0].filename
+
                 if get(l:options, 'open_in') is# 'quickfix'
                     let l:line = l:item_list[0].lnum
                     let l:column = l:item_list[0].col
@@ -108,16 +110,16 @@ function! ale#definition#FormatLSPResponse(response_item, options) abort
 
     if get(a:options, 'open_in') is# 'quickfix'
         return {
-            \ 'filename': ale#util#ToResource(l:uri),
-            \ 'lnum': l:line,
-            \ 'col': l:column,
-            \}
+        \ 'filename': ale#util#ToResource(l:uri),
+        \ 'lnum': l:line,
+        \ 'col': l:column,
+        \}
     else
         return {
-            \ 'filename': ale#util#ToResource(l:uri),
-            \ 'line': l:line,
-            \ 'column': l:column,
-            \}
+        \ 'filename': ale#util#ToResource(l:uri),
+        \ 'line': l:line,
+        \ 'column': l:column,
+        \}
     endif
 endfunction
 
@@ -139,8 +141,8 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
 
         for l:response_item in l:result
             call add(l:item_list,
-                        \ ale#definition#FormatLSPResponse(l:response_item, l:options)
-                        \)
+            \ ale#definition#FormatLSPResponse(l:response_item, l:options)
+            \)
         endfor
 
         if empty(l:item_list)
@@ -149,6 +151,7 @@ function! ale#definition#HandleLSPResponse(conn_id, response) abort
             call ale#definition#UpdateTagStack()
 
             let l:uri = ale#util#ToURI(l:item_list[0].filename)
+
             if get(l:options, 'open_in') is# 'quickfix'
                 let l:line = l:item_list[0].lnum
                 let l:column = l:item_list[0].col

--- a/test/test_go_to_definition.vader
+++ b/test/test_go_to_definition.vader
@@ -458,19 +458,15 @@ Execute(Definition responses with lists should be handled):
   \ }
   \)
 
-  AssertEqual
-  \ [
-  \   'edit +3 ' . fnameescape(ale#path#Simplify(g:dir . '/completion_dummy_file')),
-  \ ],
-  \ g:expr_list
-  AssertEqual [3, 8], getpos('.')[1:2]
+  " Multiple results should either open the ALEPreview or go to quickfix
+  AssertEqual [1, 1], getpos('.')[1:2]
   AssertEqual {}, ale#definition#GetMap()
 
 Execute(Definition responses with null response should be handled):
   call ale#definition#SetMap({3: {'open_in': 'current-buffer'}})
   call ale#definition#HandleLSPResponse(1, {'id': 3, 'result': v:null})
 
-  AssertEqual [], g:expr_list
+  AssertEqual ['echom ''No definitions found'''], g:expr_list
 
 Execute(LSP definition requests should be sent):
   runtime ale_linters/python/pylsp.vim


### PR DESCRIPTION
This PR  has the intention of implementing the list feature for `:ALEGoToDefinition` and `:ALEGoToImplementation`. Specially `:ALEGoToImplementation`. There are times a LSP may return multiple results for the `textDocument/implementation` command. This is true when we try to find implementations of an abstract class or interface. The way ALE is implemented, only the first result is returned.

Take this example.

foobar.go:
```go
type Foobarer interface {
    Do() bool
}
```

foobar_a.go
```go
type FoobarA struct {
   foo int
}

func (f *FoobarA) Do() bool {
   fmt.Printf("This foobar is int (%d)\n", f.foo)
   return true
}
```

another_foobar.go
```go
type AnotherFoobar struct {
   foo bool
}

func (f *AnotherFoobar) Do() bool {
   fmt.Printf("This foobar is bool (%v)\n", f.foo)
   return f.foo
}
```

When trying to find implementations of the `Do` function, it will only find the one from `AnotherFoobar` struct (because the LSP returns in alphabetic order). But I could want the other one. This change fixes this behavior.

![Captura de tela 2024-04-14 221711](https://github.com/dense-analysis/ale/assets/1001525/08595464-6c54-4977-bc41-3b8d31b30386)


