### PR TITLE
fix: consider the original config for signs

### DIFF
--- a/lua/ale/diagnostics.lua
+++ b/lua/ale/diagnostics.lua
@@ -68,7 +68,13 @@ module.sendAleResultsToDiagnostics = function(buffer, loclist)
   if set_signs == 1 and sign_priority then
     -- If signs are enabled, set the priority for them.
     local local_cfg = { priority = sign_priority }
-    local global_cfg = vim.diagnostic.config().signs
+    -- NOTE: vim.diagnostic.config() -- retrieving the current config values
+    -- fails in Neovim older than v0.7.0.
+    local ok, diag_cfg = pcall(vim.diagnostic.config)
+    if not ok or not diag_cfg then
+      diag_cfg = { signs = {} }
+    end
+    local global_cfg = diag_cfg.signs
 
     if type(global_cfg) == 'boolean' then
       signs = local_cfg

--- a/lua/ale/diagnostics.lua
+++ b/lua/ale/diagnostics.lua
@@ -61,11 +61,25 @@ module.sendAleResultsToDiagnostics = function(buffer, loclist)
     [1] = true,
   }
 
-  local signs = module.aleVar(buffer, 'set_signs') == 1
+  local set_signs = module.aleVar(buffer, 'set_signs')
+  local sign_priority = module.aleVar(buffer, 'sign_priority')
+  local signs
 
-  if signs then
+  if set_signs == 1 and sign_priority then
     -- If signs are enabled, set the priority for them.
-    signs = {priority = vim.g.ale_sign_priority }
+    local local_cfg = { priority = sign_priority }
+    local global_cfg = vim.diagnostic.config().signs
+
+    if type(global_cfg) == 'boolean' then
+      signs = local_cfg
+    elseif type(global_cfg) == 'table' then
+      signs = vim.tbl_extend('force', global_cfg, local_cfg)
+    else
+      signs = function(...)
+        local calculated = global_cfg(...)
+        return vim.tbl_extend('force', calculated, local_cfg)
+      end
+    end
   end
 
   vim.diagnostic.set(
@@ -73,8 +87,8 @@ module.sendAleResultsToDiagnostics = function(buffer, loclist)
     buffer,
     diagnostics,
     {
-        virtual_text = virtualtext_enabled_set[vim.g.ale_virtualtext_cursor] ~= nil,
-        signs = signs,
+      virtual_text = virtualtext_enabled_set[vim.g.ale_virtualtext_cursor] ~= nil,
+      signs = signs,
     }
   )
 end


### PR DESCRIPTION
It always overwrites signs' config this code below, and therefore, all user settings are ignored.

https://github.com/dense-analysis/ale/blob/65b49c1b8172d0ab1b08ffe8fdcabb93fc1328df/lua/ale/diagnostics.lua#L68

With this patch, ALE considers user settings and overwrites `priority` only if needed.

----

The feature for retrieving the current config values for diagnostics has been implemented in https://github.com/neovim/neovim/pull/17045. This patch is included in Neovim v0.7.0 and higher, so this fix cannot work with v0.6.x -- the minimum version ALE supports. For v0.6.x, I did a small fix (1485bab).