### PR TITLE
Rename erblint executable to erb_lint since deprecated by Shopify

### DIFF
--- a/ale_linters/eruby/erblint.vim
+++ b/ale_linters/eruby/erblint.vim
@@ -2,13 +2,13 @@
 " based on the ale ruumba and robocop linters
 " Description: ERB Lint, support for https://github.com/Shopify/erb-lint
 
-call ale#Set('eruby_erblint_executable', 'erblint')
+call ale#Set('eruby_erblint_executable', 'erb_lint')
 call ale#Set('eruby_erblint_options', '')
 
 function! ale_linters#eruby#erblint#GetCommand(buffer) abort
     let l:executable = ale#Var(a:buffer, 'eruby_erblint_executable')
 
-    return ale#ruby#EscapeExecutable(l:executable, 'erblint')
+    return ale#ruby#EscapeExecutable(l:executable, 'erb_lint')
     \   . ' --format json '
     \   . ale#Var(a:buffer, 'eruby_erblint_options')
     \   . ' --stdin %s'

--- a/doc/ale-eruby.txt
+++ b/doc/ale-eruby.txt
@@ -40,7 +40,7 @@ erblint                                                     *ale-eruby-erblint*
 eruby_erblint_executable
 g:ale_eruby_erblint_executable
   Type: |String|
-  Default: `'erblint'`
+  Default: `'erb_lint'`
 
   Override the invoked erblint binary. This is useful for running erblint
   from binstubs or a bundle.

--- a/test/linter/test_erblint.vader
+++ b/test/linter/test_erblint.vader
@@ -2,14 +2,14 @@ Before:
   call ale#assert#SetUpLinterTest('eruby', 'erblint')
   call ale#test#SetFilename('dummy.html.erb')
 
-  let g:ale_eruby_erblint_executable = 'erblint'
+  let g:ale_eruby_erblint_executable = 'erb_lint'
   let g:ale_eruby_erblint_options = ''
 
 After:
   call ale#assert#TearDownLinterTest()
 
-Execute(Executable should default to erblint):
-  AssertLinter 'erblint', ale#Escape('erblint')
+Execute(Executable should default to erb_lint):
+  AssertLinter 'erblint', ale#Escape('erb_lint')
   \   . ' --format json  --stdin %s'
 
 Execute(Should be able to set a custom executable):
@@ -18,9 +18,9 @@ Execute(Should be able to set a custom executable):
   AssertLinter 'bin/erblint' , ale#Escape('bin/erblint')
   \   . ' --format json  --stdin %s'
 
-Execute(Setting bundle appends 'exec erblint'):
+Execute(Setting bundle appends 'exec erb_lint'):
   let g:ale_eruby_erblint_executable = 'path to/bundle'
 
   AssertLinter 'path to/bundle', ale#Escape('path to/bundle')
-  \   . ' exec erblint'
+  \   . ' exec erb_lint'
   \   . ' --format json  --stdin %s'

--- a/test/linter/test_erblint.vader
+++ b/test/linter/test_erblint.vader
@@ -9,7 +9,7 @@ After:
   call ale#assert#TearDownLinterTest()
 
 Execute(Executable should default to erb_lint):
-  AssertLinter 'erblint', ale#Escape('erb_lint')
+  AssertLinter 'erb_lint', ale#Escape('erb_lint')
   \   . ' --format json  --stdin %s'
 
 Execute(Should be able to set a custom executable):


### PR DESCRIPTION
Fix warning: "Calling `erblint` is deprecated, please call the renamed executable `erb_lint` instead."