### PR TITLE
Add the typstyle formatter as a fixer for Typst

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -702,6 +702,11 @@ let s:default_registry = {
 \       'suggested_filetypes': ['clojure'],
 \       'description': 'formatter and linter for clojure files',
 \   },
+\   'typstyle': {
+\       'function': 'ale#fixers#typstyle#Fix',
+\       'suggested_filetypes': ['typst'],
+\       'description': 'A formatter for Typst files',
+\   },
 \}
 
 " Reset the function registry to the default entries.

--- a/autoload/ale/fixers/typstyle.vim
+++ b/autoload/ale/fixers/typstyle.vim
@@ -1,0 +1,20 @@
+" Author: Adrian Vollmer (computerfluesterer@protonmail.com)
+" Description: Typst formatter using typstyle
+
+call ale#Set('typst_typstyle_executable', 'typstyle')
+call ale#Set('typst_typstyle_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('typst_typstyle_options', '')
+
+function! ale#fixers#typstyle#Fix(buffer) abort
+    let l:executable = ale#path#FindExecutable(
+    \   a:buffer,
+    \   'typst_typstyle',
+    \   ['typstyle']
+    \)
+
+    let l:options = ale#Var(a:buffer, 'typst_typstyle_options')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' ' . l:options,
+    \}
+endfunction

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -684,6 +684,8 @@ Notes:
   * `tslint`
   * `tsserver`
   * `typecheck`
+* Typst
+  * `typstyle`
 * V
   * `v`!!
   * `vfmt`

--- a/doc/ale-typst.html
+++ b/doc/ale-typst.html
@@ -1,0 +1,24 @@
+===============================================================================
+ALE Typst Integration                                         *ale-typst-options*
+
+===============================================================================
+typstyle                                                     *ale-typst-typstyle*
+
+g:ale_typst_typstyle_executable                 *g:ale_typst_typstyle_executable*
+                                                *b:ale_typst_typstyle_executable*
+  Type: |String|
+  Default: `'typstyle'`
+
+  See |ale-integrations-local-executables|
+
+
+g:ale_typst_typstyle_options                       *g:ale_typst_typstyle_options*
+                                                   *b:ale_typst_typstyle_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to modify flags given to typstyle.
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3476,6 +3476,8 @@ documented in additional help files.
     tslint................................|ale-typescript-tslint|
     tsserver..............................|ale-typescript-tsserver|
     xo....................................|ale-typescript-xo|
+  typst...................................|ale-typst-options|
+    typstyle..............................|ale-typst-typstyle|
   v.......................................|ale-v-options|
     v.....................................|ale-v-v|
     vfmt..................................|ale-v-vfmt|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -693,6 +693,8 @@ formatting.
   * [tslint](https://github.com/palantir/tslint)
   * [tsserver](https://github.com/Microsoft/TypeScript/wiki/Standalone-Server-%28tsserver%29)
   * typecheck
+* Typst
+  * [typstyle](https://github.com/Enter-tainer/typstyle)
 * V
   * [v](https://github.com/vlang/v/) :floppy_disk:
   * [vfmt](https://github.com/vlang/v/)

--- a/test/fixers/test_typstyle_fixer_callback.vader
+++ b/test/fixers/test_typstyle_fixer_callback.vader
@@ -1,0 +1,21 @@
+Before:
+  call ale#assert#SetUpFixerTest('typst', 'typstyle', 'typstyle')
+
+After:
+  Restore
+
+  call ale#assert#TearDownFixerTest()
+
+Execute(The typstyle callback should return the correct default command):
+  AssertEqual
+  \ {'command': ale#Escape('typstyle') . ' '},
+  \ ale#fixers#typstyle#Fix(bufnr(''))
+
+Execute(The typstyle options should be considered):
+  call ale#test#SetFilename('../test-files/typstyle/testfile.typ')
+  let g:ale_typst_typstyle_options = '-c 100'
+
+  AssertFixer
+  \ { 'command': ale#Escape(g:ale_typst_typstyle_executable)
+  \     . ' -c 100',
+  \ }


### PR DESCRIPTION
This patch adds support for [typstyle](https://github.com/Enter-tainer/typstyle)