### PR TITLE
Fix linting with jq (#4765)

### DIFF
--- a/ale_linters/json/jq.vim
+++ b/ale_linters/json/jq.vim
@@ -5,7 +5,7 @@ call ale#Set('json_jq_filters', '.')
 
 " Matches patterns like the following:
 " parse error: Expected another key-value pair at line 4, column 3
-let s:pattern = '^parse error: \(.\+\) at line \(\d\+\), column \(\d\+\)$'
+let s:pattern = 'parse error: \(.\+\) at line \(\d\+\), column \(\d\+\)$'
 
 function! ale_linters#json#jq#Handle(buffer, lines) abort
     return ale#util#MapMatches(a:lines, s:pattern, {match -> {

--- a/test/handler/test_jq_handler.vader
+++ b/test/handler/test_jq_handler.vader
@@ -16,3 +16,15 @@ Execute (Should parse error correctly):
   \ ale_linters#json#jq#Handle(0, [
   \ 'parse error: Expected another array element at line 1, column 9'
   \ ])
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 1,
+  \     'col':  9,
+  \     'text': 'Expected another array element',
+  \   }
+  \ ],
+  \ ale_linters#json#jq#Handle(0, [
+  \ 'jq: parse error: Expected another array element at line 1, column 9'
+  \ ])


### PR DESCRIPTION
With the 1.6 version of jq the error message start with "parse error". 
With the last version of jq the error message start with "jq: parse error". 
Fix it by using a regular expression that works in both cases.

I run the test and it works.

