### PR TITLE
fix: memory-limit option for phpstan

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -22,7 +22,7 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
 
     let l:memory_limit = ale#Var(a:buffer, 'php_phpstan_memory_limit')
     let l:memory_limit_option = !empty(l:memory_limit)
-    \   ? ' --memory-limit ' . ale#Escape(l:memory_limit)
+    \   ? ' --memory-limit=' . ale#Escape(l:memory_limit)
     \   : ''
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -125,7 +125,7 @@ Execute(Memory limit parameter is added to the command):
   let g:ale_php_phpstan_memory_limit = '500M'
 
   AssertLinter 'phpstan',
-  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' --memory-limit ' . ale#Escape('500M') . ' %s'
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('4') . ' --memory-limit=' . ale#Escape('500M') . ' %s'
 
 Execute(Directory is changed to that of the configuration file):
   call writefile([], '../phpstan.neon')


### PR DESCRIPTION
This might only be a problem for newer phpstan versions (2.1.1 here).

If you try to run `phpstan` the way ale will when it builds the option, you will get something like:

```
The "--memory-limit" option requires a value.
```

It wants you to use `--memory-limit=-1` instead.

Updated existing test, but we should probably check to make sure phpstan is ~~backwards~~forward compatible with this `--key=val` option format if this is in fact a change to how that option is parsed, and otherwise make some kind of shim for both version?