### PR TITLE
biome: use --stdin-file-path for fixer

### DIFF
--- a/autoload/ale/fixers/biome.vim
+++ b/autoload/ale/fixers/biome.vim
@@ -1,12 +1,11 @@
 function! ale#fixers#biome#Fix(buffer) abort
     let l:executable = ale#handlers#biome#GetExecutable(a:buffer)
     let l:options = ale#Var(a:buffer, 'biome_options')
-    let l:apply = ale#Var(a:buffer, 'biome_fixer_apply_unsafe') ? '--write --unsafe' : '--write'
+    let l:unsafe = ale#Var(a:buffer, 'biome_fixer_apply_unsafe') ? ' --unsafe' : ''
 
     return {
-    \   'read_temporary_file': 1,
-    \   'command': ale#Escape(l:executable) . ' check ' . l:apply
+    \   'command': ale#Escape(l:executable) . ' check '
+    \       . '--write --stdin-file-path %s' . l:unsafe
     \       . (!empty(l:options) ? ' ' . l:options : '')
-    \       . ' %t'
     \}
 endfunction

--- a/test/fixers/test_biome_fixer_callback.vader
+++ b/test/fixers/test_biome_fixer_callback.vader
@@ -15,9 +15,8 @@ Execute(The default biome command should be correct):
 
   AssertFixer
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('biome')
-  \     . ' check --write %t'
+  \     . ' check --write --stdin-file-path %s'
   \ }
 
 Execute(Unsafe fixes can be applied via an option):
@@ -26,9 +25,8 @@ Execute(Unsafe fixes can be applied via an option):
 
   AssertFixer
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('biome')
-  \     . ' check --write --unsafe %t'
+  \     . ' check --write --stdin-file-path %s --unsafe'
   \ }
 
 Execute(The fixer should accept options):
@@ -37,7 +35,6 @@ Execute(The fixer should accept options):
 
   AssertFixer
   \ {
-  \   'read_temporary_file': 1,
   \   'command': ale#Escape('biome')
-  \     . ' check --write --foobar %t',
+  \     . ' check --write --stdin-file-path %s --foobar',
   \ }


### PR DESCRIPTION
This PR changes the Biome fixer to use stdin with --stdin-file-path instead of a temporary file.

By using --stdin-file-path instead of a temporary file, Biome knows where the file is and applies the inclusion/exclusion rules from the configuration file appropriately.

The tests have been updated and all tests pass.