### PR TITLE
Added 'build/Debug' and 'build/Release' to defaults

### DIFF
--- a/autoload/ale/c.vim
+++ b/autoload/ale/c.vim
@@ -12,6 +12,8 @@ let g:__ale_c_project_filenames = ['.git/HEAD', 'configure', 'Makefile', 'CMakeL
 
 let g:ale_c_build_dir_names = get(g:, 'ale_c_build_dir_names', [
 \   'build',
+\   'build/Debug',
+\   'build/Release',
 \   'bin',
 \])
 

--- a/doc/ale-c.txt
+++ b/doc/ale-c.txt
@@ -26,7 +26,7 @@ g:ale_c_always_make
 c_build_dir_names
 g:ale_c_build_dir_names
   Type: |List|
-  Default: `['build', 'bin']`
+  Default: `['build', 'build/Debug', 'build/Release', 'bin']`
 
   A list of directory names to be used when searching upwards from C files
   to discover compilation databases with. For directory named `'foo'`, ALE


### PR DESCRIPTION
Added 'build/Debug' and 'build/Release' to g:ale_c_build_dir_names list. Ale will now check those directories automatically when looking for suitable C build directories. (#4322)
