### PR TITLE
Add erlfmt fixer to the registry and use it with stdin

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -104,6 +104,11 @@ let s:default_registry = {
 \       'description': 'Indent with the Erlang mode for Emacs',
 \       'aliases': ['erlang-mode'],
 \   },
+\   'erlfmt': {
+\       'function': 'ale#fixers#erlfmt#Fix',
+\       'suggested_filetypes': ['erlang'],
+\       'description': 'Format Erlang code with erlfmt',
+\   },
 \   'fecs': {
 \       'function': 'ale#fixers#fecs#Fix',
 \       'suggested_filetypes': ['javascript', 'css', 'html'],

--- a/autoload/ale/fixers/erlfmt.vim
+++ b/autoload/ale/fixers/erlfmt.vim
@@ -13,9 +13,7 @@ function! ale#fixers#erlfmt#Fix(buffer) abort
     let l:options = ale#Var(a:buffer, 'erlang_erlfmt_options')
     let l:executable = ale#fixers#erlfmt#GetExecutable(a:buffer)
 
-    let l:command = ale#Escape(l:executable) . (empty(l:options) ? '' : ' ' . l:options) . ' %s'
+    let l:command = ale#Escape(l:executable) . ale#Pad(l:options) . ' -'
 
-    return {
-    \   'command': l:command
-    \}
+    return {'command': l:command}
 endfunction

--- a/test/fixers/test_erlfmt_fixer_callback.vader
+++ b/test/fixers/test_erlfmt_fixer_callback.vader
@@ -1,25 +1,12 @@
 Before:
-  Save b:ale_elm_format_executable
-  Save b:ale_elm_format_options
-
-  let b:ale_elm_format_executable = 'erlfmt'
-  let b:ale_elm_format_options = ''
+  call ale#assert#SetUpFixerTest('erlang', 'erlfmt')
 
 After:
-  Restore
+  call ale#assert#TearDownFixerTest()
 
 Execute(The erlfmt command should handle empty options):
-  AssertEqual
-  \ {
-  \   'command': ale#Escape('erlfmt') . ' %s'
-  \ },
-  \ ale#fixers#erlfmt#Fix(bufnr(''))
+  AssertFixer {'command': ale#Escape('erlfmt') . ' %s'}
 
 Execute(The erlfmt command should handle custom options):
   let b:ale_erlang_erlfmt_options = '--insert-pragma'
-
-  AssertEqual
-  \ {
-  \   'command': ale#Escape('erlfmt') . ' --insert-pragma %s'
-  \ },
-  \ ale#fixers#erlfmt#Fix(bufnr(''))
+  AssertFixer {'command': ale#Escape('erlfmt') . ' --insert-pragma %s'}

--- a/test/fixers/test_erlfmt_fixer_callback.vader
+++ b/test/fixers/test_erlfmt_fixer_callback.vader
@@ -2,7 +2,29 @@ Before:
   call ale#assert#SetUpFixerTest('erlang', 'erlfmt')
 
 After:
+  unlet! b:root
+
   call ale#assert#TearDownFixerTest()
+
+Execute(The local erlfmt executable should be used by default):
+  " Not sure if this is a good default though.  It seems to imply
+  " that the executable is committed to the repository.
+
+  let b:root = '../test-files/erlang/app_with_erlfmt'
+
+  call ale#test#SetFilename(b:root . '/src/app.erl')
+  AssertFixer {
+  \ 'command': ale#Escape(ale#test#GetFilename(b:root . '/erlfmt')) . ' -',
+  \}
+
+Execute(The global erlfmt executable should be configurable):
+  let b:root = '../test-files/erlang/app_with_erlfmt'
+
+  let b:ale_erlang_erlfmt_executable = '/path/to/erlfmt'
+  let b:ale_erlang_erlfmt_use_global = 1
+
+  call ale#test#SetFilename(b:root . '/src/app.erl')
+  AssertFixer {'command': ale#Escape('/path/to/erlfmt') . ' -'}
 
 Execute(The erlfmt command should handle empty options):
   AssertFixer {'command': ale#Escape('erlfmt') . ' -'}

--- a/test/fixers/test_erlfmt_fixer_callback.vader
+++ b/test/fixers/test_erlfmt_fixer_callback.vader
@@ -5,8 +5,8 @@ After:
   call ale#assert#TearDownFixerTest()
 
 Execute(The erlfmt command should handle empty options):
-  AssertFixer {'command': ale#Escape('erlfmt') . ' %s'}
+  AssertFixer {'command': ale#Escape('erlfmt') . ' -'}
 
 Execute(The erlfmt command should handle custom options):
   let b:ale_erlang_erlfmt_options = '--insert-pragma'
-  AssertFixer {'command': ale#Escape('erlfmt') . ' --insert-pragma %s'}
+  AssertFixer {'command': ale#Escape('erlfmt') . ' --insert-pragma -'}


### PR DESCRIPTION
Until the fixer is added to the registry, it cannot be used without additional configuration. And using the full path to the file being edited results in the loss of unsaved changes.

The tests are slightly refactored and expanded.