### PR TITLE
Update xvlog.vim

### DIFF
--- a/ale_linters/verilog/xvlog.vim
+++ b/ale_linters/verilog/xvlog.vim
@@ -7,6 +7,7 @@ if &filetype == 'systemverilog'
     call ale#Set('verilog_xvlog_options', '-sv')
 else
     call ale#Set('verilog_xvlog_options', '')
+endif
 
 function! ale_linters#verilog#xvlog#GetCommand(buffer) abort
     return '%e ' . ale#Pad(ale#Var(a:buffer, 'verilog_xvlog_options')) . ' %t'

--- a/ale_linters/verilog/xvlog.vim
+++ b/ale_linters/verilog/xvlog.vim
@@ -2,7 +2,11 @@
 " Description: Adds support for Xilinx Vivado `xvlog` Verilog compiler/checker
 
 call ale#Set('verilog_xvlog_executable', 'xvlog')
-call ale#Set('verilog_xvlog_options', '')
+
+if &filetype == 'systemverilog'
+    call ale#Set('verilog_xvlog_options', '-sv')
+else
+    call ale#Set('verilog_xvlog_options', '')
 
 function! ale_linters#verilog#xvlog#GetCommand(buffer) abort
     return '%e ' . ale#Pad(ale#Var(a:buffer, 'verilog_xvlog_options')) . ' %t'


### PR DESCRIPTION
when using xvlog in Vivado 2019.1 for SystemVerilog, you should add the option '-sv'.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
