### PR TITLE
Fix python linting/formatting error when in virtual environment

### DIFF
--- a/ale_linters/python/bandit.vim
+++ b/ale_linters/python/bandit.vim
@@ -45,7 +45,7 @@ function! ale_linters#python#bandit#GetCommand(buffer) abort
         endif
     endif
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run bandit'
     \   : ''
 

--- a/ale_linters/python/flake8.vim
+++ b/ale_linters/python/flake8.vim
@@ -74,7 +74,7 @@ endfunction
 function! ale_linters#python#flake8#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#flake8#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run flake8'
     \   : ''
 

--- a/ale_linters/python/flakehell.vim
+++ b/ale_linters/python/flakehell.vim
@@ -74,7 +74,7 @@ endfunction
 function! ale_linters#python#flakehell#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#flakehell#GetExecutable(a:buffer)
 
-    if (l:executable =~? 'pipenv\|poetry\|uv$')
+    if (l:executable =~? '\(pipenv\|poetry\|uv\)$')
         let l:exec_args = ' run flakehell'
     elseif (l:executable is? 'python')
         let l:exec_args = ' -m flakehell'

--- a/ale_linters/python/jedils.vim
+++ b/ale_linters/python/jedils.vim
@@ -28,7 +28,7 @@ endfunction
 
 function! ale_linters#python#jedils#GetCommand(buffer) abort
     let l:executable = ale_linters#python#jedils#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run jedi-language-server'
     \   : ''
     let l:env_string = ''

--- a/ale_linters/python/mypy.vim
+++ b/ale_linters/python/mypy.vim
@@ -49,7 +49,7 @@ endfunction
 
 function! ale_linters#python#mypy#GetCommand(buffer) abort
     let l:executable = ale_linters#python#mypy#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run mypy'
     \   : ''
 

--- a/ale_linters/python/prospector.vim
+++ b/ale_linters/python/prospector.vim
@@ -35,7 +35,7 @@ endfunction
 function! ale_linters#python#prospector#GetCommand(buffer) abort
     let l:executable = ale_linters#python#prospector#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run prospector'
     \   : ''
 

--- a/ale_linters/python/pycln.vim
+++ b/ale_linters/python/pycln.vim
@@ -42,7 +42,7 @@ endfunction
 
 function! ale_linters#python#pycln#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#pycln#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pycln'
     \   : ''
 

--- a/ale_linters/python/pycodestyle.vim
+++ b/ale_linters/python/pycodestyle.vim
@@ -30,7 +30,7 @@ endfunction
 function! ale_linters#python#pycodestyle#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pycodestyle#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pycodestyle'
     \   : ''
 

--- a/ale_linters/python/pydocstyle.vim
+++ b/ale_linters/python/pydocstyle.vim
@@ -29,7 +29,7 @@ endfunction
 
 function! ale_linters#python#pydocstyle#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pydocstyle#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pydocstyle'
     \   : ''
 

--- a/ale_linters/python/pyflakes.vim
+++ b/ale_linters/python/pyflakes.vim
@@ -29,7 +29,7 @@ endfunction
 function! ale_linters#python#pyflakes#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyflakes#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pyflakes'
     \   : ''
 

--- a/ale_linters/python/pylama.vim
+++ b/ale_linters/python/pylama.vim
@@ -30,7 +30,7 @@ endfunction
 
 function! ale_linters#python#pylama#RunWithVersionCheck(buffer) abort
     let l:executable = ale_linters#python#pylama#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pylama'
     \   : ''
 
@@ -59,7 +59,7 @@ endfunction
 
 function! ale_linters#python#pylama#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#pylama#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pylama'
     \   : ''
 

--- a/ale_linters/python/pylint.vim
+++ b/ale_linters/python/pylint.vim
@@ -44,7 +44,7 @@ endfunction
 
 function! ale_linters#python#pylint#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#pylint#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pylint'
     \   : ''
 

--- a/ale_linters/python/pylsp.vim
+++ b/ale_linters/python/pylsp.vim
@@ -43,7 +43,7 @@ endfunction
 
 function! ale_linters#python#pylsp#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pylsp#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pylsp'
     \   : ''
     let l:env_string = ''

