### PR TITLE
Use ale#Escape in c_clangformat_style_option

### DIFF
--- a/autoload/ale/fixers/clangformat.vim
+++ b/autoload/ale/fixers/clangformat.vim
@@ -22,7 +22,7 @@ function! ale#fixers#clangformat#Fix(buffer) abort
     let l:use_local_file = ale#Var(a:buffer, 'c_clangformat_use_local_file')
 
     if l:style_option isnot# ''
-        let l:style_option = '-style=' . "'" . l:style_option . "'"
+        let l:style_option = '-style=' . ale#Escape(l:style_option)
     endif
 
     if l:use_local_file

--- a/test/fixers/test_clangformat_fixer_callback.vader
+++ b/test/fixers/test_clangformat_fixer_callback.vader
@@ -45,7 +45,8 @@ Execute(The clangformat callback should include style options as well):
   \ {
   \   'command': ale#Escape(g:ale_c_clangformat_executable)
   \     . ' --assume-filename=' . ale#Escape(bufname(bufnr('')))
-  \     . ' --some-option' . " -style='{BasedOnStyle: Microsoft, ColumnLimit:80,}'",
+  \     . ' --some-option'
+  \     . ' -style=' . ale#Escape(g:ale_c_clangformat_style_option)
   \ },
   \ ale#fixers#clangformat#Fix(bufnr(''))
 


### PR DESCRIPTION
Closes #4525

The pull request fixes the issue #4525.
I have tested it on Vim 9.1 running on Windows 10 and Ubuntu 24.04.
The original issue happens only on Windows.

## Steps to reproduce on Windows 10 with Vim 9.1

1. Set `ale_c_clangformat_style_option`:
    ```
    g:ale_c_clangformat_style_option = '{IndentWidth: 2, TabWidth: 4}'
    ```
2. try to save a sample C file:
    ```c
    int main() {
         return 0;}
    ```
4. notice the file stays intact and there is an error in `:ALEInfo`
    ```
     (finished - exit code 1) 'cmd /s/c ""D:\Program Files\clang-llvm\clang+llvm-19.1.0-x86_64-pc-windows-msvc\bin\clang-format.exe" --assume-filename=test.c  -style=''{IndentWidth: 2, TabWidth: 4}'' < C:\Users\user\AppData\Local\Temp\V2M4D11.tmp\test.c"'
    ```



