### PR TITLE
Retain original formatting for LSP messages, except in `echo` functionality.

### DIFF
--- a/autoload/ale/cursor.vim
+++ b/autoload/ale/cursor.vim
@@ -23,7 +23,7 @@ function! ale#cursor#TruncatedEcho(original_message) abort
     " Change tabs to spaces.
     let l:message = substitute(l:message, "\t", ' ', 'g')
     " Remove any newlines in the message.
-    let l:message = substitute(l:message, "\n", '', 'g')
+    let l:message = substitute(l:message, "\n", ' ', 'g')
     " Convert indentation groups into single spaces for better legibility when
     " put on a single line
     let l:message = substitute(l:message, ' \+', ' ', 'g')
@@ -93,6 +93,7 @@ function! ale#cursor#EchoCursorWarning(...) abort
         if !empty(l:loc)
             let l:format = ale#Var(l:buffer, 'echo_msg_format')
             let l:msg = ale#GetLocItemMessage(l:loc, l:format)
+
             call ale#cursor#TruncatedEcho(l:msg)
             let l:info.echoed = 1
         elseif get(l:info, 'echoed')

--- a/autoload/ale/lsp/response.vim
+++ b/autoload/ale/lsp/response.vim
@@ -28,7 +28,7 @@ function! ale#lsp#response#ReadDiagnostics(diagnostics) abort
     for l:diagnostic in a:diagnostics
         let l:severity = get(l:diagnostic, 'severity', 0)
         let l:loclist_item = {
-        \   'text': substitute(l:diagnostic.message, '\(\r\n\|\n\|\r\)', ' ', 'g'),
+        \   'text': l:diagnostic.message,
         \   'type': 'E',
         \   'lnum': l:diagnostic.range.start.line + 1,
         \   'col': l:diagnostic.range.start.character + 1,

--- a/test/lsp/test_read_lsp_diagnostics.vader
+++ b/test/lsp/test_read_lsp_diagnostics.vader
@@ -109,11 +109,11 @@ Execute(ale#lsp#response#ReadDiagnostics() should include sources in detail):
   \   }
   \ ])
 
-Execute(ale#lsp#response#ReadDiagnostics() should keep detail with line breaks but replace with spaces in text):
+Execute(ale#lsp#response#ReadDiagnostics() should keep line breaks in text):
   AssertEqual [
   \   {
   \     'type': 'E',
-  \     'text': 'cannot borrow `cap` as mutable more than once at a time  mutable borrow starts here in previous iteration of loop',
+  \     'text': "cannot borrow `cap` as mutable\r\nmore than once at a time\n\nmutable borrow starts here\rin previous iteration of loop",
   \     'detail': "[rustc] cannot borrow `cap` as mutable\r\nmore than once at a time\n\nmutable borrow starts here\rin previous iteration of loop",
   \     'lnum': 10,
   \     'col': 15,

--- a/test/test_cursor_warnings.vader
+++ b/test/test_cursor_warnings.vader
@@ -30,7 +30,7 @@ Before:
   \       'nr': -1,
   \       'type': 'E',
   \       'code': 'semi',
-  \       'text': "Missing semicolon.\r",
+  \       'text': "Missing\nsemicolon.\r",
   \       'detail': "Every statement should end with a semicolon\nsecond line",
   \     },
   \     {


### PR DESCRIPTION
- Updates `ale#lsp#response#ReadDiagnostics` to always store the full, unaltered diagnostic message from the LSP in question. The current process is to replace all newline characters with whitespace (`' '`), which then leads to broken formatting when viewing complex output from an LSP with `:ALEDetail` and other commands.
- Updates `ale#cursor#TruncatedEcho` to replace newline characters with a space `' '` instead of an empty string `''` to retain the previous style of formatting for echoed messages.

Fixes: #2356
Fixes: #3068
Fixes: #2301

Related Issues:
- https://github.com/dense-analysis/ale/issues/2356
- https://github.com/dense-analysis/ale/issues/3068
- https://github.com/dense-analysis/ale/issues/2301


# Screenshots
## Before
<img width="725" alt="Screenshot 2025-04-29 at 8 43 33 AM" src="https://github.com/user-attachments/assets/8706b45e-db82-4324-a54a-27ccca95ef44" />

## After
<img width="722" alt="Screenshot 2025-04-29 at 8 42 43 AM" src="https://github.com/user-attachments/assets/cbe4f9e4-b4d5-4a3e-b4af-085744743ad3" />