### PR TITLE
Fix docs for variable names

### DIFF
--- a/doc/ale-salt.tmt
+++ b/doc/ale-salt.tmt
@@ -23,7 +23,7 @@ virtualenv directories.
 Options
 -------------------------------------------------------------------------------
 
-g:ale_salt_salt-lint_executable                *g:ale_salt_salt_lint_executable*
+g:ale_salt_salt_lint_executable                *g:ale_salt_salt_lint_executable*
                                                *b:ale_salt_salt_lint_executable*
   Type: |String|
   Default: `'salt-lint'`
@@ -31,8 +31,8 @@ g:ale_salt_salt-lint_executable                *g:ale_salt_salt_lint_executable*
   This variable can be set to change the path to salt-lint.
 
 
-g:ale_salt_salt-lint_options                      *g:ale_salt_salt-lint_options*
-                                                  *b:ale_salt_salt-lint_options*
+g:ale_salt_salt_lint_options                      *g:ale_salt_salt_lint_options*
+                                                  *b:ale_salt_salt_lint_options*
   Type: |String|
   Default: `''`
 


### PR DESCRIPTION
I suspect there was some copy pasta/sed going on.

The code is correct though, just the docs that don't reflect the code.