### PR TITLE
fix: stylua should have cwd and --stdin-filepath

### DIFF
--- a/autoload/ale/fixers/stylua.vim
+++ b/autoload/ale/fixers/stylua.vim
@@ -4,11 +4,22 @@
 call ale#Set('lua_stylua_executable', 'stylua')
 call ale#Set('lua_stylua_options', '')
 
+function! ale#fixers#stylua#GetCwd(buffer) abort
+    for l:possible_configfile in ['stylua.toml', '.stylua.toml']
+        let l:config = ale#path#FindNearestFile(a:buffer, l:possible_configfile)
+
+        return !empty(l:config) ? fnamemodify(l:config, ':h') : '%s:h'
+    endfor
+
+    return ''
+endfunction
+
 function! ale#fixers#stylua#Fix(buffer) abort
     let l:executable = ale#Var(a:buffer, 'lua_stylua_executable')
     let l:options = ale#Var(a:buffer, 'lua_stylua_options')
 
     return {
-    \   'command': ale#Escape(l:executable) . ale#Pad(l:options) . ' -',
+    \   'cwd': ale#fixers#stylua#GetCwd(a:buffer),
+    \   'command': ale#Escape(l:executable) . ale#Pad(l:options) . ' --stdin-filepath %s -',
     \}
 endfunction

--- a/test/fixers/test_stylua_fixer_callback.vader
+++ b/test/fixers/test_stylua_fixer_callback.vader
@@ -5,7 +5,7 @@ After:
   call ale#assert#TearDownFixerTest()
 
 Execute(The default command should be correct):
-  AssertFixer {'command': ale#Escape('stylua') . ' -'}
+  AssertFixer {'cwd': '%s:h', 'command': ale#Escape('stylua') . ' --stdin-filepath %s -'}
 
 Execute(The stylua callback should include custom stylua options):
   let g:ale_lua_stylua_executable = 'xxxinvalid'
@@ -13,7 +13,8 @@ Execute(The stylua callback should include custom stylua options):
 
   AssertFixer
   \ {
+  \   'cwd': '%s:h',
   \   'command': ale#Escape('xxxinvalid')
   \     . ' ' . g:ale_lua_stylua_options
-  \     . ' -',
+  \     . ' --stdin-filepath %s -',
   \ }


### PR DESCRIPTION
add `cwd` and `--stdin-filepath` to stylua, so that stylua could pickup the config file correctly.