### PR TITLE
When using `actionlint` look for & use a config file

### DIFF
--- a/ale_linters/yaml/actionlint.vim
+++ b/ale_linters/yaml/actionlint.vim
@@ -20,7 +20,30 @@ function! ale_linters#yaml#actionlint#GetCommand(buffer) abort
         let l:options .= ale#Pad('-oneline')
     endif
 
+    let l:configfile = ale_linters#yaml#actionlint#GitRepoHasConfig(a:buffer)
+
+    if !empty(l:configfile)
+        let l:options .= ale#Pad('-config-file ' . l:configfile)
+    endif
+
     return '%e' . ale#Pad(l:options) . ' - '
+endfunction
+
+" If we have a actionlint.yml or actionlint.yaml in our github directory
+" use that as our config file.
+function! ale_linters#yaml#actionlint#GitRepoHasConfig(buffer) abort
+    let l:filename = expand('#' . a:buffer . ':p')
+    let l:configfilebase = substitute(l:filename, '\.github/.*', '.github/actionlint.','')
+
+    for l:ext in ['yml', 'yaml']
+        let l:configfile = l:configfilebase . l:ext
+
+        if filereadable(l:configfile)
+            return l:configfile
+        endif
+    endfor
+
+    return ''
 endfunction
 
 function! ale_linters#yaml#actionlint#Handle(buffer, lines) abort


### PR DESCRIPTION
Actionlint supports a config file and it lives in a very searchable path, as the only files it acts on are in the `.github` directory already.

Look for an `actionlint.yml` and `.yaml` in that path, and use the config if its there.