### PR TITLE
Add nimpsort fixer for nim-lang

### DIFF
--- a/autoload/ale/fix/registry.vim
+++ b/autoload/ale/fix/registry.vim
@@ -151,6 +151,11 @@ let s:default_registry = {
 \       'description': 'Apply elm-format to a file.',
 \       'aliases': ['format'],
 \   },
+\   'nimpsort': {
+\       'function': 'ale#fixers#nimpsort#Fix',
+\       'suggested_filetypes': ['nim'],
+\       'description': 'Apply nimpsort to a file.',
+\   },
 \   'nimpretty': {
 \       'function': 'ale#fixers#nimpretty#Fix',
 \       'suggested_filetypes': ['nim'],

--- a/autoload/ale/fixers/nimpsort.vim
+++ b/autoload/ale/fixers/nimpsort.vim
@@ -1,0 +1,13 @@
+" Author: cycneuramus <cycneuramus@users.noreply.github.com>
+" Description: Integration of nimpsort with ALE.
+
+call ale#Set('nim_nimpsort_executable', 'nimpsort')
+
+function! ale#fixers#nimpsort#Fix(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'nim_nimpsort_executable')
+
+    return {
+    \   'command': ale#Escape(l:executable) . ' %t',
+    \   'read_temporary_file': 1,
+    \}
+endfunction

--- a/doc/ale-nim.txt
+++ b/doc/ale-nim.txt
@@ -42,4 +42,16 @@ g:ale_nim_nimpretty_options                       *g:ale_nim_nimpretty_options*
 
 
 ===============================================================================
+nimpsort                                                     *ale-nim-nimpsort*
+
+
+g:ale_nim_nimpsort_executable                   *g:ale_nim_nimpsort_executable*
+                                                *b:ale_nim_nimpsort_executable*
+  Type: |String|
+  Default: `'nimpsort'`
+
+  This variable can be changed to use a different executable for nimpsort.
+
+
+===============================================================================
   vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -420,6 +420,7 @@ Notes:
   * `nim check`!!
   * `nimlsp`
   * `nimpretty`
+  * `nimpsort`
 * nix
   * `alejandra`
   * `deadnix`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3234,6 +3234,7 @@ documented in additional help files.
     nimcheck..............................|ale-nim-nimcheck|
     nimlsp................................|ale-nim-nimlsp|
     nimpretty.............................|ale-nim-nimpretty|
+    nimpsort..............................|ale-nim-nimpsort|
   nix.....................................|ale-nix-options|
     alejandra.............................|ale-nix-alejandra|
     nixfmt................................|ale-nix-nixfmt|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -429,6 +429,7 @@ formatting.
   * [nim check](https://nim-lang.org/docs/nimc.html) :floppy_disk:
   * [nimlsp](https://github.com/PMunch/nimlsp)
   * nimpretty
+  * [nimpsort](https://github.com/cycneuramus/nimpsort)
 * nix
   * [alejandra](https://github.com/kamadorueda/alejandra)
   * [deadnix](https://github.com/astro/deadnix)

--- a/test/fixers/test_nimpsort_fixer_callback.vader
+++ b/test/fixers/test_nimpsort_fixer_callback.vader
@@ -1,0 +1,22 @@
+Before:
+  call ale#assert#SetUpFixerTest('nim', 'nimpsort')
+
+After:
+  call ale#assert#TearDownFixerTest()
+
+Execute (The nimpsort callback should return the 'nimsort' command with '%t' appended):
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('nimpsort') . ' %t'
+  \ },
+  \ ale#fixers#nimpsort#Fix(bufnr(''))
+
+Execute (The nimpsort callback should allow custom nimpsort executables):
+  let g:ale_nim_nimpsort_executable = '/path/to/nimpsort'
+  AssertEqual
+  \ {
+  \   'read_temporary_file': 1,
+  \   'command': ale#Escape('/path/to/nimpsort') . ' %t'
+  \ },
+  \ ale#fixers#nimpsort#Fix(bufnr(''))


### PR DESCRIPTION
This adds support for the [nimpsort](https://github.com/cycneuramus/nimpsort) fixer for nim-lang. 