### PR TITLE
more defensive coding: guard against a non-iterable loclist

### DIFF
--- a/autoload/ale/engine.vim
+++ b/autoload/ale/engine.vim
@@ -178,6 +178,12 @@ function! s:HandleExit(job_info, buffer, output, data) abort
         let l:loclist = []
     endtry
 
+    if type(l:loclist) isnot# v:t_list
+        " we only expect the list type; don't pass anything else down to
+        " `ale#engine#HandleLoclist` since it won't understand it
+        let l:loclist = []
+    endif
+
     call ale#engine#HandleLoclist(l:linter.name, a:buffer, l:loclist, 0)
 endfunction
 


### PR DESCRIPTION
Sometimes `s:HandleExit` can execute a deferred linter callback, which ends up setting the `l:loclist` that's passed into `ale#engine#HandleLoclist` at the end of `s:HandleExit` to a dictionary. This dictionary cannot be iterated over, and thus errors out.

Guard against trying to iterate over values that don't make sense.