### PR TITLE
feat: remove logic for unsupported older Neovim

### DIFF
--- a/lua/ale/diagnostics.lua
+++ b/lua/ale/diagnostics.lua
@@ -68,13 +68,7 @@ module.sendAleResultsToDiagnostics = function(buffer, loclist)
   if set_signs == 1 and sign_priority then
     -- If signs are enabled, set the priority for them.
     local local_cfg = { priority = sign_priority }
-    -- NOTE: vim.diagnostic.config() -- retrieving the current config values
-    -- fails in Neovim older than v0.7.0.
-    local ok, diag_cfg = pcall(vim.diagnostic.config)
-    if not ok or not diag_cfg then
-      diag_cfg = { signs = {} }
-    end
-    local global_cfg = diag_cfg.signs
+    local global_cfg = vim.diagnostic.config().signs
 
     if type(global_cfg) == 'boolean' then
       signs = local_cfg


### PR DESCRIPTION
ref https://github.com/dense-analysis/ale/pull/4872

Now it has dropped the support for Neovim 0.6 or older. This commit removes the logic that has become unneeded.

Revert "fix: work with older version of Neovim"

This reverts commit 9b9c74373dc12a8872f46c44366dda9fc49ba5ba.

<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!


Where are the tests? Have you added tests? Have you updated the tests? Read the
comment above and the documentation referenced in it first. Write tests!



Seriously, read `:help ale-dev` and write tests.
-->