### PR TITLE
iverilog current file search path

### DIFF
--- a/ale_linters/verilog/iverilog.vim
+++ b/ale_linters/verilog/iverilog.vim
@@ -5,6 +5,7 @@ call ale#Set('verilog_iverilog_options', '')
 
 function! ale_linters#verilog#iverilog#GetCommand(buffer) abort
     return 'iverilog -t null -Wall '
+    \   . '-y%s:h '
     \   . ale#Var(a:buffer, 'verilog_iverilog_options')
     \   . ' %t'
 endfunction

--- a/test/linter/test_iverilog.vader
+++ b/test/linter/test_iverilog.vader
@@ -5,10 +5,10 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(The default iverilog command should be correct):
-  AssertLinter 'iverilog', 'iverilog -t null -Wall  %t'
+  AssertLinter 'iverilog', 'iverilog -t null -Wall -y%s:h  %t'
 
 Execute(iverilog options should be configurable):
   " Additional args for the linter
   let g:ale_verilog_iverilog_options = '-y.'
 
-  AssertLinter 'iverilog', 'iverilog -t null -Wall -y. %t'
+  AssertLinter 'iverilog', 'iverilog -t null -Wall -y%s:h -y. %t'


### PR DESCRIPTION
In the vein of commit ea72d66b "Verilator current file search path (#3500)"

This includes the directory of the current file in the library search path. From `man iverilog`:

           -ylibdir
               Append  the  directory  to the library module search
               path. When the compiler finds an undefined module, it
               looks in these directories for files with the right name.