### PR TITLE
WIP: ALEFindReferences: add -fzf flag to show output in fzf

### DIFF
--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -148,43 +148,48 @@ function! ale#references#ShowInFzf(item_list) abort
 endfunction
 
 function! ale#references#HandleLSPResponse(conn_id, response) abort
-    if has_key(a:response, 'id')
-    \&& has_key(s:references_map, a:response.id)
-        let l:options = remove(s:references_map, a:response.id)
+    if ! (has_key(a:response, 'id') && has_key(s:references_map, a:response.id))
+        return
+    endif
 
-        " The result can be a Dictionary item, a List of the same, or null.
-        let l:result = get(a:response, 'result', [])
-        let l:item_list = []
+    let l:options = remove(s:references_map, a:response.id)
 
-        if type(l:result) is v:t_list
-            for l:response_item in l:result
-                call add(l:item_list,
-                \ ale#references#FormatLSPResponseItem(l:response_item, l:options)
-                \)
-            endfor
-        endif
+    " The result can be a Dictionary item, a List of the same, or null.
+    let l:result = get(a:response, 'result', [])
+    let l:item_list = []
 
-        if empty(l:item_list)
-            call ale#util#Execute('echom ''No references found.''')
-        else
-            if get(l:options, 'open_in') is# 'quickfix'
-                call setqflist([], 'r')
-                call setqflist(l:item_list, 'a')
-                call ale#util#Execute('cc 1')
-            elseif get(l:options, 'open_in') is# 'fzf'
-                close  " close the buffer that's been opened, we're not going to use it
-                       " when showing results through fzf
-                " TODO: use 'use_fzf' instead of 'open_in', then pass 'open_in' to
-                " ShowInFzf in order to use as default open method
+    if type(l:result) is v:t_list
+        for l:response_item in l:result
+            call add(l:item_list,
+            \ ale#references#FormatLSPResponseItem(l:response_item, l:options)
+            \)
+        endfor
+    endif
 
-                if !exists('*fzf#run')
-                    throw "fzf#run function not found. You also need Vim plugin from the main fzf repository (i.e. junegunn/fzf *and* junegunn/fzf.vim)"
-                endif
+    if empty(l:item_list)
+        call ale#util#Execute('echom ''No references found.''')
+    else
+        if get(l:options, 'open_in') is# 'quickfix'
+            call setqflist([], 'r')
+            call setqflist(l:item_list, 'a')
+            call ale#util#Execute('cc 1')
+        elseif get(l:options, 'open_in') is# 'fzf'
+            close  " close the buffer that's been opened, we're not going to use it
+                   " when showing results through fzf
+            " TODO: use 'use_fzf' instead of 'open_in', then pass 'open_in' to
+            " ShowInFzf in order to use as default open method
 
-                call ale#references#ShowInFzf(l:item_list)
-            else
-                call ale#preview#ShowSelection(l:item_list, l:options)
+            if !exists('*fzf#run')
+                throw "fzf#run function not found. You also need Vim plugin from the main fzf repository (i.e. junegunn/fzf *and* junegunn/fzf.vim)"
             endif
+
+            " if !exists('*fzf#vim#references')
+            "     throw "fzf#vim#references function not found. You need to upgrade to the latest fzf.vim version"
+            " endif
+
+            call ale#references#ShowInFzf(l:item_list)
+        else
+            call ale#preview#ShowSelection(l:item_list, l:options)
         endif
     endif
 endfunction

--- a/autoload/ale/references.vim
+++ b/autoload/ale/references.vim
@@ -73,6 +73,18 @@ function! ale#references#FormatLSPResponseItem(response_item, options) abort
         \ 'lnum': a:response_item.range.start.line + 1,
         \ 'col': a:response_item.range.start.character + 1,
         \}
+    elseif get(a:options, 'open_in') is# 'fzf'
+        " grep-style output (filename:line:col:text) so that fzf can properly
+        " show matches and previews.
+        " See note below in ShowInFzf about returning json encoded values here
+        " (and commented return below)
+        return l:filename . ':' .  (a:response_item.range.start.line + 1) . ":" . (a:response_item.range.start.character + 1) . ":" . l:line_text
+        " return json_encode({
+        " \ 'filename': l:filename,
+        " \ 'lnum': a:response_item.range.start.line + 1,
+        " \ 'col': a:response_item.range.start.character + 1,
+        " \ 'text': l:line_text,
+        " \})
     else
         return {
         \ 'filename': ale#util#ToResource(a:response_item.uri),
@@ -80,6 +92,59 @@ function! ale#references#FormatLSPResponseItem(response_item, options) abort
         \ 'column': a:response_item.range.start.character + 1,
         \}
     endif
