### PR TITLE
Match filename in xvlog linter and add tip

### DIFF
--- a/ale_linters/verilog/xvlog.vim
+++ b/ale_linters/verilog/xvlog.vim
@@ -11,13 +11,16 @@ endfunction
 function! ale_linters#verilog#xvlog#Handle(buffer, lines) abort
     "Matches patterns like the following:
     " ERROR: [VRFC 10-1412] syntax error near output [/path/to/file.v:5]
-    let l:pattern = '^ERROR:\s\+\(\[.*\)\[.*:\([0-9]\+\)\]'
+    let l:pattern = '^ERROR:\s\+\(\[.*\)\[\(.*\):\([0-9]\+\)\]'
     let l:output = []
+    let l:dir = expand('#' . a:buffer . ':p:h')
 
     " NOTE: `xvlog` only prints 'INFO' and 'ERROR' messages
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        let l:fname = ale#path#GetAbsPath(l:dir, l:match[2])
         call add(l:output, {
-        \   'lnum': l:match[2] + 0,
+        \   'filename': l:fname,
+        \   'lnum': l:match[3] + 0,
         \   'type': 'E',
         \   'text': l:match[1],
         \})

--- a/ale_linters/verilog/xvlog.vim
+++ b/ale_linters/verilog/xvlog.vim
@@ -11,18 +11,18 @@ endfunction
 function! ale_linters#verilog#xvlog#Handle(buffer, lines) abort
     "Matches patterns like the following:
     " ERROR: [VRFC 10-1412] syntax error near output [/path/to/file.v:5]
-    let l:pattern = '^ERROR:\s\+\(\[.*\)\[\(.*\):\([0-9]\+\)\]'
+    let l:pattern = '^\(WARNING\|ERROR\|INFO\):\s\+\(\[.*\)\[\(.*\):\([0-9]\+\)\]'
     let l:output = []
     let l:dir = expand('#' . a:buffer . ':p:h')
 
     " NOTE: `xvlog` only prints 'INFO' and 'ERROR' messages
     for l:match in ale#util#GetMatches(a:lines, l:pattern)
-        let l:fname = ale#path#GetAbsPath(l:dir, l:match[2])
+        let l:fname = ale#path#GetAbsPath(l:dir, l:match[3])
         call add(l:output, {
         \   'filename': l:fname,
-        \   'lnum': l:match[3] + 0,
-        \   'type': 'E',
-        \   'text': l:match[1],
+        \   'lnum': l:match[4] + 0,
+        \   'type': l:match[1][0],
+        \   'text': l:match[2],
         \})
     endfor
 

--- a/doc/ale-verilog.txt
+++ b/doc/ale-verilog.txt
@@ -127,6 +127,9 @@ g:ale_verilog_xvlog_options                       *g:ale_verilog_xvlog_options*
   Default: `''`
 
   This variable can be changed to modify the flags/options passed to 'xvlog'.
+  Vivado generates a 'compile.sh' file in the xsim directory with the flags you
+  are probably looking for. Note, however, that you may need to change the
+  relative paths in the Project File '.prj'.
 
 
 ===============================================================================


### PR DESCRIPTION
Match the xvlog stdout for the filename to properly filter out the errors per file.
Suggest using Vivado generated compile.sh file to obtain the xvlog options.

For reference, the sane way of using xvlog is along these lines:
```
let g:ale_verilog_xvlog_options = '
\ --incr --relax \
\ -L uvm -L axi_vip_v1_1_15 -L smartconnect_v1_0 -L clk_vip_v1_0_3 -L axi4stream_vip_v1_1_15 -L rst_vip_v1_0_5 -L xilinx_vip
\ -prj ./path/to/xsim/system_tb_vlog.prj'
```
Room for improvement:
The `.prj` uses relative paths and expects xvlog to be called from its path.
As is, I'm manually "fixing" the relative paths in the `.prj` to point from the cwd to xsim.
Not sure if it's worth a more elaborated solution (e.g. search for the `compile.sh`, set cwd to its location, and extract the xvlog options.