### PR TITLE
Add fixer for json: python's json.tool

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -477,6 +477,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['json'],
 \       'description': 'Fix JSON files with jq.',
 \   },
+\   'json_pytool': {
+\       'function': 'ale#fixers#json_pytool#Fix',
+\       'suggested_filetypes': ['json'],
+\       'description': "Fix JSON files with python's built-in json.tool module.",
+\   },
 \   'protolint': {
 \       'function': 'ale#fixers#protolint#Fix',
 \       'suggested_filetypes': ['proto'],

--- a/autoload/ale/fixers/json_pytool.vim
+++ b/autoload/ale/fixers/json_pytool.vim
@@ -1,0 +1,20 @@
+" Author: idbrii
+" Description: json formatter as ALE fixer using python's json.tool
+
+call ale#Set('json_pytool_executable', 'python')
+call ale#Set('json_pytool_options', '')
+call ale#Set('json_pytool_use_global', get(g:, 'ale_use_global_executables', 0))
+
+function! ale#fixers#json_pytool#GetExecutable(buffer) abort
+    return ale#path#FindExecutable(a:buffer, 'json_pytool', ['python'])
+endfunction
+
+function! ale#fixers#json_pytool#Fix(buffer) abort
+    let l:executable = ale#Escape(ale#fixers#json_pytool#GetExecutable(a:buffer))
+    let l:opts = ale#Var(a:buffer, 'json_pytool_options')
+    let l:command = printf('%s -m json.tool %s -', l:executable, l:opts)
+
+    return {
+    \   'command': l:command
+    \ }
+endfunction

--- a/doc/ale-json.txt
+++ b/doc/ale-json.txt
@@ -84,6 +84,40 @@ g:ale_json_fixjson_use_global                   *g:ale_json_fixjson_use_global*
 
 
 ===============================================================================
+pytool                                                        *ale-json-pytool*
+
+Use python's json.tool module to reformat json.
+
+g:ale_json_pytool_executable                     *g:ale_json_pytool_executable*
+                                                 *b:ale_json_pytool_executable*
+
+  Type: |String|
+  Default: `'python'`
+
+  The python executable that run to use its json.tool module. This fixer
+  requires python 3, which includes the json module.
+
+g:ale_json_pytool_options                           *g:ale_json_pytool_options*
+                                                    *b:ale_json_pytool_options*
+
+  Type: |String|
+  Default: `''`
+
+  These options are passed to the json.tool module. Example: >
+    let g:ale_json_pytool_options = '--sort-keys --indent 2'
+<  See docs for all options:
+    https://docs.python.org/3/library/json.html#module-json.tool
+
+g:ale_json_pytool_use_global                     *g:ale_json_pytool_use_global*
+                                                 *b:ale_json_pytool_use_global*
+
+  Type: |Number|
+  Default: `get(g:, 'ale_use_global_executables', 0)`
+
+  See |ale-integrations-local-executables|
+
+
+===============================================================================
 jsonlint                                                    *ale-json-jsonlint*
 
 g:ale_json_jsonlint_executable                 *g:ale_json_jsonlint_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -329,6 +329,7 @@ Notes:
   * `eslint`
   * `fixjson`
   * `jq`
+  * `json.tool`
   * `jsonlint`
   * `prettier`
   * `spectral`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3159,6 +3159,7 @@ documented in additional help files.
     dprint................................|ale-json-dprint|
     eslint................................|ale-json-eslint|
     fixjson...............................|ale-json-fixjson|
+    pytool................................|ale-json-pytool|
     jsonlint..............................|ale-json-jsonlint|
     jq....................................|ale-json-jq|
     prettier..............................|ale-json-prettier|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -338,6 +338,7 @@ formatting.
   * [eslint](http://eslint.org/) :warning:
   * [fixjson](https://github.com/rhysd/fixjson)
   * [jq](https://stedolan.github.io/jq/) :warning:
+  * [json.tool](https://docs.python.org/3/library/json.html#module-json.tool) :warning:
   * [jsonlint](https://github.com/zaach/jsonlint)
   * [prettier](https://github.com/prettier/prettier)
   * [spectral](https://github.com/stoplightio/spectral)


### PR DESCRIPTION
Resolves #4314. 

Add a fixer that's built into python for json formatting. Include a couple arguments in docs to make these features more discoverable.

Uses stdin-based fixing so you don't need to save the file to fix.



Unlike most python commands (i.e., pyflakes), this one doesn't seem to include a standalone executable. I can't find any other ale modules that get a python path, so this fixer has its own variable:
```
call ale#Set('json_pytool_executable', 'python')
```
