### PR TITLE
Fix golangci-lint fixer with version 2

### DIFF
--- a/autoload/ale/fixers/golangci_lint.vim
+++ b/autoload/ale/fixers/golangci_lint.vim
@@ -1,32 +1,48 @@
 " Author: Ian Stapleton Cordasco <graffatcolmingov@gmail.com>
 " Description: Run golangci-lint with the --fix flag to autofix some issues
 
-call ale#Set('go_golangci_lint_options', '')
-call ale#Set('go_golangci_lint_executable', 'golangci-lint')
-call ale#Set('go_golangci_lint_package', 1)
+call ale#Set('go_golangci_formatter_options', '')
+call ale#Set('go_golangci_formatter_executable', 'golangci-lint')
 
-function! ale#fixers#golangci_lint#GetCommand(buffer) abort
+function! ale#fixers#golangci_lint#GetExecutable(buffer) abort
+    let l:executable = ale#Var(a:buffer, 'go_golangci_formatter_executable')
+
+    return l:executable
+endfunction
+
+function! ale#fixers#golangci_lint#GetCommand(buffer, version) abort
     let l:filename = expand('#' . a:buffer . ':t')
-    let l:executable = ale#Var(a:buffer, 'go_golangci_lint_executable')
-    let l:options = ale#Var(a:buffer, 'go_golangci_lint_options') . ' --fix'
-    let l:package_mode = ale#Var(a:buffer, 'go_golangci_lint_package')
+    let l:executable = ale#fixers#golangci_lint#GetExecutable(a:buffer)
+    let l:options = ale#Var(a:buffer, 'go_golangci_formatter_options')
     let l:env = ale#go#EnvString(a:buffer)
 
-
-    if l:package_mode
+    if ale#semver#GTE(a:version, [2, 0, 0])
         return l:env . ale#Escape(l:executable)
-        \   . ' run '
-        \   .  l:options
+        \   . ' fmt --stdin '
+        \   . l:options
+    else
+        return l:env . ale#Escape(l:executable)
+        \   . ' run --fix '
+        \   . l:options
+        \   . ' '
+        \   . ale#Escape(l:filename)
     endif
+endfunction
 
-    return l:env . ale#Escape(l:executable)
-    \   . ' run '
-    \   . l:options
-    \   . ' ' . ale#Escape(l:filename)
+function! ale#fixers#golangci_lint#GetCommandForVersion(buffer, version) abort
+    return {
+    \ 'command': ale#fixers#golangci_lint#GetCommand(a:buffer, a:version)
+    \}
 endfunction
 
 function! ale#fixers#golangci_lint#Fix(buffer) abort
-    return {
-    \  'command': ale#fixers#golangci_lint#GetCommand(a:buffer),
-    \}
+    let l:executable =  ale#fixers#golangci_lint#GetExecutable(a:buffer)
+    let l:command = ale#fixers#golangci_lint#GetExecutable(a:buffer) . ale#Pad('--version')
+
+    return ale#semver#RunWithVersionCheck(
+    \   a:buffer,
+    \   l:executable,
+    \   l:command,
+    \   function('ale#fixers#golangci_lint#GetCommandForVersion'),
+    \)
 endfunction

--- a/doc/ale-go.txt
+++ b/doc/ale-go.txt
@@ -144,7 +144,7 @@ g:ale_go_golangci_lint_options
   Default: `''`
 
   This variable can be changed to alter the command-line arguments to the
-  golangci-lint invocation.
+  golangci-lint run invocation.
 
                                          *ale-options.go_golangci_lint_package*
                                                *g:ale_go_golangci_lint_package*
@@ -157,6 +157,30 @@ g:ale_go_golangci_lint_package
   When set to `1`, the whole Go package will be checked instead of only the
   current file.
 
+golangci_lint can also be user as a fixer to format go source files. In this
+case the following configuration variables can be used to configure the
+formatters:
+
+                                    *ale-options.go_golangci_formatter_executable*
+                                          *g:ale_go_golangci_formatter_executable*
+                                          *b:ale_go_golangci_formatter_executable*
+go_golangci_formatter_executable
+g:ale_go_golangci_formatter_executable
+  Type: |String|
+  Default: `'golangci-lint'`
+
+  The executable that will be run for golangci-lint.
+
+                                      *ale-options.go_golangci_formatter_options*
+                                            *g:ale_go_golangci_formatter_options*
+                                            *b:ale_go_golangci_formatter_options*
+go_golangci_formatter_options
+g:ale_go_golangci_formatter_options
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to alter the command-line arguments to the
+  golangci-lint fmt invocation.
 
 ===============================================================================
 golangserver                                              *ale-go-golangserver*

