### PR TITLE
Update dart analysis_server command

### DIFF
--- a/ale_linters/dart/analysis_server.vim
+++ b/ale_linters/dart/analysis_server.vim
@@ -15,9 +15,7 @@ function! ale_linters#dart#analysis_server#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'dart_analysis_server_executable')
     let l:dart = resolve(exepath(l:executable))
 
-    return '%e '
-    \   . fnamemodify(l:dart, ':h') . '/snapshots/analysis_server.dart.snapshot'
-    \   . ' --lsp'
+    return '%e language-server --protocol=lsp'
 endfunction
 
 call ale#linter#Define('dart', {

--- a/ale_linters/dart/analysis_server.vim
+++ b/ale_linters/dart/analysis_server.vim
@@ -1,7 +1,7 @@
 " Author: Nelson Yeung <nelsyeung@gmail.com>
 " Description: Check Dart files with dart analysis server LSP
 
-call ale#Set('dart_analysis_server_enable_language_server', 0)
+call ale#Set('dart_analysis_server_enable_language_server', 1)
 call ale#Set('dart_analysis_server_executable', 'dart')
 
 function! ale_linters#dart#analysis_server#GetProjectRoot(buffer) abort

--- a/ale_linters/dart/analysis_server.vim
+++ b/ale_linters/dart/analysis_server.vim
@@ -1,6 +1,7 @@
 " Author: Nelson Yeung <nelsyeung@gmail.com>
 " Description: Check Dart files with dart analysis server LSP
 
+call ale#Set('dart_analysis_server_enable_language_server', 0)
 call ale#Set('dart_analysis_server_executable', 'dart')
 
 function! ale_linters#dart#analysis_server#GetProjectRoot(buffer) abort
@@ -12,10 +13,19 @@ function! ale_linters#dart#analysis_server#GetProjectRoot(buffer) abort
 endfunction
 
 function! ale_linters#dart#analysis_server#GetCommand(buffer) abort
+    let l:language_server = ale#Var(a:buffer, 'dart_analysis_server_enable_language_server')
     let l:executable = ale#Var(a:buffer, 'dart_analysis_server_executable')
     let l:dart = resolve(exepath(l:executable))
+    let l:output = '%e '
+    \   . fnamemodify(l:dart, ':h') . '/snapshots/analysis_server.dart.snapshot'
+    \   . ' --lsp'
 
-    return '%e language-server --protocol=lsp'
+    " Enable new language-server command
+    if l:language_server == 1
+        let l:output = '%e language-server --protocol=lsp'
+    endif
+
+    return l:output
 endfunction
 
 call ale#linter#Define('dart', {

--- a/doc/ale-dart.txt
+++ b/doc/ale-dart.txt
@@ -27,6 +27,16 @@ g:ale_dart_analysis_server_executable   *g:ale_dart_analysis_server_executable*
   This variable can be set to change the path of dart.
 
 
+g:ale_dart_analysis_server_enable_language_server
+                            *g:ale_dart_analysis_server_enable_language_server*
+                            *b:ale_dart_analysis_server_enable_language_server*
+  Type: |Number|
+  Default: `0`
+
+  When set to `1`, ALE will use the new `dart language-server` command to
+  launch the language server.
+
+
 ===============================================================================
 dart-analyze                                                 *ale-dart-analyze*
 

--- a/doc/ale-dart.txt
+++ b/doc/ale-dart.txt
@@ -31,10 +31,11 @@ g:ale_dart_analysis_server_enable_language_server
                             *g:ale_dart_analysis_server_enable_language_server*
                             *b:ale_dart_analysis_server_enable_language_server*
   Type: |Number|
-  Default: `0`
+  Default: `1`
 
   When set to `1`, ALE will use the new `dart language-server` command to
-  launch the language server.
+  launch the language server. When set to `0`, ALE will use the original
+  `./snapshots/analysis_server.dart.snapshot --lsp` command.
 
 
 ===============================================================================

--- a/doc/ale-dart.txt
+++ b/doc/ale-dart.txt
@@ -33,9 +33,11 @@ g:ale_dart_analysis_server_enable_language_server
   Type: |Number|
   Default: `1`
 
-  When set to `1`, ALE will use the new `dart language-server` command to
-  launch the language server. When set to `0`, ALE will use the original
-  `./snapshots/analysis_server.dart.snapshot --lsp` command.
+  When set to `1`, ALE will use the new `dart language-server` command,
+  available from Dart version 2.16.0, to launch the language server. When set
+  to `0`, ALE will instead use the deprecated
+  `./snapshots/analysis_server.dart.snapshot --lsp` command used by older
+  versions of Dart.
 
 
 ===============================================================================

--- a/test/linter/test_dart_analysis_server.vader
+++ b/test/linter/test_dart_analysis_server.vader
@@ -6,10 +6,10 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'dart', ale#Escape('dart')
-  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'
+  \   . ' language-server --protocol=lsp'
 
 Execute(The executable should be configurable):
   let g:ale_dart_analysis_server_executable = 'foobar'
 
   AssertLinter 'foobar', ale#Escape('foobar')
-  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'
+  \   . ' language-server --protocol=lsp'

--- a/test/linter/test_dart_analysis_server.vader
+++ b/test/linter/test_dart_analysis_server.vader
@@ -6,16 +6,16 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'dart', ale#Escape('dart')
-  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'
+  \   . ' language-server --protocol=lsp'
 
 Execute(The executable should be configurable):
   let g:ale_dart_analysis_server_executable = 'foobar'
 
   AssertLinter 'foobar', ale#Escape('foobar')
-  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'
+  \   . ' language-server --protocol=lsp'
 
-Execute(Should be able to enable new language-server command):
-  let g:ale_dart_analysis_server_enable_language_server = 1
+Execute(Should be able to disable new language-server command):
+  let g:ale_dart_analysis_server_enable_language_server = 0
 
   AssertLinter 'dart', ale#Escape('dart')
-  \   . ' language-server --protocol=lsp'
+  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'

--- a/test/linter/test_dart_analysis_server.vader
+++ b/test/linter/test_dart_analysis_server.vader
@@ -6,10 +6,16 @@ After:
 
 Execute(The default command should be correct):
   AssertLinter 'dart', ale#Escape('dart')
-  \   . ' language-server --protocol=lsp'
+  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'
 
 Execute(The executable should be configurable):
   let g:ale_dart_analysis_server_executable = 'foobar'
 
   AssertLinter 'foobar', ale#Escape('foobar')
+  \   . ' ./snapshots/analysis_server.dart.snapshot --lsp'
+
+Execute(Should be able to enable new language-server command):
+  let g:ale_dart_analysis_server_enable_language_server = 1
+
+  AssertLinter 'dart', ale#Escape('dart')
   \   . ' language-server --protocol=lsp'


### PR DESCRIPTION
In 2021 the dart team added a new sub-command `language-server` to replace the original `./snapshots/analysis_server.dart.snapshot --lsp` convention for starting the language server.

The original convention does not work with the latest versions of dart.

* [Dart SDK Language Server Documentation](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md)
* https://github.com/dart-lang/sdk/commit/c224cc2e0d4cd8fc536c21ee963a0254d18a27bb
