### PR TITLE
Only run actionlint on github workflow files

### DIFF
--- a/ale_linters/yaml/actionlint.vim
+++ b/ale_linters/yaml/actionlint.vim
@@ -5,8 +5,8 @@ call ale#Set('yaml_actionlint_executable', 'actionlint')
 call ale#Set('yaml_actionlint_options', '')
 
 function! ale_linters#yaml#actionlint#GetCommand(buffer) abort
-    " Only execute actionlint on YAML files in /.github/ paths.
-    if expand('#' . a:buffer . ':p') !~# '\v[/\\]\.github[/\\]'
+    " Only execute actionlint on YAML files in /.github/workflows/ paths.
+    if expand('#' . a:buffer . ':p') !~# '\v[/\\]\.github[/\\]workflows[/\\]'
         return ''
     endif
 

--- a/test/linter/test_yaml_actionlint.vader
+++ b/test/linter/test_yaml_actionlint.vader
@@ -1,6 +1,6 @@
 Before:
   call ale#assert#SetUpLinterTest('yaml', 'actionlint')
-  call ale#test#SetFilename('/.github/file.yml')
+  call ale#test#SetFilename('/.github/workflows/file.yml')
 
 After:
   call ale#assert#TearDownLinterTest()

--- a/test/linter/test_yaml_actionlint.vader
+++ b/test/linter/test_yaml_actionlint.vader
@@ -18,3 +18,8 @@ Execute(Options should be added to command):
 
 Execute(actionlint not run on files outside of /.github/ paths):
   call ale#test#SetFilename('/something-else/file.yml')
+
+Execute(actionlint not run on Dependabot configuration files):
+  call ale#test#SetFilename('/.github/dependabot.yml')
+
+  AssertLinterNotExecuted


### PR DESCRIPTION
This PR adds a test to show that current code runs `actionlint` on `.github/dependabot.yml` and it fails (as it's not a workflow).

And it changes `ale`, so it only looks for files in `.github/workflows` instead of `.github`.