### PR TITLE
Surface warnings from Zeek linter

### DIFF
--- a/ale_linters/zeek/zeek.vim
+++ b/ale_linters/zeek/zeek.vim
@@ -4,11 +4,12 @@
 call ale#Set('zeek_zeek_executable', 'zeek')
 
 function! ale_linters#zeek#zeek#HandleErrors(buffer, lines) abort
-    let l:pattern = 'error in \v.*, line (\d+): (.*)$'
+    let l:pattern = '\(error\|warning\) in \v.*, line (\d+): (.*)$'
 
     return map(ale#util#GetMatches(a:lines, l:pattern), "{
-    \   'lnum': str2nr(v:val[1]),
-    \   'text': v:val[2],
+    \   'lnum': str2nr(v:val[2]),
+    \   'text': v:val[3],
+    \   'type': (v:val[1] is# 'error') ? 'E': 'W',
     \}")
 endfunction
 

--- a/test/handler/test_zeek_handler.vader
+++ b/test/handler/test_zeek_handler.vader
@@ -4,14 +4,28 @@ Before:
 After:
   call ale#linter#Reset()
 
-Execute(The zeek handler should parse input correctly):
+Execute(The zeek handler should parse errors correctly):
   AssertEqual
   \ [
   \   {
   \     'lnum': 2,
-  \     'text': 'unknown identifier bar, at or near "bar"'
+  \     'text': 'unknown identifier bar, at or near "bar"',
+  \     'type': 'E',
   \   },
   \ ],
   \ ale_linters#zeek#zeek#HandleErrors(bufnr(''), [
   \ 'error in /tmp/foo.zeek, line 2: unknown identifier bar, at or near "bar"'
+  \ ])
+
+Execute(The zeek handler should parse warnings correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 11,
+  \     'text': 'expression value ignored (c$removal_hooks)',
+  \     'type': 'W',
+  \   },
+  \ ],
+  \ ale_linters#zeek#zeek#HandleErrors(bufnr(''), [
+  \ 'warning in /tmp/bar.zeek, line 11: expression value ignored (c$removal_hooks)'
   \ ])


### PR DESCRIPTION
In addition to errors Zeek's parsing can also expose warning messages, e.g., for the following code

```zeek
event http_stats(c: connection, stats: http_stats_rec) {
    c$removal_hooks;
}
```

a warning is emitted

```
warning in /tmp/foo.zeek, line 2: expression value ignored (c$removal_hooks)
```

This patch adds parsing and propagation of these warning messages.
