### PR TITLE
Add initial support for named-checkzone linter

### DIFF
--- a/ale_linters/bindzone/checkzone.vim
+++ b/ale_linters/bindzone/checkzone.vim
@@ -1,0 +1,43 @@
+" Description: named-checkzone for bindzone
+
+call ale#Set('bindzone_checkzone_executable', 'named-checkzone')
+call ale#Set('bindzone_checkzone_options', '-c IN')
+
+function! ale_linters#bindzone#checkzone#GetCommand(buffer) abort
+    return '%e' . ale#Pad(ale#Var(a:buffer, 'bindzone_checkzone_options'))
+    \   . ' example.com %t'
+endfunction
+
+function! ale_linters#bindzone#checkzone#Handle(buffer, lines) abort
+    let l:warning_pattern = '\vzone example.com/IN: (.+)$'
+    let l:error_pattern = '\v:(\d+): (.+)$'
+    let l:output = []
+
+    for l:match in ale#util#GetMatches(a:lines, l:error_pattern)
+        let l:lnum = l:match[1]
+        let l:text = l:match[2]
+
+        call add(l:output, {'text': l:text, 'lnum': l:lnum + 0, 'type': 'E'})
+    endfor
+
+    for l:match in ale#util#GetMatches(a:lines, l:warning_pattern)
+        let l:text = l:match[1]
+
+        " Ignore information messages
+        let l:scrub_match = matchlist(l:text, '\v(loaded serial|not loaded due to) ')
+
+        if empty(l:scrub_match)
+            call add(l:output, {'text': l:text, 'lnum': 0, 'type': 'W'})
+        endif
+    endfor
+
+    return l:output
+endfunction
+
+call ale#linter#Define('bindzone', {
+\   'name': 'checkzone',
+\   'executable': {b -> ale#Var(b, 'bindzone_checkzone_executable')},
+\   'command': function('ale_linters#bindzone#checkzone#GetCommand'),
+\   'callback': 'ale_linters#bindzone#checkzone#Handle',
+\   'read_buffer': 0,
+\})

--- a/doc/ale-bindzone.txt
+++ b/doc/ale-bindzone.txt
@@ -1,0 +1,32 @@
+===============================================================================
+ALE BINDZone Integration                                 *ale-bindzone-options*
+
+===============================================================================
+checkzone                                              *ale-bindzone-checkzone*
+
+                                    *ale-options.bindzone_checkzone_executable*
+                                          *g:ale_bindzone_checkzone_executable*
+                                          *b:ale_bindzone_checkzone_executable*
+bindzone_checkzone_executable
+g:ale_bindzone_checkzone_executable
+  Type: |String|
+  Default: `named-checkzone`
+
+  This variable can be changed to set the path to named-checkzone executable.
+
+                                       *ale-options.bindzone_checkzone_options*
+                                             *g:ale_bindzone_checkzone_options*
+                                             *b:ale_bindzone_checkzone_options*
+bindzone_checkzone_options
+g:ale_bindzone_checkzone_options
+  Type: |String|
+  Default: `-c IN`
+
+  This variable can be changed to add additional command-line arguments.
+  All available options can be found at:
+
+  https://bind9.readthedocs.io/en/stable/manpages.html#named-checkzone-zone-file-validation-tool
+
+
+===============================================================================
+  vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -60,6 +60,8 @@ Notes:
   * `bibclean`
 * Bicep
   * `bicep`
+* Bindzone
+  * `checkzone` (named-checkzone)
 * BitBake
   * `oelint-adv`
 * Bourne Shell

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3361,6 +3361,8 @@ documented in additional help files.
   bicep...................................|ale-bicep-options|
     bicep.................................|ale-bicep-bicep|
     az_bicep..............................|ale-bicep-az_bicep|
+  bindzone................................|ale-bindzone-options|
+    checkzone.............................|ale-bindzone-checkzone|
   bitbake.................................|ale-bitbake-options|
     oelint-adv............................|ale-bitbake-oelint_adv|
   c.......................................|ale-c-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -69,6 +69,8 @@ formatting.
   * [bibclean](http://ftp.math.utah.edu/pub/bibclean/)
 * Bicep
   * [bicep](https://github.com/Azure/bicep) :floppy_disk:
+* Bindzone
+  * [checkzone](https://bind9.readthedocs.io/en/stable/manpages.html#named-checkzone-zone-file-validation-tool)
 * BitBake
   * [oelint-adv](https://github.com/priv-kweihmann/oelint-adv)
 * Bourne Shell

--- a/test/handler/test_bindzone_checkzone.vader
+++ b/test/handler/test_bindzone_checkzone.vader
@@ -1,0 +1,26 @@
+Before:
+  runtime ale_linters/bindzone/checkzone.vim
+
+After:
+  call ale#linter#Reset()
+
+Execute(The checkzone handler should handle basic warnings):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 2,
+  \     'type': 'E',
+  \     'text': 'unknown RR type ''fasd''',
+  \   },
+  \   {
+  \     'lnum': 0,
+  \     'type': 'W',
+  \     'text': '_some_srv._tcp.example.com/SRV ''some.example.com'' (out of zone) has no addresses records (A or AAAA)',
+  \   },
+  \ ],
+  \ ale_linters#bindzone#checkzone#Handle(1, [
+  \   'zone example.com/IN: _some_srv._tcp.example.com/SRV ''some.example.com'' (out of zone) has no addresses records (A or AAAA)',
+  \   'zone example.com/IN: loaded serial 2025050400',
+  \   'zone example.com/IN: not loaded due to errors',
+  \   '/tmp/vb3wXsu/2/example.com:2: unknown RR type ''fasd''',
+  \ ])

--- a/test/linter/test_bindzone_checkzone.vader
+++ b/test/linter/test_bindzone_checkzone.vader
@@ -1,0 +1,19 @@
+Before:
+  call ale#assert#SetUpLinterTest('bindzone', 'checkzone')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'named-checkzone',
+  \ ale#Escape('named-checkzone') . ' -c IN example.com %t'
+
+Execute(The default command should be overridden):
+  let b:ale_bindzone_checkzone_executable = '/bin/bind9-checkzone'
+  AssertLinter '/bin/bind9-checkzone',
+  \ ale#Escape('/bin/bind9-checkzone') . ' -c IN example.com %t'
+
+Execute(The default options should be overridden):
+  let b:ale_bindzone_checkzone_options = '-c IN -d'
+  AssertLinter 'named-checkzone',
+  \ ale#Escape('named-checkzone') . ' -c IN -d example.com %t'


### PR DESCRIPTION
Hello!

Here's simple checker for bindzone files.
No support for $INCLUDE yet and maybe some other sort of bind magic which I don't use myself.

Link: [BIND 9](https://bind9.readthedocs.io/en/latest/)
Link: [named-checkzone](https://bind9.readthedocs.io/en/stable/manpages.html#named-checkzone-zone-file-validation-tool)