### PR TITLE
Remove ANSI color codes from nix linter messages

### DIFF
--- a/ale_linters/nix/nix.vim
+++ b/ale_linters/nix/nix.vim
@@ -29,7 +29,7 @@ function! ale_linters#nix#nix#Handle(buffer, lines) abort
                     \     'type': 'E',
                     \     'lnum': l:result.line,
                     \     'col': l:result.column,
-                    \     'text': l:result.raw_msg
+                    \     'text': substitute(l:result.raw_msg, '\e\[[0-9;]*m', '', 'g'),
                     \})
                 endif
             endif

--- a/test/handler/test_nix_handler.vader
+++ b/test/handler/test_nix_handler.vader
@@ -27,6 +27,22 @@ Execute(The nix handler should parse nix-instantiate error messages correctly):
   \   "@nix {\"unrelated\":\"message\"}"
   \ ])
 
+Execute(The nix handler should parse nix-instantiate error messages with ANSI color codes correctly):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'col': 5,
+  \     'type': 'E',
+  \     'text': "undefined variable 'foo'",
+  \   },
+  \
+  \ ],
+  \ ale_linters#nix#nix#Handle(bufnr(''), [
+  \   "@nix {\"line\":3,\"column\":5,\"raw_msg\":\"undefined variable '\u001b[35;1mfoo\u001b[0m'\"}",
+  \   "@nix {\"unrelated\":\"message\"}"
+  \ ])
+
 Execute(The nix handler should parse message from old nix-instantiate correctly):
   AssertEqual
   \ [

--- a/test/handler/test_nix_handler.vader
+++ b/test/handler/test_nix_handler.vader
@@ -39,7 +39,7 @@ Execute(The nix handler should parse nix-instantiate error messages with ANSI co
   \
   \ ],
   \ ale_linters#nix#nix#Handle(bufnr(''), [
-  \   "@nix {\"line\":3,\"column\":5,\"raw_msg\":\"undefined variable '\u001b[35;1mfoo\u001b[0m'\"}",
+  \   "@nix {\"line\":3,\"column\":5,\"raw_msg\":\"undefined variable '\\u001b[35;1mfoo\\u001b[0m'\"}",
   \   "@nix {\"unrelated\":\"message\"}"
   \ ])
 


### PR DESCRIPTION
Before: 
```
E 88                  foobar     ■ undefined variable '^[[35;1mfoobar^[[0m' 
```

After:
```
E 88                  foobar     ■ undefined variable 'foobar'
```
