### PR TITLE
Add option to use human readable ruff errors

### DIFF
--- a/ale_linters/python/ruff.vim
+++ b/ale_linters/python/ruff.vim
@@ -8,6 +8,7 @@ call ale#Set('python_ruff_change_directory', 1)
 call ale#Set('python_ruff_auto_pipenv', 0)
 call ale#Set('python_ruff_auto_poetry', 0)
 call ale#Set('python_ruff_auto_uv', 0)
+call ale#Set('python_ruff_human_readable', 0)
 
 call ale#fix#registry#Add('ruff',
 \   'ale#fixers#ruff#Fix',
@@ -113,7 +114,7 @@ function! ale_linters#python#ruff#Handle(buffer, lines) abort
         \   'col': l:item.location.column,
         \   'end_lnum': l:item.end_location.row,
         \   'end_col': l:item.end_location.column - 1,
-        \   'code': l:item.code,
+        \   'code': ale#Var(a:buffer, 'python_ruff_human_readable') ? l:item.name : l:item.code,
         \   'text': l:item.message,
         \   'type': l:item.code =~? '\vE\d+' ? 'E' : 'W',
         \})

--- a/doc/ale-python.txt
+++ b/doc/ale-python.txt
@@ -2007,6 +2007,17 @@ g:ale_python_ruff_use_global
 
   See |ale-integrations-local-executables|
 
+                                       *ale-options.python_ruff_human_readable*
+                                             *g:ale_python_ruff_human_readable*
+                                             *b:ale_python_ruff_human_readable*
+python_ruff_human_readable
+g:ale_python_ruff_human_readable
+  Type: |Number|
+  Default: `0`
+
+  Show human-readable error names (usable by `ruff:ignore` comments) instead
+  of the default numeric error codes.
+
                                           *ale-options.python_ruff_auto_pipenv*
                                                 *g:ale_python_ruff_auto_pipenv*
                                                 *b:ale_python_ruff_auto_pipenv*

--- a/test/handler/test_ruff_handler.vader
+++ b/test/handler/test_ruff_handler.vader
@@ -1,9 +1,11 @@
 Before:
   Save g:ale_warn_about_trailing_blank_lines
   Save g:ale_warn_about_trailing_whitespace
+  Save g:ale_python_ruff_human_readable
 
   let g:ale_warn_about_trailing_blank_lines = 1
   let g:ale_warn_about_trailing_whitespace = 1
+  let g:ale_python_ruff_human_readable = 0
 
   runtime ale_linters/python/ruff.vim
 
@@ -12,6 +14,7 @@ After:
 
   unlet! b:ale_warn_about_trailing_blank_lines
   unlet! b:ale_warn_about_trailing_whitespace
+  unlet! b:ale_python_ruff_human_readable
 
   call ale#linter#Reset()
 
@@ -114,4 +117,23 @@ Execute(Disabling trailing blank line warnings should work):
   \ [],
   \ ale_linters#python#ruff#Handle(bufnr(''), [
   \   '{"cell":null,"code":"W391","end_location":{"column":2,"row":6},"filename":"/test.py","fix":null,"location":{"column":1,"row":6},"message":"blank line at end of file","noqa_row":2,"url":""}',
+  \ ])
+
+Execute(python_ruff_human_readable should use rule names instead of codes):
+  let b:ale_python_ruff_human_readable = 1
+
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 2,
+  \     'col': 1,
+  \     'end_lnum': 2,
+  \     'end_col': 7,
+  \     'code': 'undefined-name',
+  \     'type': 'W',
+  \     'text': 'Undefined name example',
+  \   },
+  \ ],
+  \ ale_linters#python#ruff#Handle(bufnr(''), [
+  \   '{"cell":null,"code":"F821","end_location":{"column":8,"row":2},"filename":"/test.py","fix":null,"location":{"column":1,"row":2},"message":"Undefined name example","name":"undefined-name","noqa_row":2,"url":"https://docs.astral.sh/ruff/rules/undefined-name"}',
   \ ])


### PR DESCRIPTION
`ruff` started adding some checks to push towards comments of the form `# ruff: ignore[some-rule-name]` ([RUF106](https://docs.astral.sh/ruff/rules/rule-codes-in-suppression-comments/)) instead of `# noqa: ignore[F401]` ([RUF105](https://docs.astral.sh/ruff/rules/noqa-comments/)). 

This adds an option `python_ruff_human_readable` to allow ale to show the human readable version if the project uses that instead of the error codes. With this enabled, the diagnostic looks something like
```
[ruff] `collections.abc.Sequence` imported but unused (unused-import) [Warning]
```