### PR TITLE
fix!(biome): allow passing options to `biome check`

### DIFF
--- a/ale_linters/javascript/biome.vim
+++ b/ale_linters/javascript/biome.vim
@@ -6,6 +6,6 @@ call ale#linter#Define('javascript', {
 \   'lsp': 'stdio',
 \   'language': function('ale#handlers#biome#GetLanguage'),
 \   'executable': function('ale#handlers#biome#GetExecutable'),
-\   'command': function('ale#handlers#biome#GetCommand'),
+\   'command': '%e lsp-proxy',
 \   'project_root': function('ale#handlers#biome#GetProjectRoot'),
 \})

--- a/ale_linters/typescript/biome.vim
+++ b/ale_linters/typescript/biome.vim
@@ -6,6 +6,6 @@ call ale#linter#Define('typescript', {
 \   'lsp': 'stdio',
 \   'language': function('ale#handlers#biome#GetLanguage'),
 \   'executable': function('ale#handlers#biome#GetExecutable'),
-\   'command': function('ale#handlers#biome#GetCommand'),
+\   'command': '%e lsp-proxy',
 \   'project_root': function('ale#handlers#biome#GetProjectRoot'),
 \})

--- a/autoload/ale/handlers/biome.vim
+++ b/autoload/ale/handlers/biome.vim
@@ -19,13 +19,6 @@ function! ale#handlers#biome#GetExecutable(buffer) abort
     \])
 endfunction
 
-function! ale#handlers#biome#GetCommand(buffer) abort
-    let l:options = ale#Var(a:buffer, 'biome_options')
-
-    return '%e lsp-proxy'
-    \   . (!empty(l:options) ? ' ' . l:options : '')
-endfunction
-
 function! ale#handlers#biome#GetLanguage(buffer) abort
     return getbufvar(a:buffer, '&filetype')
 endfunction

--- a/doc/ale-typescript.txt
+++ b/doc/ale-typescript.txt
@@ -16,7 +16,8 @@ g:ale_biome_options                                       *g:ale_biome_options*
   Type: |String|
   Default: `''`
 
-  This variable can be set to pass additional options to biome.
+  This variable can be set to pass additional options to `biome check` when
+  applying fixes.
 
 
 g:ale_biome_use_global                                 *g:ale_biome_use_global*

--- a/test/fixers/test_biome_fixer_callback.vader
+++ b/test/fixers/test_biome_fixer_callback.vader
@@ -11,7 +11,7 @@ After:
   call ale#assert#TearDownFixerTest()
 
 Execute(The default biome command should be correct):
-  call ale#test#SetFilename('../test-files/typescript/test.ts')
+  call ale#test#SetFilename('../test-files/biome/jsonc/src/test.ts')
 
   AssertFixer
   \ {
@@ -21,7 +21,7 @@ Execute(The default biome command should be correct):
   \ }
 
 Execute(Unsafe fixes can be applied via an option):
-  call ale#test#SetFilename('../test-files/typescript/test.ts')
+  call ale#test#SetFilename('../test-files/biome/jsonc/src/test.ts')
   let g:ale_biome_fixer_apply_unsafe = 1
 
   AssertFixer
@@ -29,4 +29,15 @@ Execute(Unsafe fixes can be applied via an option):
   \   'read_temporary_file': 1,
   \   'command': ale#Escape('biome')
   \     . ' check --apply-unsafe %t'
+  \ }
+
+Execute(The fixer should accept options):
+  call ale#test#SetFilename('../test-files/biome/jsonc/src/test.ts')
+  let g:ale_biome_options = '--foobar'
+
+  AssertFixer
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('biome')
+  \     . ' check --apply --foobar %t',
   \ }

--- a/test/linter/test_biome.vader
+++ b/test/linter/test_biome.vader
@@ -14,11 +14,6 @@ After:
 Execute(The default biome command should be correct):
   AssertLinter 'biome', ale#Escape('biome') . ' lsp-proxy'
 
-Execute(The biome command should accept options):
-  let g:ale_biome_options = '--foobar'
-
-  AssertLinter 'biome', ale#Escape('biome') . ' lsp-proxy --foobar'
-
 Execute(Uses the filetype as the language):
   call ale#test#SetFilename('test.ts')
   set filetype=typescript


### PR DESCRIPTION
The only option available to biome's `lsp-proxy` command used for linting is `--config-path`. However, we are using ALE to find and set the project root, and have a way to manually override, so that is no longer necessary.

The LSP proxy also used the `g:ale_biome_options` config, which is shared with the fixer's `check` command, but `lsp-proxy` will throw an error if unknown options are included, making it so that option is only useful to set the project root.

BREAKING CHANGE: We are no longer passing options to the biome LSP proxy, but we can still set the project root with
`g:ale_biome_lsp_project_root`.

---

I added a test that shows you can pass arbitrary options along to `biome check` and updated the documentation.

I had thought about continuing to pass `g:ale_biome_options` to the LSP for backwards compatibility and t hen creating a new `g:ale_biome_fixer_options` that get added additionally to the fixer, but that seemed a lot more complex. Considering the only shared option is `--config-path`, which is also the only LSP option, people either were only using that option or their LSP would have been broken.

The downside to this approach is that if someone is relying on `--config-path` they may need to update to use `ale_biome_lsp_project_root` instead, so maybe a deprecation path is better. @w0rp @hsanson, what do you think?