### PR TITLE
fix phpstan: use configured level 0

### DIFF
--- a/ale_linters/php/phpstan.vim
+++ b/ale_linters/php/phpstan.vim
@@ -27,6 +27,10 @@ function! ale_linters#php#phpstan#GetCommand(buffer, version) abort
 
     let l:level =  ale#Var(a:buffer, 'php_phpstan_level')
 
+    if type(l:level) is v:t_number
+        let l:level = string(l:level)
+    endif
+
     if empty(l:level) && empty(ale_linters#php#phpstan#FindConfigFile(a:buffer))
         " if no configuration file is found, then use 4 as a default level
         let l:level = '4'

--- a/test/linter/test_phpstan.vader
+++ b/test/linter/test_phpstan.vader
@@ -59,6 +59,13 @@ Execute(project with level set to 3):
   AssertLinter 'phpstan',
   \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('3') . ' %s'
 
+Execute(project with level set to 0):
+  call ale#test#SetFilename('phpstan-test-files/foo/test.php')
+  let g:ale_php_phpstan_level = 0
+
+  AssertLinter 'phpstan',
+  \ ale#Escape('phpstan') . ' analyze --no-progress --errorFormat json -l ' . ale#Escape('0') . ' %s'
+
 Execute(Custom phpstan configuration file):
   let g:ale_php_phpstan_configuration = 'phpstan_config'
 


### PR DESCRIPTION
Fixes #3139

Use `g:ale_php_phpstan_level` for `phpstan` `-l` (`--level`) command argument if it is configured to `0` (as a number rather than string).

`0` (number) is considered to be empty, but `'0'` (string) is not.