+endfunction
+
+function! ale#references#ShowInFzf(item_list) abort
+    let l:name = "LSP References"
+    let l:capname = "References"
+
+    " start with an empty query to let user filter
+    let l:start_query = ''
+    let l:opts = {
+    \ 'source':  a:item_list,
+    \ 'options': ['--ansi', '--prompt', l:name.'> ', '--query', l:start_query,
+    \             '--disabled',
+    \             '--multi', '--bind', 'alt-a:select-all,alt-d:deselect-all',
+    \             '--delimiter', ':', '--preview-window', '+{2}/2']
+    \}
+
+    function! s:action(key, file_info, ...)
+        " FIXME: temporarily only using edit, need to add more methods
+        silent keepjumps keepalt execute "edit " . fnameescape(a:file_info['filename'])
+        execute a:file_info.lnum
+        call cursor(0, a:file_info.col)
+    endfunction
+
+
+    function! s:references_to_qf(line)
+        " mimics ag_to_qf in fzf.vim
+        " NOTE: it's kinda annoying that we have to format each match as
+        " filename:linenum:column:text, but that's how we can easily display
+        " matches (and previews) in fzf, and then we have to parse it again here.
+        "
+        " TODO: figure out a way pass json to fzf and use that for matches.
+        " We could get rid of this code and just have FormatLSPResponseItem
+        " return json_encode(<match info>) and then here:
+        "   let l:dict = json_decode(a:line)
+        "
+        let parts = matchlist(a:line, '\(.\{-}\)\s*:\s*\(\d\+\)\%(\s*:\s*\(\d\+\)\)\?\%(\s*:\(.*\)\)\?')
+        let file = &acd ? fnamemodify(parts[1], ':p') : parts[1]
+
+        return {'filename': file, 'lnum': parts[2], 'col': parts[3], 'text': parts[4]}
+    endfunction
+
+    function! opts.sinklist(lines) closure
+        let l:references = map(filter(a:lines, 'len(v:val)'), 's:references_to_qf(v:val)')
+
+        for ref in l:references
+            call s:action("dummykey", l:ref)
+        endfor
+    endfunction
+
+    let l:opts_with_preview = fzf#vim#with_preview(l:opts)
+    let l:fullscreen = 1 " FIXME: decide what to do with this
+
+    call fzf#run(fzf#wrap(l:name, l:opts_with_preview, l:fullscreen))
 endfunction
 
 function! ale#references#HandleLSPResponse(conn_id, response) abort
@@ -106,6 +171,17 @@ function! ale#references#HandleLSPResponse(conn_id, response) abort
                 call setqflist([], 'r')
                 call setqflist(l:item_list, 'a')
                 call ale#util#Execute('cc 1')
+            elseif get(l:options, 'open_in') is# 'fzf'
+                close  " close the buffer that's been opened, we're not going to use it
+                       " when showing results through fzf
+                " TODO: use 'use_fzf' instead of 'open_in', then pass 'open_in' to
+                " ShowInFzf in order to use as default open method
+
+                if !exists('*fzf#run')
+                    throw "fzf#run function not found. You also need Vim plugin from the main fzf repository (i.e. junegunn/fzf *and* junegunn/fzf.vim)"
+                endif
+
+                call ale#references#ShowInFzf(l:item_list)
             else
                 call ale#preview#ShowSelection(l:item_list, l:options)
             endif
@@ -165,6 +241,8 @@ function! ale#references#Find(...) abort
                 let l:options.open_in = 'vsplit'
             elseif l:option is? '-quickfix'
                 let l:options.open_in = 'quickfix'
+            elseif l:option is? '-fzf'
+                let l:options.open_in = 'fzf'
             endif
         endfor
     endif


### PR DESCRIPTION
This (WIP) adds `:ALEFindReferences -fzf` to list/matches found by the LSP Server using [fzf](https://github.com/junegunn/fzf) and [fzf.vim](https://github.com/junegunn/fzf.vim).

This is a very rough draft, but this is what's working:

- Listing files matched by the LSP using fzf
- Showing previews for matches
- Opening multiple files (`edit` only)

What's not implemented:

- Opening multiple files in splits/tabs
- a lot more


Here's what this looks like so far:

![fzf-references](https://github.com/user-attachments/assets/fca4ba13-3c86-4259-8824-71089416a902)


Related: #2252, #3321

Based on #5001

cc @w0rp would love some feedback