### PR TITLE
Fix 4913 - use JSON output for golangci-lint instead of regexps.

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -33,6 +33,10 @@ function! ale_linters#go#golangci_lint#Handler(buffer, lines) abort
 
     let l:matches = ale#util#FuzzyJSONDecode(a:lines, [])
 
+    if empty(l:matches)
+        return []
+    endif
+
     for l:match in l:matches['Issues']
         if l:match['FromLinter'] is# 'typecheck'
             let l:msg_type = 'E'

--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -15,39 +15,37 @@ function! ale_linters#go#golangci_lint#GetCommand(buffer) abort
         return ale#go#EnvString(a:buffer)
         \   . '%e run '
         \   .  l:options
+        \   . ' --out-format=json'
+        \   . ' --show-stats=0'
     endif
 
     return ale#go#EnvString(a:buffer)
     \   . '%e run '
     \   . ale#Escape(l:filename)
     \   . ' ' . l:options
-endfunction
-
-function! ale_linters#go#golangci_lint#GetMatches(lines) abort
-    let l:pattern = '\v^([a-zA-Z]?:?[^:]+):(\d+):?(\d+)?:?:?:?\s\*?(.+)\s+\((.+)\)$'
-
-    return ale#util#GetMatches(a:lines, l:pattern)
+    \   . ' --out-format=json'
+    \   . ' --show-stats=0'
 endfunction
 
 function! ale_linters#go#golangci_lint#Handler(buffer, lines) abort
     let l:dir = expand('#' . a:buffer . ':p:h')
     let l:output = []
 
-    for l:match in ale_linters#go#golangci_lint#GetMatches(a:lines)
-        if l:match[5] is# 'typecheck'
+    let l:matches = ale#util#FuzzyJSONDecode(a:lines, [])
+
+    for l:match in l:matches['Issues']
+        if l:match['FromLinter'] is# 'typecheck'
             let l:msg_type = 'E'
         else
             let l:msg_type = 'W'
         endif
 
-        " l:match[1] will already be an absolute path, output from
-        " golangci_lint
         call add(l:output, {
-        \   'filename': ale#path#GetAbsPath(l:dir, l:match[1]),
-        \   'lnum': l:match[2] + 0,
-        \   'col': l:match[3] + 0,
+        \   'filename': ale#path#GetAbsPath(l:dir, l:match['Pos']['Filename']),
+        \   'lnum': l:match['Pos']['Line'] + 0,
+        \   'col': l:match['Pos']['Column'] + 0,
         \   'type': l:msg_type,
-        \   'text': l:match[4] . ' (' . l:match[5] . ')',
+        \   'text': match['FromLinter'] . ' - ' . l:match['Text'],
         \})
     endfor
 

--- a/test/handler/test_golangci_lint_handler.vader
+++ b/test/handler/test_golangci_lint_handler.vader
@@ -4,63 +4,107 @@ Before:
 After:
   call ale#linter#Reset()
 
-Execute (The golangci-lint handler should handle names with spaces):
-  " We can't test Windows paths with the path resovling on Linux, but we can
-  " test the regex.
-  AssertEqual
-  \ [
-  \   [
-  \     'C:\something\file with spaces.go',
-  \     '12',
-  \     '3',
-  \     'expected ''package'', found ''IDENT'' gibberish',
-  \     'staticcheck',
-  \   ],
-  \ ],
-  \ map(ale_linters#go#golangci_lint#GetMatches([
-  \   'C:\something\file with spaces.go:12:3: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \ ]), 'v:val[1:5]')
-
-Execute (The golangci-lint handler should handle paths correctly):
-  call ale#test#SetFilename('app/test.go')
-
-  let file = ale#path#GetAbsPath(expand('%:p:h'), 'test.go')
-
-  AssertEqual
-  \ [
-  \   {
-  \     'lnum': 12,
-  \     'col': 3,
-  \     'text': 'expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \     'type': 'W',
-  \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
-  \   },
-  \ ],
-  \ ale_linters#go#golangci_lint#Handler(bufnr(''), [
-  \   file . ':12:3: expected ''package'', found ''IDENT'' gibberish (staticcheck)',
-  \ ])
-
 Execute (The golangci-lint handler should handle only typecheck lines as errors):
   call ale#test#SetFilename('app/main.go')
 
   AssertEqual
   \ [
   \   {
-  \     'lnum': 30,
-  \     'col': 5,
-  \     'text': 'variable ''err'' is not used (typecheck)',
+  \     'lnum': 1,
+  \     'col': 0,
+  \     'text': 'typecheck - found packages main (main.go) and validator (validation.go) in ',
   \     'type': 'E',
-  \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/main.go'),
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'col': 1,
+  \     'text': 'typecheck - package validator_test; expected package main_test',
+  \     'type': 'E',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/validation_encoder_test.go'),
+  \   },
+  \   {
+  \     'lnum': 1,
+  \     'col': 1,
+  \     'text': 'typecheck - package validator_test; expected package main_test',
+  \     'type': 'E',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/validation_error_test.go'),
   \   },
   \   {
   \     'lnum': 505,
   \     'col': 75,
-  \     'text': 'Magic number: 404, in <argument> detected (gomnd)',
+  \     'text': 'gomnd - Magic number: 404, in <argument> detected',
   \     'type': 'W',
-  \     'filename': ale#path#Simplify(expand('%:p:h') . '/test.go'),
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/main.go'),
   \   }
   \ ],
   \ ale_linters#go#golangci_lint#Handler(bufnr(''), [
