### PR TITLE
Add djlint fixer for various HTML template formats

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -98,6 +98,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['dhall'],
 \       'description': 'Standard code formatter for the Dhall language and removing dead code',
 \   },
+\   'djlint': {
+\       'function': 'ale#fixers#djlint#Fix',
+\       'suggested_filetypes': ['html', 'htmldjango', 'htmlangular', 'jinja', 'handlebars', 'nunjucks', 'gohtmltmpl'],
+\       'description': 'Fix HTML templates with `djlint --reformat`.',
+\   },
 \   'dune': {
 \       'function': 'ale#fixers#dune#Fix',
 \       'suggested_filetypes': ['dune'],

--- a/autoload/ale/fixers/djlint.vim
+++ b/autoload/ale/fixers/djlint.vim
@@ -1,0 +1,48 @@
+" Author: Adrian Vollmer (computerfluesterer@protonmail.com)
+" Description: HTML template formatter using `djlint --reformat`
+
+call ale#Set('html_djlint_executable', 'djlint')
+call ale#Set('html_djlint_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('html_djlint_options', '')
+
+function! ale#fixers#djlint#Fix(buffer) abort
+    let l:executable = ale#python#FindExecutable(
+    \   a:buffer,
+    \   'html_djlint',
+    \   ['djlint']
+    \)
+
+    let l:options = ale#Var(a:buffer, 'html_djlint_options')
+
+    let l:profile = ''
+    let l:filetypes = split(getbufvar(a:buffer, '&filetype'), '\.')
+
+    " Append the --profile flag depending on the current filetype (unless it's
+    " already set in g:html_djlint_options).
+    if match(l:options, '--profile') == -1
+        let l:djlint_profiles = {
+        \    'html': 'html',
+        \    'htmldjango': 'django',
+        \    'jinja': 'jinja',
+        \    'nunjucks': 'nunjucks',
+        \    'handlebars': 'handlebars',
+        \    'gohtmltmpl': 'golang',
+        \    'htmlangular': 'angular',
+        \}
+
+        for l:filetype in l:filetypes
+            if has_key(l:djlint_profiles, l:filetype)
+                let l:profile = l:djlint_profiles[l:filetype]
+                break
+            endif
+        endfor
+    endif
+
+    if !empty(l:profile)
+        let l:options = (!empty(l:options) ? l:options . ' ' : '') . '--profile ' . l:profile
+    endif
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' --reformat ' . l:options . ' -',
+    \}
+endfunction

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3067,6 +3067,8 @@ documented in additional help files.
     govet.................................|ale-go-govet|
     revive................................|ale-go-revive|
     staticcheck...........................|ale-go-staticcheck|
+  gohtmltmpl..............................ale-html-options
+    djlint................................|ale-html-djlint|
   graphql.................................|ale-graphql-options|
     eslint................................|ale-graphql-eslint|
     gqlint................................|ale-graphql-gqlint|
@@ -3078,6 +3080,7 @@ documented in additional help files.
     hackfmt...............................|ale-hack-hackfmt|
     hhast.................................|ale-hack-hhast|
   handlebars..............................|ale-handlebars-options|
+    djlint................................|ale-html-djlint|
     prettier..............................|ale-handlebars-prettier|
     ember-template-lint...................|ale-handlebars-embertemplatelint|
   haskell.................................|ale-haskell-options|
@@ -3116,6 +3119,10 @@ documented in additional help files.
     tidy..................................|ale-html-tidy|
     vscodehtml............................|ale-html-vscode|
     write-good............................|ale-html-write-good|
+  htmlangular.............................ale-html-options
+    djlint................................|ale-html-djlint|
+  htmldjango..............................ale-html-options
+    djlint................................|ale-htm-djlint|
   hurl....................................|ale-hurl-options|
     hurlfmt...............................|ale-hurl-hurlfmt|
   idris...................................|ale-idris-options|
@@ -3153,6 +3160,8 @@ documented in additional help files.
     prettier-standard.....................|ale-javascript-prettier-standard|
     standard..............................|ale-javascript-standard|
     xo....................................|ale-javascript-xo|
+  jinja...................................ale-jinja
+    djlint................................|ale-html-djlint|
   json....................................|ale-json-options|
     biome.................................|ale-json-biome|
     clang-format..........................|ale-json-clangformat|
@@ -3230,6 +3239,8 @@ documented in additional help files.
     deadnix...............................|ale-nix-deadnix|
   nroff...................................|ale-nroff-options|
     write-good............................|ale-nroff-write-good|
+  nujuck..................................ale-html-options
+    djlint................................|ale-html-djlint|
   objc....................................|ale-objc-options|
     ccls..................................|ale-objc-ccls|
     clang.................................|ale-objc-clang|

--- a/test/fixers/test_djlint_fixer_callback.vader
+++ b/test/fixers/test_djlint_fixer_callback.vader
@@ -1,0 +1,12 @@
+Before:
+  call ale#assert#SetUpFixerTest('html', 'djlint', 'djlint')
+
+After:
+  Restore
+
+  call ale#assert#TearDownFixerTest()
+
+Execute(The djlint callback should return the correct default command):
+  AssertEqual
+  \ {'command': ale#Escape('djlint') . ' --reformat  -'},
+  \ ale#fixers#djlint#Fix(bufnr(''))


### PR DESCRIPTION
* Supported formats:
    - html
    - htmlangular
    - htmldjango
    - jinja
    - handlebars
    - nunjucks
    - gohtmltmpl

* Add doc entries

* Add basic vader test

---

I was a bit confused about how the doc entries relate to file types. I hope it's okay the way I did it.

Also, see #4909, where `djlint` was added as a linter, but for `html` only.