### PR TITLE
Return floating_preview window id

### DIFF
--- a/autoload/ale/floating_preview.vim
+++ b/autoload/ale/floating_preview.vim
@@ -21,6 +21,7 @@ function! ale#floating_preview#Show(lines, ...) abort
     else
         call s:VimShow(a:lines, l:options)
     endif
+    return w:preview.id
 endfunction
 
 function! s:NvimShow(lines, options) abort

--- a/test/test_floating_preview.vader
+++ b/test/test_floating_preview.vader
@@ -12,6 +12,7 @@ Before:
   function! ale#floating_preview#Show(lines, ...) abort
     let g:floating_preview_show_called = 1
     let g:floated_lines = a:lines
+    return win_getid()
   endfunction
 
   let g:ale_buffer_info = {

--- a/test/test_hover.vader
+++ b/test/test_hover.vader
@@ -25,6 +25,7 @@ Before:
   function! ale#floating_preview#Show(lines, ...) abort
     let g:floating_preview_show_called = 1
     let g:floated_lines = a:lines
+    return win_getid()
   endfunction
 
   function! ale#lsp_linter#StartLSP(buffer, linter, callback) abort


### PR DESCRIPTION
Make `ale#floating_preview#Show` more similar to `popup_create` and return the id of the window so it's easy to set the filetype of the resulting buffer.

This doesn't affect any other ale code. It just makes it easier to use ALE's library function in my vim config.