### PR TITLE
Yara yls support

### DIFF
--- a/ale_linters/yara/yls.vim
+++ b/ale_linters/yara/yls.vim
@@ -1,0 +1,17 @@
+" Author: TcM1911
+" Description: A language server for Yara.
+
+call ale#Set('yara_yls_executable', 'yls')
+
+function! ale_linters#yara#yls#FindProjectRoot(buffer) abort
+   let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
+   return !empty(l:project_root) ? (l:project_root) : ''
+endfunction
+
+call ale#linter#Define('yara', {
+\   'name': 'yls',
+\   'lsp': 'stdio',
+\   'executable': {b -> ale#Var(b, 'yara_yls_executable')},
+\   'command': '%e -v',
+\   'project_root': function('ale_linters#yara#yls#FindProjectRoot'),
+\})

--- a/ale_linters/yara/yls.vim
+++ b/ale_linters/yara/yls.vim
@@ -5,6 +5,7 @@ call ale#Set('yara_yls_executable', 'yls')
 
 function! ale_linters#yara#yls#FindProjectRoot(buffer) abort
     let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
+
     return !empty(l:project_root) ? (ale#path#Upwards(l:project_root)[1]) : ''
 endfunction
 

--- a/ale_linters/yara/yls.vim
+++ b/ale_linters/yara/yls.vim
@@ -5,7 +5,7 @@ call ale#Set('yara_yls_executable', 'yls')
 
 function! ale_linters#yara#yls#FindProjectRoot(buffer) abort
     let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
-    return !empty(l:project_root) ? (l:project_root) : ''
+    return !empty(l:project_root) ? (ale#path#Upwards(l:project_root)[1]) : ''
 endfunction
 
 call ale#linter#Define('yara', {

--- a/ale_linters/yara/yls.vim
+++ b/ale_linters/yara/yls.vim
@@ -4,8 +4,8 @@
 call ale#Set('yara_yls_executable', 'yls')
 
 function! ale_linters#yara#yls#FindProjectRoot(buffer) abort
-   let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
-   return !empty(l:project_root) ? (l:project_root) : ''
+    let l:project_root = ale#path#FindNearestDirectory(a:buffer, '.git')
+    return !empty(l:project_root) ? (l:project_root) : ''
 endfunction
 
 call ale#linter#Define('yara', {

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -734,9 +734,9 @@ Notes:
   * `yamlfix`
   * `yamlfmt`
   * `yamllint`
+  * `yq`
 * Yara
   * `yls`
-  * `yq`
 * YANG
   * `yang-lsp`
 * Zeek

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -729,6 +729,8 @@ Notes:
   * `yamlfix`
   * `yamlfmt`
   * `yamllint`
+* Yara
+  * `yls`
 * YANG
   * `yang-lsp`
 * Zeek

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -735,10 +735,10 @@ Notes:
   * `yamlfmt`
   * `yamllint`
   * `yq`
-* Yara
-  * `yls`
 * YANG
   * `yang-lsp`
+* Yara
+  * `yls`
 * Zeek
   * `zeek`!!
 * Zig

--- a/doc/ale-yara.txt
+++ b/doc/ale-yara.txt
@@ -1,0 +1,22 @@
+===============================================================================
+ALE Yara Integration                                         *ale-yara-options*
+                                                         *ale-integration-yara*
+
+===============================================================================
+Integration Information
+
+  Currently, the only supported linter for yara is yls.
+
+
+===============================================================================
+yls                                                              *ale-yara-yls*
+
+g:ale_yara_yls_executable                           *g:ale_yara_yls_executable*
+                                                    *b:ale_yara_yls_executable*
+  Type: |String|
+  Default: `'yls'`
+
+  This variable can be modified to change the executable path for `yls`.
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3525,6 +3525,8 @@ documented in additional help files.
     yq....................................|ale-yaml-yq|
   yang....................................|ale-yang-options|
     yang-lsp..............................|ale-yang-lsp|
+  yara....................................|ale-yara-options|
+    yls...................................|ale-yara-yls|
   zeek....................................|ale-zeek-options|
     zeek..................................|ale-zeek-zeek|
   zig.....................................|ale-zig-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -740,6 +740,8 @@ formatting.
   * [yamllint](https://yamllint.readthedocs.io/)
 * YANG
   * [yang-lsp](https://github.com/theia-ide/yang-lsp)
+* Yara
+  * [yls](https://github.com/avast/yls)
 * Zeek
   * [zeek](http://zeek.org) :floppy_disk:
 * Zig

--- a/test/linter/test_yara_yls.vader
+++ b/test/linter/test_yara_yls.vader
@@ -1,0 +1,15 @@
+Before:
+  call ale#assert#SetUpLinterTest('yara', 'yls')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default executable path should be correct):
+  AssertLinter 'yls', ale#Escape('yls')
+
+Execute(The project root should be detected correctly):
+  AssertLSPProject ''
+
+  call ale#test#SetFilename('../test-files/yara/dummy.yar')
+
+  AssertLSPProject ale#path#Simplify(g:dir . '/../..')

--- a/test/linter/test_yara_yls.vader
+++ b/test/linter/test_yara_yls.vader
@@ -5,11 +5,9 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default executable path should be correct):
-  AssertLinter 'yls', ale#Escape('yls')
+  AssertLinter 'yls', ale#Escape('yls') . ' -v'
 
 Execute(The project root should be detected correctly):
-  AssertLSPProject ''
-
   call ale#test#SetFilename('../test-files/yara/dummy.yar')
 
   AssertLSPProject ale#path#Simplify(g:dir . '/../..')

--- a/test/test-files/yara/dummy.yar
+++ b/test/test-files/yara/dummy.yar
@@ -1,0 +1,5 @@
+rule dummy
+{
+    condition:
+        false
+}


### PR DESCRIPTION
This adds Yara support to ALE using Avast's language server for yara:
https://avast.github.io/yls/

A `.git` folder is used to determine the project_root so this means the
Yara rules must be in a git repo for the integration to work.

The server only have 1 optional argument (-v, --verbose). Since this is
the case, no additional configuration options are available.