### PR TITLE
fix(golangci-lint): incorrect filename concat preventing errors from being displayed

### DIFF
--- a/ale_linters/go/golangci_lint.vim
+++ b/ale_linters/go/golangci_lint.vim
@@ -45,7 +45,7 @@ function! ale_linters#go#golangci_lint#Handler(buffer, lines) abort
         endif
 
         call add(l:output, {
-        \   'filename': ale#path#GetAbsPath(l:dir, l:match['Pos']['Filename']),
+        \   'filename': ale#path#GetAbsPath(l:dir, fnamemodify(l:match['Pos']['Filename'], ':t')),
         \   'lnum': l:match['Pos']['Line'] + 0,
         \   'col': l:match['Pos']['Column'] + 0,
         \   'type': l:msg_type,

--- a/test/handler/test_golangci_lint_handler.vader
+++ b/test/handler/test_golangci_lint_handler.vader
@@ -108,3 +108,39 @@ Execute (The golangci-lint handler should handle only typecheck lines as errors)
   \ '  ]',
   \ '}',
   \ ])
+
+Execute (The golangci-lint handler should set proper filename):
+  call ale#test#SetFilename('app/cmd/server/main.go')
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 198,
+  \     'col': 19,
+  \     'text': 'funlen - Function getConfig has too many statements (51 > 50)',
+  \     'type': 'W',
+  \     'filename': ale#path#Simplify(expand('%:p:h') . '/main.go'),
+  \   },
+  \ ],
+  \ ale_linters#go#golangci_lint#Handler(bufnr(''), [
+  \ '{',
+  \ '  "Issues": [',
+  \ '  {',
+  \ '    "FromLinter": "funlen",',
+  \ '    "Text": "Function getConfig has too many statements (51 > 50)",',
+  \ '    "Severity": "",',
+  \ '    "SourceLines": [',
+  \ '      "package main"',
+  \ '    ],',
+  \ '    "Pos": {',
+  \ '      "Filename": "cmd/server/main.go",',
+  \ '      "Offset": 5374,',
+  \ '      "Line": 198,',
+  \ '      "Column": 19',
+  \ '    },',
+  \ '    "ExpectNoLint": false,',
+  \ '    "ExpectedNoLintLinter": ""',
+  \ '  }',
+  \ '  ]',
+  \ '}',
+  \ ])


### PR DESCRIPTION
## Summary

The code updated in PR #4917 does not work in projects where the lined file is under a subdirectory. On line 48, `l:match['Pos']['Filename']` contains the path of the linted Go file relative to the CWD. If the file is under the CWD, it will work correctly; if it is in a subdirectory like `cmd/tellama/tellama.go`, the `cmd/tellama` part will be added twice into the full filename, which creates the wrong path, and results in the errors not showing up in the editor.

https://github.com/dense-analysis/ale/blob/1c91102112ac5addbdbf178268c61a2ead64fb2a/ale_linters/go/golangci_lint.vim#L47-L53

## Example

In this example below, I add an echo statement to print the linter's output. The actual full path of this file is `/home/k4yt3x/projects/programs/tellama/cmd/tellama/tellama.go` You can see that the `cmd/tellama` part was repeated:

![image](https://github.com/user-attachments/assets/382444c4-3f9b-4915-9fdd-0687cd1732cc)

The above is because golangci-lint's `Issues.Pos.Filename` field is a relative path, not just the file's name:

![image](https://github.com/user-attachments/assets/f07f65cd-b1ef-4e02-8df6-c564b6b4a6da)

After applying this patch, the filename is correct and the warning shows up correctly:

![image](https://github.com/user-attachments/assets/42ca271c-9db1-46aa-b4aa-fed9b8a07bbb)

## Tests

I am not familiar with how tests work here, and sorry I don't have time to learn & write them. Perhaps someone else can add them to cover these cases?