### PR TITLE
fix(lsp): check completionProvider key existence, not emptiness

### DIFF
--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -265,7 +265,8 @@ function! ale#lsp#UpdateCapabilities(conn_id, capabilities) abort
         let l:conn.capabilities.code_actions = 1
     endif
 
-    if !empty(get(a:capabilities, 'completionProvider'))
+    let l:completion = get(a:capabilities, 'completionProvider', v:false)
+    if type(l:completion) is v:t_dict || l:completion is v:true
         let l:conn.capabilities.completion = 1
     endif
 

--- a/autoload/ale/lsp.vim
+++ b/autoload/ale/lsp.vim
@@ -265,7 +265,9 @@ function! ale#lsp#UpdateCapabilities(conn_id, capabilities) abort
         let l:conn.capabilities.code_actions = 1
     endif
 
-    if !empty(get(a:capabilities, 'completionProvider'))
+    let l:completion = get(a:capabilities, 'completionProvider', v:false)
+
+    if type(l:completion) is v:t_dict || l:completion is v:true
         let l:conn.capabilities.completion = 1
     endif
 


### PR DESCRIPTION
completionProvider: {} is valid per the LSP spec (means completion enabled with default options). The old !empty() check incorrectly rejected empty objects, causing ALE to silently disable completion for servers that send completionProvider: {}.

This change fixes auto completion for openscad-lsp added in #5156.