### PR TITLE
Always use safe file local variables for erlang-mode fixer

### DIFF
--- a/autoload/ale/fixers/erlang_mode.vim
+++ b/autoload/ale/fixers/erlang_mode.vim
@@ -17,10 +17,11 @@ let s:variables = {
 \}
 
 function! ale#fixers#erlang_mode#Fix(buffer) abort
-    let emacs_executable =
+    let l:emacs_executable =
     \   ale#Var(a:buffer, 'erlang_erlang_mode_emacs_executable')
 
     let l:exprs = [
+    \   '(setq enable-local-variables :safe)',
     \   s:SetqDefault(a:buffer, s:variables),
     \   '(erlang-mode)',
     \   '(font-lock-fontify-region (point-min) (point-max))',

--- a/test/fixers/test_erlang_mode_fixer_callback.vader
+++ b/test/fixers/test_erlang_mode_fixer_callback.vader
@@ -33,6 +33,9 @@ Execute(Emacs executable should be configurable):
   let b:ale_erlang_erlang_mode_emacs_executable = '/path/to/emacs'
   AssertEqual 0, stridx(Fixer('command'), ale#Escape('/path/to/emacs'))
 
+Execute(enable-local-variables should be :safe):
+  Assert Fixer('command') =~# '\m\<enable-local-variables :safe\>'
+
 Execute(erlang-indent-level should be 4 by default):
   Assert Fixer('command') =~# '\m\<erlang-indent-level 4\>'
 


### PR DESCRIPTION
File local variables in Emacs are used in a way similar to Vim modelines.  For example, at the end of the file you might find something like the following:

    %% Local Variables:
    %% erlang-indent-level: 2
    %% something-weird: t
    %% End:

The `erlang-indent-level` variable in this list instructs the Erlang mode to use two columns per indentation level.  But since the `something-weird` variable is likely unknown, both may be ignored.

By default, Emacs in batch mode ignores all variable/value pairs if it encounters at least one that is not known to be safe.  Setting `enable-local-variables` to `:safe` tells Emacs to use only safe values and ignore the rest.