### PR TITLE
phpstan: support config phpstan.dist.neon

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -83,6 +83,10 @@ function! ale_linters#php#phpstan#FindConfigFile(buffer) abort
         let l:result = ale#path#FindNearestFile(a:buffer, 'phpstan.neon.dist')
     endif
 
+    if empty(l:result)
+        let l:result = ale#path#FindNearestFile(a:buffer, 'phpstan.dist.neon')
+    endif
+
     return l:result
 endfunction
 

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -95,6 +95,17 @@ Execute(Configuration dist file exists in current directory):
   \ ]
   AssertLinterCwd g:dir
 
+Execute(Configuration alternative dist file exists in current directory):
+  call writefile(['parameters:', '  level: 7'], './phpstan.dist.neon')
+  let g:ale_php_phpstan_level = ''
+  let g:ale_php_phpstan_configuration = ''
+
+  AssertLinter 'phpstan', [
+  \ ale#Escape('phpstan') . ' --version',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json %s'
+  \ ]
+  AssertLinterCwd g:dir
+
 Execute(Configuration file exists in current directory, but force phpstan level):
   call writefile(['parameters:', '  level: 7'], './phpstan.neon')
   let g:ale_php_phpstan_configuration = ''


### PR DESCRIPTION
`phpstan` loads config from (in order) `phpstan.neon`, `phpstan.neon.dist`, or `phpstan.dist.neon`. See [PHPStan Config Reference - Config file](https://phpstan.org/config-reference#config-file)

Update ALE to look for `phpstan.dist.neon` if the other config files are not found.