### PR TITLE
Update oelint pattern

### DIFF
--- a/ale_linters/bitbake/oelint_adv.vim
+++ b/ale_linters/bitbake/oelint_adv.vim
@@ -17,7 +17,7 @@ function! ale_linters#bitbake#oelint_adv#Command(buffer) abort
 endfunction
 
 function! ale_linters#bitbake#oelint_adv#Handle(buffer, lines) abort
-    let l:pattern = '\v^(.+):(.+):(.+):(.+):(.+)$'
+    let l:pattern = '\v^(.+):(.+):(.+):(.+):(.+)( \[branch:.+)$'
     let l:output = []
 
     for l:match in ale#util#GetMatches(a:lines, l:pattern)

--- a/test/handler/test_bitbake_oelint_adv_handler.vader
+++ b/test/handler/test_bitbake_oelint_adv_handler.vader
@@ -23,6 +23,6 @@ Execute(The oelint_adv handler should handle warnings):
   \   },
   \ ],
   \ ale_linters#bitbake#oelint_adv#Handle(1, [
-  \   '/meta-x/recipes-y/example/example_1.0.bb:1234:info:oelint.var.suggestedvar.BUGTRACKER:Variable ''BUGTRACKER'' should be set',
-  \   '[31mexample2_1.1.bb:17:error:oelint.var.mandatoryvar.DESCRIPTION:Variable ''DESCRIPTION'' should be set[0m',
+  \   '/meta-x/recipes-y/example/example_1.0.bb:1234:info:oelint.var.suggestedvar.BUGTRACKER:Variable ''BUGTRACKER'' should be set [branch:true]',
+  \   '[31mexample2_1.1.bb:17:error:oelint.var.mandatoryvar.DESCRIPTION:Variable ''DESCRIPTION'' should be set[0m [branch:true]',
   \ ])


### PR DESCRIPTION
Recent oelint versions (6.0+) include a `[branch:…]` at the end of each line, which can break parsing.