### PR TITLE
fix ale_python_auto_virtualenv to correctly set virtualenv env vars

### DIFF
--- a/autoload/ale/python.vim
+++ b/autoload/ale/python.vim
@@ -108,12 +108,17 @@ function! ale#python#AutoVirtualenvEnvString(buffer) abort
 
     if !empty(l:venv_dir)
         let l:strs = [ ]
+        " venv/bin directory
+        let l:pathdir = join([l:venv_dir, s:bin_dir], s:sep)
 
         " expand PATH correctly inside of the appropriate shell.
+        " set VIRTUAL_ENV to point to venv
         if has('win32')
-            call add(l:strs, 'set PATH=' . ale#Escape(l:venv_dir) . ';%PATH% && ')
+            call add(l:strs, 'set PATH=' . ale#Escape(l:pathdir) . ';%PATH% && ')
+            call add(l:strs, 'set VIRTUAL_ENV=' . ale#Escape(l:venv_dir) . ' && ')
         else
-            call add(l:strs, 'PATH=' . ale#Escape(l:venv_dir) . '":$PATH" ')
+            call add(l:strs, 'PATH=' . ale#Escape(l:pathdir) . '":$PATH" ')
+            call add(l:strs, 'VIRTUAL_ENV=' . ale#Escape(l:venv_dir) . ' ')
         endif
 
         return join(l:strs, '')

--- a/test/test_python_virtualenv.vader
+++ b/test/test_python_virtualenv.vader
@@ -14,7 +14,7 @@ Execute(ale#python#FindVirtualenv falls back to $VIRTUAL_ENV when no directories
 Execute(ale#python#AutoVirtualenvEnvString should return the correct values):
   if has('win32')
     AssertEqual
-    \ 'set PATH=/opt/example/\Scripts;%PATH% && set VIRTUAL_ENV=/opt/example/ &&',
+    \ 'set PATH=/opt/example/\Scripts;%PATH% && set VIRTUAL_ENV=/opt/example/ && ',
     \ ale#python#AutoVirtualenvEnvString(bufnr(''))
   else
     AssertEqual

--- a/test/test_python_virtualenv.vader
+++ b/test/test_python_virtualenv.vader
@@ -14,10 +14,10 @@ Execute(ale#python#FindVirtualenv falls back to $VIRTUAL_ENV when no directories
 Execute(ale#python#AutoVirtualenvEnvString should return the correct values):
   if has('win32')
     AssertEqual
-    \ 'set PATH=/opt/example/;%PATH% && ',
+    \ 'set PATH=/opt/example/\\Scripts;%PATH% && set VIRTUAL_ENV=/opt/example/ &&',
     \ ale#python#AutoVirtualenvEnvString(bufnr(''))
   else
     AssertEqual
-    \ 'PATH=''/opt/example/''":$PATH" ',
+    \ 'PATH=''/opt/example//bin''":$PATH" VIRTUAL_ENV=''/opt/example/'' ',
     \ ale#python#AutoVirtualenvEnvString(bufnr(''))
   endif

--- a/test/test_python_virtualenv.vader
+++ b/test/test_python_virtualenv.vader
@@ -14,7 +14,7 @@ Execute(ale#python#FindVirtualenv falls back to $VIRTUAL_ENV when no directories
 Execute(ale#python#AutoVirtualenvEnvString should return the correct values):
   if has('win32')
     AssertEqual
-    \ 'set PATH=/opt/example/\\Scripts;%PATH% && set VIRTUAL_ENV=/opt/example/ &&',
+    \ 'set PATH=/opt/example/\Scripts;%PATH% && set VIRTUAL_ENV=/opt/example/ &&',
     \ ale#python#AutoVirtualenvEnvString(bufnr(''))
   else
     AssertEqual


### PR DESCRIPTION
First, thank you for ALE!

According to the documentation, `ale_python_auto_virtualenv` should automatically set environment variables for commands, but previously the variables were not set completely or correctly.

Before:
  `PATH` variable was expanded to include `/path/to/venv`
After:
  `PATH` variable is expanded to include `/path/to/venv/bin`
  `VIRTUAL_ENV` variable is set to `path/to/venv`

This mimics exactly what the `activate` scripts do, and allows the configuration knob to work as expected.

For example, after this change, `jedi-language-server` can be installed globally (instead of inside every venv), and it will "just work" (e.g. find references to dependencies in the venv) when editing a file in a project that uses a venv, because the correct variables are set.

