### PR TITLE
Fix for ruff fixer for ruff version >=0.5.0

### DIFF
--- a/autoload/ale/fixers/ruff.vim
+++ b/autoload/ale/fixers/ruff.vim
@@ -50,6 +50,11 @@ function! ale#fixers#ruff#FixForVersion(buffer, version) abort
         call extend(l:cmd, ['run', 'ruff'])
     endif
 
+    " NOTE: ruff 0.5.0 removes `ruff <path>` in favor of `ruff check <path>`
+    if ale#semver#GTE(a:version, [0, 5, 0])
+        call extend(l:cmd, ['check'])
+    endif
+
     let l:options = ale#Var(a:buffer, 'python_ruff_options')
 
     if !empty(l:options)

--- a/test/fixers/test_ruff_fixer_callback.vader
+++ b/test/fixers/test_ruff_fixer_callback.vader
@@ -73,6 +73,20 @@ Execute(The ruff callback should respect custom options):
   \     . ' --ignore F401 -q --stdin-filename '. fname . ' --fix -',
   \ }
 
+Execute(The ruff callback should use ruff check for 0.5.0):
+  let file_path = g:dir . '/../test-files/python/with_virtualenv/subdir/foo/bar.py'
+
+  silent execute 'file ' . fnameescape(file_path)
+
+  let fname = ale#Escape(ale#path#Simplify(file_path))
+
+  GivenCommandOutput ['ruff 0.5.0']
+  AssertFixer
+  \ {
+  \   'cwd': ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/subdir'),
+  \   'command': ale#Escape(ale#path#Simplify(g:dir . '/../test-files/python/with_virtualenv/env/' . b:bin_dir . '/ruff')) . ' check --stdin-filename ' . fname  . ' --fix -',
+  \ }
+
 Execute(Pipenv is detected when python_ruff_auto_pipenv is set):
   let g:ale_python_ruff_auto_pipenv = 1
   let g:ale_python_ruff_change_directory = 0


### PR DESCRIPTION
As of [ruff 0.5.0](https://github.com/astral-sh/ruff/releases/tag/0.5.0) the deprecated `ruff <path>` has now been fully removed in favour of `ruff check <path>`. This caused the `ruff` fixer to fail as it was still using the old style CLI command. 

