### PR TITLE
Properly handle optional end_line_no/end_line_pos in sqlfluff

### DIFF
--- a/ale_linters/sql/sqlfluff.vim
+++ b/ale_linters/sql/sqlfluff.vim
@@ -52,16 +52,19 @@ function! ale_linters#sql#sqlfluff#Handle(buffer, version, lines) abort
 
     if ale#semver#GTE(a:version, [3, 0, 0])
         for l:violation in get(l:json, 'violations', [])
-            call add(l:output, {
+            err = {
             \   'filename': l:json.filepath,
             \   'lnum': l:violation.start_line_no,
-            \   'end_lnum': l:violation.end_line_no,
             \   'col': l:violation.start_line_pos,
-            \   'end_col': l:violation.end_line_pos,
             \   'text': l:violation.description,
             \   'code': l:violation.code,
             \   'type': 'W',
-            \})
+            \}
+            if has_key(l.violation, 'end_line_no')
+                err.end_lnum = l:violation.end_line_no
+            if has_key(l.violation, 'end_line_pos')
+                err.end_col = l:violation.end_line_pos
+            call add(l:output, err)
         endfor
     else
         for l:violation in get(l:json, 'violations', [])


### PR DESCRIPTION
end_line_no/end_line_pos are optional. Example SQL:
```SELECT NULL FROM {{ a_jinja_templated_table }};```

`sqlfluff lint --dialect ansi --format json` gives the following error
among others:
```
{"start_line_no": 2, "start_line_pos": 9, "code": "TMP", "description": "Undefined jinja template variable: 'a_jinja_templated_table'", "name": "", "warning": false}
```
As one can see there is noe end_line_no/end_line_pos.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