--- a/ale_linters/python/pyre.vim
+++ b/ale_linters/python/pyre.vim
@@ -28,7 +28,7 @@ endfunction
 
 function! ale_linters#python#pyre#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyre#GetExecutable(a:buffer)
-    let l:exec_args = (l:executable =~? 'pipenv\|poetry\|uv$' ? ' run pyre' : '') . ' persistent'
+    let l:exec_args = (l:executable =~? '\(pipenv\|poetry\|uv\)$' ? ' run pyre' : '') . ' persistent'
 
     return ale#Escape(l:executable) . l:exec_args
 endfunction

--- a/ale_linters/python/pyright.vim
+++ b/ale_linters/python/pyright.vim
@@ -70,7 +70,7 @@ endfunction
 
 function! ale_linters#python#pyright#GetCommand(buffer) abort
     let l:executable = ale_linters#python#pyright#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pyright-langserver'
     \   : ''
     let l:env_string = ''

--- a/ale_linters/python/refurb.vim
+++ b/ale_linters/python/refurb.vim
@@ -41,7 +41,7 @@ endfunction
 
 function! ale_linters#python#refurb#GetCommand(buffer) abort
     let l:executable = ale_linters#python#refurb#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run refurb'
     \   : ''
 

--- a/ale_linters/python/ruff.vim
+++ b/ale_linters/python/ruff.vim
@@ -47,7 +47,7 @@ endfunction
 
 function! ale_linters#python#ruff#GetCommand(buffer, version) abort
     let l:executable = ale_linters#python#ruff#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run ruff'
     \   : ''
 

--- a/ale_linters/python/unimport.vim
+++ b/ale_linters/python/unimport.vim
@@ -28,7 +28,7 @@ endfunction
 
 function! ale_linters#python#unimport#GetCommand(buffer) abort
     let l:executable = ale_linters#python#unimport#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run unimport'
     \   : ''
 

--- a/ale_linters/python/vulture.vim
+++ b/ale_linters/python/vulture.vim
@@ -47,7 +47,7 @@ endfunction
 
 function! ale_linters#python#vulture#GetCommand(buffer) abort
     let l:executable = ale_linters#python#vulture#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run vulture'
     \   : ''
     let l:lint_dest = ale#Var(a:buffer, 'python_vulture_change_directory')

--- a/autoload/ale/fixers/autoflake.vim
+++ b/autoload/ale/fixers/autoflake.vim
@@ -30,7 +30,7 @@ endfunction
 function! ale#fixers#autoflake#Fix(buffer) abort
     let l:executable = ale#fixers#autoflake#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run autoflake'
     \   : ''
 

--- a/autoload/ale/fixers/autoimport.vim
+++ b/autoload/ale/fixers/autoimport.vim
@@ -30,7 +30,7 @@ endfunction
 function! ale#fixers#autoimport#Fix(buffer) abort
     let l:executable = ale#fixers#autoimport#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run autoimport'
     \   : ''
 

--- a/autoload/ale/fixers/autopep8.vim
+++ b/autoload/ale/fixers/autopep8.vim
@@ -30,7 +30,7 @@ endfunction
 function! ale#fixers#autopep8#Fix(buffer) abort
     let l:executable = ale#fixers#autopep8#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run autopep8'
     \   : ''
 

--- a/autoload/ale/fixers/black.vim
+++ b/autoload/ale/fixers/black.vim
@@ -32,7 +32,7 @@ function! ale#fixers#black#Fix(buffer) abort
     let l:executable = ale#fixers#black#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'black'])
     endif
 

--- a/autoload/ale/fixers/isort.vim
+++ b/autoload/ale/fixers/isort.vim
@@ -31,7 +31,7 @@ function! ale#fixers#isort#GetCmd(buffer) abort
     let l:executable = ale#fixers#isort#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'isort'])
     endif
 
