### PR TITLE
feat: openscad-lsp support

### DIFF
--- a/ale_linters/openscad/openscad_lsp.vim
+++ b/ale_linters/openscad/openscad_lsp.vim
@@ -1,0 +1,23 @@
+" Author: Johan Niklasson <johan@niklasson-embedded.se>
+" Description: openscad-lsp support for OpenSCAD
+
+call ale#Set('openscad_openscad_lsp_executable', 'openscad-lsp')
+call ale#Set('openscad_openscad_lsp_options', '')
+
+function! ale_linters#openscad#openscad_lsp#GetProjectRoot(buffer) abort
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    if !empty(l:git_path)
+        return fnamemodify(l:git_path, ':h:h')
+    endif
+
+    return expand('#' . a:buffer . ':p:h')
+endfunction
+
+call ale#linter#Define('openscad', {
+\   'name': 'openscad_lsp',
+\   'lsp': 'stdio',
+\   'executable': {b -> ale#Var(b, 'openscad_openscad_lsp_executable')},
+\   'command': {b -> '%e --stdio' . ale#Pad(ale#Var(b, 'openscad_openscad_lsp_options'))},
+\   'project_root': function('ale_linters#openscad#openscad_lsp#GetProjectRoot'),
+\})

--- a/ale_linters/openscad/openscad_lsp.vim
+++ b/ale_linters/openscad/openscad_lsp.vim
@@ -1,0 +1,28 @@
+" Author: Johan Niklasson <johan@niklasson-embedded.se>
+" Description: openscad-lsp support for OpenSCAD
+
+call ale#Set('openscad_openscad_lsp_executable', 'openscad-lsp')
+call ale#Set('openscad_openscad_lsp_use_global', get(g:, 'ale_use_global_executables', 0))
+call ale#Set('openscad_openscad_lsp_options', '')
+
+function! ale_linters#openscad#openscad_lsp#GetProjectRoot(buffer) abort
+    let l:git_path = ale#path#FindNearestDirectory(a:buffer, '.git')
+
+    if !empty(l:git_path)
+        return fnamemodify(l:git_path, ':h')
+    endif
+
+    let l:buf_dir = fnamemodify(bufname(a:buffer), ':p:h')
+
+    return !empty(l:buf_dir) ? l:buf_dir : getcwd()
+endfunction
+
+call ale#linter#Define('openscad', {
+\   'name': 'openscad_lsp',
+\   'lsp': 'stdio',
+\   'executable': {b -> ale#path#FindExecutable(b, 'openscad_openscad_lsp', [
+\       'openscad-lsp',
+\   ])},
+\   'command': {b -> '%e --stdio' . ale#Pad(ale#Var(b, 'openscad_openscad_lsp_options'))},
+\   'project_root': function('ale_linters#openscad#openscad_lsp#GetProjectRoot'),
+\})

--- a/doc/ale-openscad.txt
+++ b/doc/ale-openscad.txt
@@ -3,6 +3,27 @@ ALE OpenSCAD Integration                                 *ale-openscad-options*
 
 
 ===============================================================================
+openscad-lsp                                         *ale-openscad-openscad_lsp*
+
+`openscad-lsp` is a Language Server Protocol implementation for OpenSCAD.
+
+g:ale_openscad_openscad_lsp_executable    *g:ale_openscad_openscad_lsp_executable*
+                                          *b:ale_openscad_openscad_lsp_executable*
+  Type: |String|
+  Default: `'openscad-lsp'`
+
+  This variable can be changed to use a different executable for openscad-lsp.
+
+
+g:ale_openscad_openscad_lsp_options          *g:ale_openscad_openscad_lsp_options*
+                                             *b:ale_openscad_openscad_lsp_options*
+  Type: |String|
+  Default: `''`
+
+  This variable can be changed to pass additional flags to openscad-lsp.
+
+
+===============================================================================
 sca2d                                                      *ale-openscad-sca2d*
 
                                         *ale-options.openscad_sca2d_executable*

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -505,6 +505,7 @@ Notes:
   * `yamllint`
 * OpenSCAD
   * `SCA2D`
+  * `openscad-lsp`
   * `scadformat`
 * Packer
   * `packer-fmt-fixer`

--- a/doc/ale-supported-languages-and-tools.txt
+++ b/doc/ale-supported-languages-and-tools.txt
@@ -504,6 +504,7 @@ Notes:
   * `yamllint`
 * OpenSCAD
   * `SCA2D`
+  * `openscad-lsp`
   * `scadformat`
 * Packer
   * `packer-fmt-fixer`

--- a/doc/ale.txt
+++ b/doc/ale.txt
@@ -3839,6 +3839,7 @@ documented in additional help files.
     prettier..............................|ale-openapi-prettier|
     yamllint..............................|ale-openapi-yamllint|
   openscad................................|ale-openscad-options|
+    openscad-lsp..........................|ale-openscad-openscad_lsp|
     sca2d.................................|ale-openscad-sca2d|
     scadformat............................|ale-openscad-scadformat|
   packer..................................|ale-packer-options|

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -514,6 +514,7 @@ formatting.
   * [yamllint](https://yamllint.readthedocs.io/)
 * OpenSCAD
   * [SCA2D](https://gitlab.com/bath_open_instrumentation_group/sca2d) :floppy_disk:
+  * [openscad-lsp](https://github.com/Leathong/openscad-LSP)
   * [scadformat](https://github.com/hugheaves/scadformat)
 * Packer (HCL)
   * [packer-fmt-fixer](https://github.com/hashicorp/packer)

--- a/supported-tools.md
+++ b/supported-tools.md
@@ -515,6 +515,7 @@ formatting.
   * [yamllint](https://yamllint.readthedocs.io/)
 * OpenSCAD
   * [SCA2D](https://gitlab.com/bath_open_instrumentation_group/sca2d) :floppy_disk:
+  * [openscad-lsp](https://github.com/Leathong/openscad-LSP)
   * [scadformat](https://github.com/hugheaves/scadformat)
 * Packer (HCL)
   * [packer-fmt-fixer](https://github.com/hashicorp/packer)

--- a/test/linter/test_openscad_openscad_lsp.vader
+++ b/test/linter/test_openscad_openscad_lsp.vader
@@ -1,0 +1,20 @@
+Before:
+  call ale#assert#SetUpLinterTest('openscad', 'openscad_lsp')
+
+After:
+  call ale#assert#TearDownLinterTest()
+
+Execute(The default command should be correct):
+  AssertLinter 'openscad-lsp', ale#Escape('openscad-lsp') . ' --stdio'
+
+Execute(The executable should be configurable):
+  let g:ale_openscad_openscad_lsp_executable = '/custom/path/openscad-lsp'
+
+  AssertLinter '/custom/path/openscad-lsp',
+  \ ale#Escape('/custom/path/openscad-lsp') . ' --stdio'
+
+Execute(Options should be appended to the command):
+  let b:ale_openscad_openscad_lsp_options = '--ignore-default'
+
+  AssertLinter 'openscad-lsp',
+  \ ale#Escape('openscad-lsp') . ' --stdio --ignore-default'


### PR DESCRIPTION
Just started out learning openscad and I found that openscad-lsp was missing. 

Based on the suggestion in #4519.

On the current version of ALE, autocompletion does not work due to ALE assuming no auto completion is supported if a server is returning `completionProvider: {}`. I've got a separate PR ready that solves this.