### PR TITLE
Properly handle optional end_line_no/end_line_pos in sqlfluff

### DIFF
--- a/ale_linters/sql/sqlfluff.vim
+++ b/ale_linters/sql/sqlfluff.vim
@@ -52,16 +52,24 @@ function! ale_linters#sql#sqlfluff#Handle(buffer, version, lines) abort
 
     if ale#semver#GTE(a:version, [3, 0, 0])
         for l:violation in get(l:json, 'violations', [])
-            call add(l:output, {
+            let l:err = {
             \   'filename': l:json.filepath,
             \   'lnum': l:violation.start_line_no,
-            \   'end_lnum': l:violation.end_line_no,
             \   'col': l:violation.start_line_pos,
-            \   'end_col': l:violation.end_line_pos,
             \   'text': l:violation.description,
             \   'code': l:violation.code,
             \   'type': 'W',
-            \})
+            \}
+
+            if has_key(l:violation, 'end_line_no')
+                let l:err.end_lnum = l:violation.end_line_no
+            endif
+
+            if has_key(l:violation, 'end_line_pos')
+                let l:err.end_col = l:violation.end_line_pos
+            endif
+
+            call add(l:output, l:err)
         endfor
     else
         for l:violation in get(l:json, 'violations', [])

--- a/test/handler/test_sql_sqlfluff_handler.vader
+++ b/test/handler/test_sql_sqlfluff_handler.vader
@@ -69,7 +69,15 @@ Execute(The sqlfluff handler should handle basic warnings with version newer tha
   \     'code': 'L009',
   \     'text': 'Files must end with a single trailing newline.',
   \   },
+  \   {
+  \     'filename': 'schema.sql',
+  \     'lnum': 3,
+  \     'col': 21,
+  \     'type': 'W',
+  \     'code': 'TMP',
+  \     'text': "Undefined jinja template variable: 'a_jinja_templated_table'",
+  \   },
   \ ],
   \ ale_linters#sql#sqlfluff#Handle(bufnr(''), [3, 0, 0], [
-  \    '[{"filepath": "schema.sql", "violations": [{"start_line_no": 1, "end_line_no":1, "start_line_pos": 8, "end_line_pos":12, "code": "L010", "description": "Keywords must be consistently upper case."}, {"start_line_no": 13, "end_line_no":13, "start_line_pos": 2, "end_line_pos":20, "code": "L003", "description": "Expected 1 indentation, found 0 [compared to line 12]"}, {"start_line_no": 16, "end_line_no":16, "start_line_pos": 1, "end_line_pos":5, "code": "L009", "description": "Files must end with a single trailing newline."}]}]',
+  \    '[{"filepath": "schema.sql", "violations": [{"start_line_no": 1, "end_line_no":1, "start_line_pos": 8, "end_line_pos":12, "code": "L010", "description": "Keywords must be consistently upper case."}, {"start_line_no": 13, "end_line_no":13, "start_line_pos": 2, "end_line_pos":20, "code": "L003", "description": "Expected 1 indentation, found 0 [compared to line 12]"}, {"start_line_no": 16, "end_line_no":16, "start_line_pos": 1, "end_line_pos":5, "code": "L009", "description": "Files must end with a single trailing newline."}, {"start_line_no": 3, "start_line_pos": 21, "code": "TMP", "description": "Undefined jinja template variable: ''a_jinja_templated_table''"}]}]',
   \ ])


### PR DESCRIPTION
end_line_no/end_line_pos are optional. Example SQL: `SELECT NULL FROM {{ a_jinja_templated_table }};`

`sqlfluff lint --dialect ansi --format json` gives the following error among others:
```
{"start_line_no": 1, "start_line_pos": 21, "code": "TMP", "description":
"Undefined jinja template variable: 'a_jinja_templated_table'", "name":
"", "warning": false}
```

As one can see there is no end_line_no/end_line_pos.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->

Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!

Seriously, read `:help ale-dev` and write tests.
