### PR TITLE
xmllint fixer must read from stdin - not buffer filename

### DIFF
--- a/autoload/ale/fixers/xmllint.vim
+++ b/autoload/ale/fixers/xmllint.vim
@@ -7,15 +7,8 @@ call ale#Set('xml_xmllint_indentsize', 2)
 
 function! ale#fixers#xmllint#Fix(buffer) abort
     let l:executable = ale#Escape(ale#Var(a:buffer, 'xml_xmllint_executable'))
-    let l:filename = bufname(a:buffer)
 
-    if empty(l:filename)
-        let l:filename = '%t'
-    else
-        let l:filename = ale#Escape(l:filename)
-    endif
-
-    let l:command = l:executable . ' --format ' . l:filename
+    let l:command = l:executable . ' --format'
 
     let l:indent = ale#Var(a:buffer, 'xml_xmllint_indentsize')
 
@@ -31,6 +24,6 @@ function! ale#fixers#xmllint#Fix(buffer) abort
     endif
 
     return {
-    \   'command': l:command
+    \   'command': l:command . ' -'
     \}
 endfunction

--- a/test/fixers/test_xmllint_fixer_callback.vader
+++ b/test/fixers/test_xmllint_fixer_callback.vader
@@ -18,39 +18,39 @@ Execute(The xmllint callback should return the correct default command with unpe
   AssertEqual
   \ {
   \   'command': ale#Escape('/path/to/xmllint')
-  \     . ' --format %t'
+  \     . ' --format -'
   \ },
   \ ale#fixers#xmllint#Fix(bufnr(''))
 
 Execute(The xmllint callback should return the correct default command):
+  call ale#test#SetFilename('../test-files/xml/dummy.xml')
+
   AssertEqual
   \ {
   \   'command': ale#Escape('/path/to/xmllint')
-  \     . ' --format '
-  \     . ale#Escape(bufname(bufnr('')))
+  \     . ' --format -'
   \ },
   \ ale#fixers#xmllint#Fix(bufnr(''))
 
 Execute(The xmllint callback should include the XMLLINT_INDENT variable):
+  call ale#test#SetFilename('../test-files/xml/dummy.xml')
   let g:ale_xml_xmllint_indentsize = 2
 
   AssertEqual
   \ {
   \   'command': ale#Env('XMLLINT_INDENT', '  ')
   \     . ale#Escape('/path/to/xmllint')
-  \     . ' --format '
-  \     . ale#Escape(bufname(bufnr('')))
+  \     . ' --format -'
   \ },
   \ ale#fixers#xmllint#Fix(bufnr(''))
 
 Execute(The xmllint callback should include additional options):
-  let g:ale_xml_xmllint_options = '--nonet'
+  call ale#test#SetFilename('../test-files/xml/dummy.xml')
+  let g:ale_xml_xmllint_options = '--nonet --custom-opt 2'
 
   AssertEqual
   \ {
   \   'command': ale#Escape('/path/to/xmllint')
-  \     . ' --format '
-  \     . ale#Escape(bufname(bufnr('')))
-  \     . ' --nonet'
+  \     . ' --format --nonet --custom-opt 2 -'
   \ },
   \ ale#fixers#xmllint#Fix(bufnr(''))

--- a/test/test-files/xml/dummy.xml
+++ b/test/test-files/xml/dummy.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<xml>
+  <test id="12"/>
+</xml>


### PR DESCRIPTION
The current xmllint fixer reads and formats the file that a buffer is associated with from disk instead of accepting input from stdin. This has the side effect that if the filename is changed in the buffer, but not saved yet, the fixer discards all the pending changes and replaces the buffer contents with the formatted text from the file contents on disk.

https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html