### PR TITLE
Re-enable displaying type errors in pyrefly

### DIFF
--- a/ale_linters/python/pyrefly.vim
+++ b/ale_linters/python/pyrefly.vim
@@ -6,6 +6,7 @@ call ale#Set('python_pyrefly_use_global', get(g:, 'ale_use_global_executables', 
 call ale#Set('python_pyrefly_auto_pipenv', 0)
 call ale#Set('python_pyrefly_auto_poetry', 0)
 call ale#Set('python_pyrefly_auto_uv', 0)
+call ale#Set('python_pyrefly_config', {'python': {'pyrefly': {'displayTypeErrors': 'force-on'}}})
 
 function! ale_linters#python#pyrefly#GetExecutable(buffer) abort
     if (ale#Var(a:buffer, 'python_auto_pipenv') || ale#Var(a:buffer, 'python_pyrefly_auto_pipenv'))
@@ -54,4 +55,5 @@ call ale#linter#Define('python', {
 \   'project_root': function('ale#python#FindProjectRoot'),
 \   'completion_filter': 'ale#completion#python#CompletionItemFilter',
 \   'cwd': function('ale_linters#python#pyrefly#GetCwd'),
+\   'lsp_config': {b -> ale#Var(b, 'python_pyrefly_config')},
 \})

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -1677,8 +1677,36 @@ g:ale_python_pyrefly_auto_uv
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
+                                           *ale-options.python_pyrefly_config*
+                                                 *g:ale_python_pyrefly_config*
+                                                 *b:ale_python_pyrefly_config*
+python_pyrefly_config
+g:ale_python_pyrefly_config
+	Type: |Dictionary|
+  Default: `{'python': {'pyrefly': {'displayTypeErrors': 'force-on'}}}`
 
+	Settings for configuring the `pyrefly` language server.
 
+	Starting with `pyrefly` version `0.31.1` displaying type errors is
+	disabled by default. The default |g:ale_python_pyrefly_config|
+	enables `displayTypeErrors`. When explicitly configuring
+	|g:ale_python_pyrefly_config| ensure to configure `displayTypeErrors`
+	if desired. To disable `displayTypeErrors` set the value to `force-off`
+	or set to `default` to require a `pyrefly` configuration for the
+	project.
+
+  A commonly used setting for `pyrefly` is disabling language services
+  apart from type checking, you can set this setting like so, or use
+	whatever other settings you want: >
+
+  let b:ale_python_pyright_config = {
+  \   'python': {
+  \       'pyrefly': {
+  \           'disableLanguageServices': v:true,
+	\       }
+  \   },
+  \}
+<
 ===============================================================================
 pyright                                                    *ale-python-pyright*
 

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -1688,7 +1688,8 @@ g:ale_python_pyrefly_config
 	Settings for configuring the `pyrefly` language server.
 
 	Starting with `pyrefly` version `0.31.1` displaying type errors is
-	disabled by default. The default |g:ale_python_pyrefly_config|
+	disabled by default if no `pyrefly.toml` or `pyproject.toml` with a
+	`[tool.pyrefly]` section exists. The default |g:ale_python_pyrefly_config|
 	enables `displayTypeErrors`. When explicitly configuring
 	|g:ale_python_pyrefly_config| ensure to configure `displayTypeErrors`
 	if desired. To disable `displayTypeErrors` set the value to `force-off`

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -1677,6 +1677,7 @@ g:ale_python_pyrefly_auto_uv
 
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
+
                                            *ale-options.python_pyrefly_config*
                                                  *g:ale_python_pyrefly_config*
                                                  *b:ale_python_pyrefly_config*

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -1678,9 +1678,9 @@ g:ale_python_pyrefly_auto_uv
   Set the executable to `uv` if true. This is overridden by a manually-set
   executable.
 
-                                           *ale-options.python_pyrefly_config*
-                                                 *g:ale_python_pyrefly_config*
-                                                 *b:ale_python_pyrefly_config*
+                                            *ale-options.python_pyrefly_config*
+                                                  *g:ale_python_pyrefly_config*
+                                                  *b:ale_python_pyrefly_config*
 python_pyrefly_config
 g:ale_python_pyrefly_config
 	Type: |Dictionary|

--- a/test/linter/test_pyrefly.vader
+++ b/test/linter/test_pyrefly.vader
@@ -67,3 +67,10 @@ Execute(uv is detected when python_pyrefly_auto_uv is set):
 
   AssertLinter 'uv',
   \ ale#Escape('uv') . ' run pyrefly lsp'
+
+Execute(Assert the default config):
+  AssertLSPConfig {'python': {'pyrefly': {'displayTypeErrors': 'force-on'}}}
+
+  let b:ale_python_pyrefly_config = {}
+
+  AssertLSPConfig {}


### PR DESCRIPTION
In `pyrefly` `0.31.1` a new configuration `python.pyrefly.displayTypeErrors` was added, changing the previous default behavior.

This PR adds the appropriate LSP configuration to restore the behavior for the ale pyrefly linter, including a new `python_pyrefly_config` option to allow further configuration of the LSP.