### PR TITLE
Set two-space indent for *.vader in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.vader]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Will be useful for those who use an EditorConfig plugin.
