### PR TITLE
Add erlang-ls as an alias for erlang_ls linter

### DIFF
--- a/ale_linters/erlang/erlang_ls.vim
+++ b/ale_linters/erlang/erlang_ls.vim
@@ -53,4 +53,5 @@ call ale#linter#Define('erlang', {
 \   'command': function('s:GetCommand'),
 \   'lsp': 'stdio',
 \   'project_root': function('s:FindProjectRoot'),
+\   'aliases': ['erlang-ls'],
 \})


### PR DESCRIPTION
The project itself is often referred to as Erlang LS, so erlang-ls would be a suitable alias.
