### PR TITLE
fix(biome): send correct language to lsp proxy

### DIFF
--- a/ale_linters/javascript/biome.vim
+++ b/ale_linters/javascript/biome.vim
@@ -4,6 +4,7 @@
 call ale#linter#Define('javascript', {
 \   'name': 'biome',
 \   'lsp': 'stdio',
+\   'language': function('ale#handlers#biome#GetLanguage'),
 \   'executable': function('ale#handlers#biome#GetExecutable'),
 \   'command': function('ale#handlers#biome#GetCommand'),
 \   'project_root': function('ale#handlers#biome#GetProjectRoot'),

--- a/ale_linters/typescript/biome.vim
+++ b/ale_linters/typescript/biome.vim
@@ -4,6 +4,7 @@
 call ale#linter#Define('typescript', {
 \   'name': 'biome',
 \   'lsp': 'stdio',
+\   'language': function('ale#handlers#biome#GetLanguage'),
 \   'executable': function('ale#handlers#biome#GetExecutable'),
 \   'command': function('ale#handlers#biome#GetCommand'),
 \   'project_root': function('ale#handlers#biome#GetProjectRoot'),

--- a/autoload/ale/handlers/biome.vim
+++ b/autoload/ale/handlers/biome.vim
@@ -25,6 +25,10 @@ function! ale#handlers#biome#GetCommand(buffer) abort
     \   . (!empty(l:options) ? ' ' . l:options : '')
 endfunction
 
+function! ale#handlers#biome#GetLanguage(buffer) abort
+    return getbufvar(a:buffer, '&filetype')
+endfunction
+
 function! ale#handlers#biome#GetProjectRoot(buffer) abort
     let l:biome_file = ale#path#FindNearestFile(a:buffer, 'biome.json')
 

--- a/test/linter/test_biome.vader
+++ b/test/linter/test_biome.vader
@@ -16,3 +16,20 @@ Execute(The biome command should accept options):
   let g:ale_biome_options = '--foobar'
 
   AssertLinter 'biome', ale#Escape('biome') . ' lsp-proxy --foobar'
+
+Execute(Uses the filetype as the language):
+  call ale#test#SetFilename('test.ts')
+  set filetype=typescript
+  AssertLSPLanguage 'typescript'
+
+  call ale#test#SetFilename('test.tsx')
+  set filetype=typescriptreact
+  AssertLSPLanguage 'typescriptreact'
+
+  call ale#test#SetFilename('test.js')
+  set filetype=javascript
+  AssertLSPLanguage 'javascript'
+
+  call ale#test#SetFilename('test.jsx')
+  set filetype=javascriptreact
+  AssertLSPLanguage 'javascriptreact'


### PR DESCRIPTION
Since Biome understands `typescriptreact` and `javascriptreact` as languages, we can send the `filetype` to the LSP, rather than only sending `typescript` for both `ts` and `tsx` files, or `javascript` for `js` and `jsx` files.

fixes: #4752

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

--- 

I moved the `ale_typescript_biome.vader` tests to just `ale_biome.vader` since it covers multiple languages, and I added some tests for this case. I also fixed what seemed like an issue with the biome tests where if the linters run first then the fixers fail. Now it saves the variables and resets them before the tests.

Linting and biome vader tests both pass locally for me