### PR TITLE
lint: treat bash as sh

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -11,6 +11,7 @@ let s:linters = {}
 " NOTE: Update the g:ale_linter_aliases documentation when modifying this.
 let s:default_ale_linter_aliases = {
 \   'Dockerfile': 'dockerfile',
+\   'bash': 'sh',
 \   'csh': 'sh',
 \   'javascriptreact': ['javascript', 'jsx'],
 \   'plaintex': 'tex',

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1504,6 +1504,7 @@ g:ale_linter_aliases                                     *g:ale_linter_aliases*
 
   {
   \   'Dockerfile': 'dockerfile',
+  \   'bash': 'sh',
   \   'csh': 'sh',
   \   'javascriptreact': ['javascript', 'jsx'],
   \   'plaintex': 'tex',


### PR DESCRIPTION
Vim version 9.1.0965 [1] in commit b9b762c21f (patch 9.1.0965: filetype: sh filetype set when detecting the use of bash, 2024-12-27) broke out bash as a standalone filetype (whose runtime support already redirects through the shell runtime support).

As a consequence, ALE didn't lint filetype=bash well. Teach it to consider bash an alias of sh (until and unless it is desirable to have bash-specific linters, at which point we may need to duplicate some linters like shellcheck or find another way to mark them enabled for bash).

Something like

    runtime! ale_linters/sh/*.vim

in `ale_linters/bash/redirect_to_sh.vim` doesn't work because the linters are defined with ale#linter#Define('sh', …).

[1]: https://github.com/vim/vim/commit/b9b762c21f2b61e0e7d8fee43d4d3dc8ecffd721
