### PR TITLE
Update: #4785 New tool pymarkdown added for markdown linting

### DIFF
--- a/ale_linters/markdown/pymarkdown.vim
+++ b/ale_linters/markdown/pymarkdown.vim
@@ -1,0 +1,73 @@
+
+call ale#Set('markdown_pymarkdown_executable', 'pymarkdown')
+call ale#Set('markdown_pymarkdown_options', '')
+call ale#Set('markdown_pymarkdown_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('markdown_pymarkdown_auto_pipenv', 0)
+call ale#Set('markdown_pymarkdown_auto_poetry', 0)
+call ale#Set('markdown_pymarkdown_auto_uv', 0)
+
+function! ale_linters#markdown#pymarkdown#GetExecutable(buffer) abort
+    if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'markdown_pymarkdown_auto_pipenv'))
+    \ && ale#python#PipenvPresent(a:buffer)
+        return 'pipenv'
+    endif
+
+    if (ale#Var(a:buffer, 'python_auto_poetry') || ale#Var(a:buffer, 'markdown_pymarkdown_auto_poetry'))
+    \ && ale#python#PoetryPresent(a:buffer)
+        return 'poetry'
+    endif
+
+    if (ale#Var(a:buffer, 'python_auto_uv') || ale#Var(a:buffer, 'markdown_pymarkdown_auto_uv'))
+    \ && ale#python#UvPresent(a:buffer)
+        return 'uv'
+    endif
+
+    return ale#python#FindExecutable(a:buffer, 'markdown_pymarkdown', ['pymarkdown'])
+endfunction
+
+function! ale_linters#markdown#pymarkdown#GetCommand(buffer) abort
+    let l:executable = ale_linters#markdown#pymarkdown#GetExecutable(a:buffer)
+
+    let l:exec_args = l:executable =~? 'pipenv\|poetry\|uv$'
+    \   ? ' run pymarkdown'
+    \   : ''
+
+    return ale#Escape(l:executable) . l:exec_args
+    \   . ' '
+    \   . ale#Var(a:buffer, 'markdown_pymarkdown_options')
+    \   . 'scan-stdin'
+endfunction
+
+function! ale_linters#markdown#pymarkdown#Handle(buffer, lines) abort
+    let l:pattern = '\v^(\S*):(\d+):(\d+): ([A-Z]+\d+): (.*)$'
+    let l:output = []
+    " lines are formatted as follows:
+    " sample.md:1:1: MD022: Headings should be surrounded by blank lines. [Expected: 1; Actual: 0; Below] (blanks-around-headings,blanks-around-headers)
+
+    for l:match in ale#util#GetMatches(a:lines, l:pattern)
+        if(l:match[4] is# 'MD009')
+        \&& !ale#Var(a:buffer, 'warn_about_trailing_whitespace')
+            " Skip warnings for trailing whitespace if the option is off.
+            continue
+        endif
+
+        let l:item = {
+        \   'lnum': l:match[2] + 0,
+        \   'col': l:match[3] + 0,
+        \   'type': l:match[4][0],
+        \   'text': l:match[5],
+        \   'code': l:match[4],
+        \}
+
+        call add(l:output, l:item)
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('markdown', {
+\   'name': 'pymarkdown',
+\   'executable': function('ale_linters#markdown#pymarkdown#GetExecutable'),
+\   'command': function('ale_linters#markdown#pymarkdown#GetCommand'),
+\   'callback': 'ale_linters#markdown#pymarkdown#Handle',
+\})

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -389,6 +389,7 @@ Notes:
   * `pandoc`
   * `prettier`
   * `proselint`
+  * `pymarkdown`
   * `redpen`
   * `remark-lint`
   * `textlint`

--- a/test/linter/test_pymarkdown.vader
+++ b/test/linter/test_pymarkdown.vader
@@ -1,0 +1,50 @@
+Before:
+  call ale#assert#SetUpLinterTest('markdown', 'pymarkdown')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The pymarkdown command callback should return default string):
+  AssertLinter 'pymarkdown', ale#Escape('pymarkdown') . ' scan-stdin'
+
+Execute(The pycodestyle command callback should allow options):
+  let g:markdown_pymarkdown_options = '--exclude=test*.py'
+
+Execute(The pymarkdown executable should be configurable):
+  let g:ale_markdown_pymarkdown_executable = '~/.local/bin/pymarkdown'
+
+  AssertLinter '~/.local/bin/pymarkdown',
+  \ ale#Escape('~/.local/bin/pymarkdown') . ' scan-stdin'
+
+Execute(Setting executable to 'pipenv' appends 'run pymarkdown'):
+  let g:ale_markdown_pymarkdown_executable = 'path/to/pipenv'
+
+  AssertLinter 'path/to/pipenv',
+  \ ale#Escape('path/to/pipenv') . ' run pymarkdown scan-stdin'
+
+Execute(Pipenv is detected when markdown_pymarkdown_auto_pipenv is set):
+  let g:ale_markdown_pymarkdown_auto_pipenv = 1
+  call ale#test#SetFilename('../test-files/python/pipenv/whatever.py')
+
+  AssertLinter 'pipenv',
+  \ ale#Escape('pipenv') . ' run pymarkdown scan-stdin'
+
+Execute(Setting executable to 'poetry' appends 'run pymarkdown'):
+  let g:ale_markdown_pymarkdown_executable = 'path/to/poetry'
+
+  AssertLinter 'path/to/poetry',
+  \ ale#Escape('path/to/poetry') . ' run pymarkdown scan-stdin'
+
+Execute(Poetry is detected when markdown_pymarkdown_auto_poetry is set):
+  let g:ale_markdown_pymarkdown_auto_poetry = 1
+  call ale#test#SetFilename('../test-files/python/poetry/whatever.py')
+
+  AssertLinter 'poetry',
+  \ ale#Escape('poetry') . ' run pymarkdown scan-stdin'
+
+Execute(uv is detected when markdown_pymarkdown_auto_uv is set):
+  let g:ale_markdown_pymarkdown_auto_uv = 1
+  call ale#test#SetFilename('../test-files/python/uv/whatever.py')
+
+  AssertLinter 'uv',
+  \ ale#Escape('uv') . ' run pymarkdown scan-stdin'

--- a/test/linter/test_pymarkdown_handler.vader
+++ b/test/linter/test_pymarkdown_handler.vader
@@ -1,0 +1,52 @@
+Before:
+    Save g:ale_warn_about_trailing_whitespace
+
+    let g:ale_warn_about_trailing_whitespace = 1
+
+    runtime ale_linters/markdown/pymarkdown.vim
+
+After:
+    Restore
+    unlet! b:ale_warn_about_trailing_whitespace
+
+    call ale#linter#Reset()
+
+Execute (Should parse error correctly):
+  AssertEqual
+  \ [
+  \   {
+        \   'lnum': 1,
+        \   'col': 1,
+        \   'type': 'M',
+        \   'text': 'Headings should be surrounded by blank lines',
+        \   'code': 'MD022',
+  \   }
+  \ ],
+  \ ale_linters#markdown#pymarkdown#Handle(bufnr(''), [
+  \ 'foo.md:1:1: MD022: Headings should be surrounded by blank lines',
+  \ ])
+
+Execute(Warnings about trailing whitespace should be reported by default):
+  AssertEqual
+  \ [
+  \   {
+        \   'lnum': 1,
+        \   'col': 1,
+        \   'type': 'M',
+        \   'text': 'who cares',
+        \   'code': 'MD009',
+  \   },
+  \ ],
+  \ ale_linters#markdown#pymarkdown#Handle(bufnr(''), [
+  \   'foo.md:1:1: MD009: who cares',
+  \ ])
+
+Execute(Disabling trailing whitespace warnings should work):
+  let b:ale_warn_about_trailing_whitespace = 0
+
+  AssertEqual
+  \ [
+  \ ],
+  \ ale_linters#markdown#pymarkdown#Handle(bufnr(''), [
+  \   'foo.md:1:1: MD009: who cares',
+  \ ])


### PR DESCRIPTION
We added the new tool in  doc/ale-supported-tools.txt
