### PR TITLE
fix(biome): use temp file instead of stdin

### DIFF
--- a/autoload/ale/fixers/biome.vim
+++ b/autoload/ale/fixers/biome.vim
@@ -3,8 +3,9 @@ function! ale#fixers#biome#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'biome_options')
 
     return {
+    \   'read_temporary_file': 1,
     \   'command': ale#Escape(l:executable) . ' format'
     \       . (!empty(l:options) ? ' ' . l:options : '')
-    \       . ' --stdin-file-path=%s',
+    \       . ' %t'
     \}
 endfunction

--- a/test/fixers/test_biome_fixer_callback.vader
+++ b/test/fixers/test_biome_fixer_callback.vader
@@ -9,7 +9,8 @@ Execute(The default biome command should be correct):
 
   AssertFixer
   \ {
+  \   'read_temporary_file': 1,
   \   'command': ale#Escape('biome')
-  \     . ' format --stdin-file-path=%s'
+  \     . ' format %t'
   \ }
 


### PR DESCRIPTION
biome handles utf8 characters differently between files and stdin, and in some cases can replace emojis with ascii characters when using stdin

refs: biomejs/biome#2604

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

---

This is pretty small but I made sure to update the relevant test. Again, it will have minor conflicts with #4774, #4763, and #4773, but I wanted to keep the fixes focused.

Vader tests and linters are passing locally.

I have another change pending to add biome support for json and jsonc and clean up the options, but it sort of depends on some of these other PRs so I'll wait until these are resolved.