### PR TITLE
Add bash to the linter aliases

### DIFF
--- a/autoload/ale/linter.vim
+++ b/autoload/ale/linter.vim
@@ -11,6 +11,7 @@ let s:linters = {}
 " NOTE: Update the g:ale_linter_aliases documentation when modifying this.
 let s:default_ale_linter_aliases = {
 \   'Dockerfile': 'dockerfile',
+\   'bash': 'sh',
 \   'csh': 'sh',
 \   'javascriptreact': ['javascript', 'jsx'],
 \   'plaintex': 'tex',

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -1735,6 +1735,7 @@ g:ale_linter_aliases
 
   {
   \   'Dockerfile': 'dockerfile',
+  \   'bash': 'sh',
   \   'csh': 'sh',
   \   'javascriptreact': ['javascript', 'jsx'],
   \   'plaintex': 'tex',


### PR DESCRIPTION
Closes #4947

Add bash to the default linter aliases file (#4947).