### PR TITLE
fix(biome): run all enabled biome fixers

### DIFF
--- a/autoload/ale/fixers/biome.vim
+++ b/autoload/ale/fixers/biome.vim
@@ -1,10 +1,11 @@
 function! ale#fixers#biome#Fix(buffer) abort
     let l:executable = ale#handlers#biome#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'biome_options')
+    let l:apply = ale#Var(a:buffer, 'biome_fixer_apply_unsafe') ? '--apply-unsafe' : '--apply'
 
     return {
     \   'read_temporary_file': 1,
-    \   'command': ale#Escape(l:executable) . ' format'
+    \   'command': ale#Escape(l:executable) . ' check ' . l:apply
     \       . (!empty(l:options) ? ' ' . l:options : '')
     \       . ' %t'
     \}

--- a/autoload/ale/handlers/biome.vim
+++ b/autoload/ale/handlers/biome.vim
@@ -4,6 +4,7 @@
 call ale#Set('biome_executable', 'biome')
 call ale#Set('biome_use_global', get(g:, 'ale_use_global_executables', 0))
 call ale#Set('biome_options', '')
+call ale#Set('biome_fixer_apply_unsafe', 0)
 
 function! ale#handlers#biome#GetExecutable(buffer) abort
     return ale#path#FindExecutable(a:buffer, 'biome', [

--- a/doc/ale-typescript.txt
+++ b/doc/ale-typescript.txt
@@ -27,6 +27,14 @@ g:ale_biome_use_global                                 *g:ale_biome_use_global*
   See |ale-integrations-local-executables|
 
 
+g:ale_biome_fixer_apply_unsafe                 *g:ale_biome_fixer_apply_unsafe*
+                                               *b:ale_biome_fixer_apply_unsafe*
+  Type: |Number|
+  Default: `0`
+
+  If set to `1`, biome will apply unsafe fixes along with safe fixes.
+
+
 ===============================================================================
 cspell                                                  *ale-typescript-cspell*
 

--- a/test/fixers/test_biome_fixer_callback.vader
+++ b/test/fixers/test_biome_fixer_callback.vader
@@ -1,4 +1,10 @@
 Before:
+  Save g:ale_biome_options
+  Save g:ale_biome_fixer_apply_unsafe
+
+  let g:ale_biome_options = ''
+  let g:ale_biome_fixer_apply_unsafe = 0
+
   call ale#assert#SetUpFixerTest('typescript', 'biome')
 
 After:
@@ -11,6 +17,16 @@ Execute(The default biome command should be correct):
   \ {
   \   'read_temporary_file': 1,
   \   'command': ale#Escape('biome')
-  \     . ' format %t'
+  \     . ' check --apply %t'
   \ }
 
+Execute(Unsafe fixes can be applied via an option):
+  call ale#test#SetFilename('../test-files/typescript/test.ts')
+  let g:ale_biome_fixer_apply_unsafe = 1
+
+  AssertFixer
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('biome')
+  \     . ' check --apply-unsafe %t'
+  \ }

--- a/test/linter/test_typescript_biome.vader
+++ b/test/linter/test_typescript_biome.vader
@@ -1,4 +1,8 @@
 Before:
+  Save g:ale_biome_options
+
+  let g:ale_biome_options = ''
+
   call ale#assert#SetUpLinterTest('typescript', 'biome')
   call ale#test#SetFilename('test.ts')
 
@@ -9,6 +13,6 @@ Execute(The default biome command should be correct):
   AssertLinter 'biome', ale#Escape('biome') . ' lsp-proxy'
 
 Execute(The biome command should accept options):
-  let b:ale_biome_options = '--foobar'
+  let g:ale_biome_options = '--foobar'
 
   AssertLinter 'biome', ale#Escape('biome') . ' lsp-proxy --foobar'


### PR DESCRIPTION
- based on biome config, will format, lint, and/or sort imports
- adds variable to apply unsafe fixes, disabled by default

fixes: #4754