--- a/test/fixers/test_golangci_lint_fixer_callback.vader
+++ b/test/fixers/test_golangci_lint_fixer_callback.vader
@@ -1,48 +1,80 @@
 Before:
+  call ale#assert#SetUpFixerTest('go', 'golangci_lint')
   Save g:ale_go_go111module
-  Save g:ale_go_golangci_lint_executable
-  Save g:ale_go_golangci_lint_options
-  Save g:ale_go_golangci_lint_package
+  Save g:ale_go_golangci_formatter_executable
+  Save g:ale_go_golangci_formatter_options
 
-  " Use an invalid global executable, so we don't match it.
-  let g:ale_go_golangci_lint_executable = 'xxxinvalid'
-  let g:ale_go_golangci_lint_options = ''
 
   call ale#test#SetDirectory('/testplugin/test/fixers')
   call ale#test#SetFilename('../test-files/go/testfile.go')
+
 After:
-  Restore
+  call ale#test#RestoreDirectory()
+  call ale#assert#TearDownFixerTest()
 
   unlet! b:ale_go_go111module
 
-  call ale#test#RestoreDirectory()
+Execute(The golangci-lint callback should return the correct default values with v1):
 
-Execute(The golangci-lint callback should return the correct default values):
+  GivenCommandOutput ['golangci-lint has version 1.64.8 built with go1.23.0']
 
-  AssertEqual
+  AssertFixer
   \ {
-  \   'command': ale#Escape('xxxinvalid') . ' run  --fix',
+  \   'command': ale#Escape('golangci-lint') . ' run --fix  ' . ale#Escape('testfile.go'),
+  \ }
+
+Execute(The golangci-lint callback should include custom golangci-lint options with v1):
+  let g:ale_go_golangci_formatter_options = "--new --config /dev/null"
+
+  GivenCommandOutput ['golangci-lint has version 1.64.8 built with go1.23.0']
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape('golangci-lint')
+  \     . ' run --fix ' . g:ale_go_golangci_formatter_options . ' ' . ale#Escape('testfile.go'),
   \ },
-  \ ale#fixers#golangci_lint#Fix(bufnr(''))
 
-Execute(The golangci-lint callback should include custom golangci-lint options):
-  let g:ale_go_golangci_lint_options = "--new --config /dev/null"
+Execute(The golangci-lint callback should override executable with v1):
+  let g:ale_go_golangci_formatter_executable = 'xxxinvalid'
 
-  AssertEqual
+  GivenCommandOutput ['golangci-lint has version 1.64.8 built with go1.23.0']
+
+  AssertFixer
   \ {
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' run ' . g:ale_go_golangci_lint_options . ' --fix',
+  \     . ' run --fix '
+  \     . g:ale_go_golangci_formatter_options
+  \     . ' ' . ale#Escape('testfile.go'),
   \ },
-  \ ale#fixers#golangci_lint#Fix(bufnr(''))
 
-Execute(The golangci-lint callback should support per-file mode):
-  let g:ale_go_golangci_lint_package = 0
+Execute(The golangci-lint callback should return the correct default values with v2):
 
-  AssertEqual
+  GivenCommandOutput ['golangci-lint has version 2.1.5 built with go1.23.0']
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape('golangci-lint') . ' fmt --stdin ',
+  \ }
+
+Execute(The golangci-lint callback should include custom golangci-lint options with v2):
+  let g:ale_go_golangci_formatter_options = "--new --config /dev/null"
+
+  GivenCommandOutput ['golangci-lint has version 2.1.5 built with go1.23.0']
+
+  AssertFixer
+  \ {
+  \   'command': ale#Escape('golangci-lint')
+  \     . ' fmt --stdin ' . g:ale_go_golangci_formatter_options,
+  \ },
+
+Execute(The golangci-lint callback should override executable with v2):
+  let g:ale_go_golangci_formatter_executable = 'xxxinvalid'
+
+  GivenCommandOutput ['golangci-lint has version 2.1.5 built with go1.23.0']
+
+  AssertFixer
   \ {
   \   'command': ale#Escape('xxxinvalid')
-  \     . ' run '
-  \     . g:ale_go_golangci_lint_options
-  \     . ' --fix ' . ale#Escape('testfile.go'),
+  \     . ' fmt --stdin '
+  \     . g:ale_go_golangci_formatter_options
   \ },
-  \ ale#fixers#golangci_lint#Fix(bufnr(''))


### PR DESCRIPTION
<!--
Before creating a pull request, do the following.

* Read the Contributing guide linked above first.
* Read the documentation that comes with ALE with `:help ale-dev`.

Have fun!
-->
Update golangci-lint fixer to support version 2 of the tool that changes significantly the command arguments. Instead of `run --fix` it now uses `fmt --stdin`.

Closes #4951 
