### PR TITLE
Add initialization_options to Sorbet LSP linter

### DIFF
--- a/ale_linters/ruby/sorbet.vim
+++ b/ale_linters/ruby/sorbet.vim
@@ -1,6 +1,7 @@
 call ale#Set('ruby_sorbet_executable', 'srb')
 call ale#Set('ruby_sorbet_options', '')
 call ale#Set('ruby_sorbet_enable_watchman', 0)
+call ale#Set('ruby_sorbet_initialization_options', { 'highlightUntyped': v:false })
 
 function! ale_linters#ruby#sorbet#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'ruby_sorbet_executable')
@@ -21,6 +22,6 @@ call ale#linter#Define('ruby', {
 \   'language': 'ruby',
 \   'executable': {b -> ale#Var(b, 'ruby_sorbet_executable')},
 \   'command': function('ale_linters#ruby#sorbet#GetCommand'),
-\   'project_root': function('ale#ruby#FindProjectRoot')
+\   'project_root': function('ale#ruby#FindProjectRoot'),
+\   'initialization_options': {b -> ale#Var(b, 'ruby_sorbet_initialization_options')}
 \})
-

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -267,6 +267,20 @@ g:ale_ruby_sorbet_enable_watchman
   to files from outside of vim. Defaults to disable watchman because it
   requires watchman to be installed separately from sorbet.
 
+                               *ale-options.ruby_sorbet_initialization_options*
+                                     *g:ale_ruby_sorbet_initialization_options*
+                                     *b:ale_ruby_sorbet_initialization_options*
+ruby_sorbet_initialization_options
+g:ale_ruby_sorbet_initialization_options
+  Type: |Dictionary|
+  Default: `{ 'highlightUntyped': v:false  }`
+
+  This variable can be changed to modify initialization options provided to
+  the Sorbet language server. By default, a minimal object with defaults is
+  provided to ensure proper LSP initialization.
+
+  See https://sorbet.org/docs/lsp#initialize-request for available options.
+
 
 ===============================================================================
 standardrb                                                *ale-ruby-standardrb*

--- a/doc/ale-ruby.txt
+++ b/doc/ale-ruby.txt
@@ -273,11 +273,14 @@ g:ale_ruby_sorbet_enable_watchman
 ruby_sorbet_initialization_options
 g:ale_ruby_sorbet_initialization_options
   Type: |Dictionary|
-  Default: `{ 'highlightUntyped': v:false  }`
+  Default: `{ 'highlightUntyped': v:false }`
 
   This variable can be changed to modify initialization options provided to
   the Sorbet language server. By default, a minimal object with defaults is
   provided to ensure proper LSP initialization.
+
+  Setting this variable to a an empty object will cause sorbet LSP to
+  fail during initialization.
 
   See https://sorbet.org/docs/lsp#initialize-request for available options.
 

--- a/test/linter/test_sorbet.vader
+++ b/test/linter/test_sorbet.vader
@@ -6,6 +6,7 @@ Before:
   let g:ale_ruby_sorbet_executable = 'srb'
   let g:ale_ruby_sorbet_options = ''
   let g:ale_ruby_sorbet_enable_watchman = 0
+  let g:ale_ruby_sorbet_initialization_options = { 'highlightUntyped': v:false }
 
 After:
   call ale#assert#TearDownLinterTest()
@@ -32,3 +33,11 @@ Execute(Setting bundle appends 'exec srb tc'):
   AssertLinter 'path to/bundle', ale#Escape('path to/bundle')
   \   . ' exec srb'
   \   . ' tc --lsp --disable-watchman'
+
+Execute(Should use predetermined initialization_options by default):
+  AssertLSPOptions { 'highlightUntyped': v:false }
+
+Execute(Should be able to set custom initialization_options):
+  let g:ale_ruby_sorbet_initialization_options = {'enableTypedFalse': v:true}
+
+  AssertLSPOptions {'enableTypedFalse': v:true}


### PR DESCRIPTION
I started getting an error in neovim when opening ruby files with the Sorbet linter.

```
Error executing vim.schedule lua callback: ...nvimEllFDd/usr/share/nvim/runtime/lua/vim/lsp/client.lua:548: RPC[Error] code_name = InvalidParams, message = "Unable to deserialize LSP request: Error deserializing JSON message: Expected field `InitializeParams.initializationOptions` to have value of type `object`, but had value `[]`."
stack traceback:
        [C]: in function 'assert'
        ...nvimEllFDd/usr/share/nvim/runtime/lua/vim/lsp/cl…
```

Turns out Lua's uses the same underlying `table` data type for both arrays and dictionaries. Whenever we pass nothing or `{}` to neovim's LSP client, it gets serialized as an `[]`.  [LSP defines the initializationOptions as anything](https://github.com/neovim/neovim/pull/33551#issuecomment-2819014845). Unfortunately Sorbet is too strict and raises an error when anything other than an object is passed which causes the linter to fail.

Using a predefined object will ensure that Sorbet always receives an object instead of an array. 
This also allows users of this to set their own LSP initialization options 


I'm thinking of following up with a PR to Sorbet's LSP implementation to relax that requirement a bit more or at least not crash in this situations but I figured this would be a good start.