-  \   ale#path#GetAbsPath(expand('%:p:h'), 'test.go') . ':30:5: variable ''err'' is not used (typecheck)',
-  \   ale#path#GetAbsPath(expand('%:p:h'), 'test.go') . ':505:75: Magic number: 404, in <argument> detected (gomnd)',
+  \ '{',
+  \ '  "Issues": [',
+  \ '  {',
+  \ '    "FromLinter": "typecheck",',
+  \ '    "Text": "found packages main (main.go) and validator (validation.go) in ",',
+  \ '    "Severity": "",',
+  \ '    "SourceLines": [',
+  \ '      "package main"',
+  \ '    ],',
+  \ '    "Pos": {',
+  \ '      "Filename": "main.go",',
+  \ '      "Offset": 0,',
+  \ '      "Line": 1,',
+  \ '      "Column": 0',
+  \ '    },',
+  \ '    "ExpectNoLint": false,',
+  \ '    "ExpectedNoLintLinter": ""',
+  \ '  },',
+  \ '  {',
+  \ '    "FromLinter": "typecheck",',
+  \ '    "Text": "package validator_test; expected package main_test",',
+  \ '    "Severity": "",',
+  \ '    "SourceLines": [',
+  \ '      "package validator_test"',
+  \ '    ],',
+  \ '    "Pos": {',
+  \ '      "Filename": "validation_encoder_test.go",',
+  \ '      "Offset": 0,',
+  \ '      "Line": 1,',
+  \ '      "Column": 1',
+  \ '    },',
+  \ '    "ExpectNoLint": false,',
+  \ '    "ExpectedNoLintLinter": ""',
+  \ '  },',
+  \ '  {',
+  \ '    "FromLinter": "typecheck",',
+  \ '    "Text": "package validator_test; expected package main_test",',
+  \ '    "Severity": "",',
+  \ '    "SourceLines": [',
+  \ '      "package validator_test"',
+  \ '    ],',
+  \ '    "Pos": {',
+  \ '      "Filename": "validation_error_test.go",',
+  \ '      "Offset": 0,',
+  \ '      "Line": 1,',
+  \ '      "Column": 1',
+  \ '    },',
+  \ '    "ExpectNoLint": false,',
+  \ '    "ExpectedNoLintLinter": ""',
+  \ '  },',
+  \ '  {',
+  \ '    "FromLinter": "gomnd",',
+  \ '    "Text": "Magic number: 404, in <argument> detected",',
+  \ '    "Severity": "",',
+  \ '    "SourceLines": [',
+  \ '      "package validator_test"',
+  \ '    ],',
+  \ '    "Pos": {',
+  \ '      "Filename": "main.go",',
+  \ '      "Offset": 0,',
+  \ '      "Line": 505,',
+  \ '      "Column": 75',
+  \ '    },',
+  \ '    "ExpectNoLint": false,',
+  \ '    "ExpectedNoLintLinter": ""',
+  \ '    }',
+  \ '  ]',
+  \ '}',
   \ ])

--- a/test/linter/test_golangci_lint.vader
+++ b/test/linter/test_golangci_lint.vader
@@ -14,14 +14,14 @@ After:
 Execute(The golangci-lint defaults should be correct):
   AssertLinterCwd '%s:h',
   AssertLinter 'golangci-lint',
-  \ ale#Escape('golangci-lint') . ' run '
+  \ ale#Escape('golangci-lint') . ' run  --out-format=json --show-stats=0'
 
 Execute(The golangci-lint callback should use a configured executable):
   let b:ale_go_golangci_lint_executable = 'something else'
 
   AssertLinter 'something else',
   \ ale#Escape('something else')
-  \   . ' run '
+  \   . ' run  --out-format=json --show-stats=0'
 
 Execute(The golangci-lint callback should use configured options):
   let b:ale_go_golangci_lint_options = '--foobar'
@@ -29,7 +29,9 @@ Execute(The golangci-lint callback should use configured options):
   AssertLinter 'golangci-lint',
   \ ale#Escape('golangci-lint')
   \   . ' run '
-  \   . '--foobar'
+  \   . '--foobar '
+  \   . '--out-format=json '
+  \   . '--show-stats=0'
 
 Execute(The golangci-lint callback should support environment variables):
   let b:ale_go_go111module = 'on'
@@ -37,11 +39,13 @@ Execute(The golangci-lint callback should support environment variables):
   AssertLinter 'golangci-lint',
   \ ale#Env('GO111MODULE', 'on')
   \   . ale#Escape('golangci-lint')
-  \   . ' run '
+  \   . ' run  '
+  \   . '--out-format=json '
+  \   . '--show-stats=0'
 
 Execute(The golangci-lint `lint_package` option should use the correct command):
   let b:ale_go_golangci_lint_package = 0
   AssertLinter 'golangci-lint',
   \ ale#Escape('golangci-lint')
   \   . ' run ' . ale#Escape(expand('%' . ':t'))
-  \   . ' '
+  \   . '  --out-format=json --show-stats=0'


### PR DESCRIPTION
golangci-lint linter uses regular expressions for parsing linter output that is fragile given that golangci-lint is a meta linter that supports many others with different outputs. Fortunately it supports JSON output since at least version 1.7 from 2018  that is more stable and easier to parse.

This PR modifies ALE golangci-lint handler to parse JSON output.
