### PR TITLE
syntax_tree: no need to write and read temporary file

### DIFF
--- a/autoload/ale/fixers/syntax_tree.vim
+++ b/autoload/ale/fixers/syntax_tree.vim
@@ -6,7 +6,7 @@ function! ale#fixers#syntax_tree#GetCommand(buffer) abort
     let l:options = ale#Var(a:buffer, 'ruby_syntax_tree_options')
 
     return ale#ruby#EscapeExecutable(l:executable, 'stree')
-    \   . ' write'
+    \   . ' format'
     \   . (!empty(l:options) ? ' ' . l:options : '')
     \   . ' %t'
 endfunction
@@ -14,6 +14,5 @@ endfunction
 function! ale#fixers#syntax_tree#Fix(buffer) abort
     return {
     \   'command': ale#fixers#syntax_tree#GetCommand(a:buffer),
-    \   'read_temporary_file': 1,
     \}
 endfunction

--- a/test/fixers/test_syntax_tree_fixer_callback.vader
+++ b/test/fixers/test_syntax_tree_fixer_callback.vader
@@ -18,9 +18,8 @@ Execute(The syntax_tree callback should return the correct default values):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_syntax_tree_executable)
-  \     . ' write %t',
+  \     . ' format %t',
   \ },
   \ ale#fixers#syntax_tree#Fix(bufnr(''))
 
@@ -30,8 +29,7 @@ Execute(The syntax_tree callback should include custom options):
 
   AssertEqual
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape(g:ale_ruby_syntax_tree_executable)
-  \     . ' write --print-width=100 --plugins=plugin/trailing_comma %t',
+  \     . ' format --print-width=100 --plugins=plugin/trailing_comma %t',
   \ },
   \ ale#fixers#syntax_tree#Fix(bufnr(''))


### PR DESCRIPTION
The `format` option prints out to `stdout`, so there is no need to write and read back the temporary file.