@@ -42,7 +42,7 @@ function! ale#fixers#isort#FixForVersion(buffer, version) abort
     let l:executable = ale#fixers#isort#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'isort'])
     endif
 

--- a/autoload/ale/fixers/pycln.vim
+++ b/autoload/ale/fixers/pycln.vim
@@ -42,7 +42,7 @@ endfunction
 
 function! ale#fixers#pycln#GetCommand(buffer) abort
     let l:executable = ale#fixers#pycln#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run pycln'
     \   : ''
 
@@ -53,7 +53,7 @@ function! ale#fixers#pycln#FixForVersion(buffer, version) abort
     let l:executable = ale#fixers#pycln#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'pycln'])
     endif
 

--- a/autoload/ale/fixers/pyflyby.vim
+++ b/autoload/ale/fixers/pyflyby.vim
@@ -33,7 +33,7 @@ function! ale#fixers#pyflyby#Fix(buffer) abort
     let l:executable = ale#fixers#pyflyby#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'tidy-imports'])
     endif
 

--- a/autoload/ale/fixers/reorder_python_imports.vim
+++ b/autoload/ale/fixers/reorder_python_imports.vim
@@ -30,7 +30,7 @@ endfunction
 function! ale#fixers#reorder_python_imports#Fix(buffer) abort
     let l:executable = ale#fixers#reorder_python_imports#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run reorder-python-imports'
     \   : ''
 

--- a/autoload/ale/fixers/ruff.vim
+++ b/autoload/ale/fixers/ruff.vim
@@ -41,7 +41,7 @@ endfunction
 
 function! ale#fixers#ruff#GetCommand(buffer) abort
     let l:executable = ale#fixers#ruff#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run ruff'
     \   : ''
 
@@ -52,7 +52,7 @@ function! ale#fixers#ruff#FixForVersion(buffer, version) abort
     let l:executable = ale#fixers#ruff#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'ruff'])
     endif
 

--- a/autoload/ale/fixers/ruff_format.vim
+++ b/autoload/ale/fixers/ruff_format.vim
@@ -41,7 +41,7 @@ endfunction
 
 function! ale#fixers#ruff_format#GetCommand(buffer) abort
     let l:executable = ale#fixers#ruff_format#GetExecutable(a:buffer)
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run ruff'
     \   : ''
 
@@ -52,7 +52,7 @@ function! ale#fixers#ruff_format#Fix(buffer) abort
     let l:executable = ale#fixers#ruff_format#GetExecutable(a:buffer)
     let l:cmd = [ale#Escape(l:executable)]
 
-    if l:executable =~? 'pipenv\|poetry\|uv$'
+    if l:executable =~? '\(pipenv\|poetry\|uv\)$'
         call extend(l:cmd, ['run', 'ruff'])
     endif
 

--- a/autoload/ale/fixers/yapf.vim
+++ b/autoload/ale/fixers/yapf.vim
@@ -29,7 +29,7 @@ endfunction
 function! ale#fixers#yapf#Fix(buffer) abort
     let l:executable = ale#fixers#yapf#GetExecutable(a:buffer)
 
-    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    let l:exec_args = l:executable =~? '\(pipenv\|poetry\|uv\)$'
     \   ? ' run yapf'
     \   : ''
 


### PR DESCRIPTION
Python fixer black fails when vim is running in a virtual environment that's located in a path containing text `poetry` with `python_auto_poetry = 0`. An example would be a path like `~/poetry_in_motion/.venv/bin/black` . The cause of this is the regular expression `poetry\|pipenv\|uv$` which matches `poetry` and `pipenv` if they appear anywhere in the virtualenv path. The trailing `$` in the regex only binds to `uv` only.

This is the error I am getting in `ALEInfo` when running black:
```
(finished - exit code 2) ['/bin/sh', '-c', 'cd ''/home/user/tmp/ale_test/poetry_in_motion'' && ''/home/user/tmp/ale_test/poetry_in_motion/.venv/bin/black'' run black - < ''/tmp/nvim.user/4ou7OE/2/formatting_test.py''']
```
Looks like the bug exists in other places too, so I have fixed them as well.