### PR TITLE
fix: linter fortitude: renamed location key from "row" to "line"

### DIFF
--- a/ale_linters/fortran/fortitude.vim
+++ b/ale_linters/fortran/fortitude.vim
@@ -21,9 +21,13 @@ function! ale_linters#fortran#fortitude#Handle(buffer, lines) abort
         let l:prefix = matchstr(l:error['code'], '^\a\+')
         let l:type = get(s:severity_map, l:prefix, 'I')
 
+        " Fortitude renamed `row` to `line` (PlasmaFAIR/fortitude@0eda11975096517b16bf30bf683011f83a24e55e)
+        let l:line = get(l:error['location'], 'line', get(l:error['location'], 'row'))
+        let l:end_line = get(l:error['end_location'], 'line', get(l:error['end_location'], 'row'))
+
         call add(l:output, {
-        \   'lnum': l:error['location']['line'],
-        \   'end_lnum': l:error['end_location']['line'],
+        \   'lnum': l:line,
+        \   'end_lnum': l:end_line,
         \   'col': l:error['location']['column'],
         \   'end_col': l:error['end_location']['column'],
         \   'text': l:error['message'],

--- a/ale_linters/fortran/fortitude.vim
+++ b/ale_linters/fortran/fortitude.vim
@@ -22,8 +22,8 @@ function! ale_linters#fortran#fortitude#Handle(buffer, lines) abort
         let l:type = get(s:severity_map, l:prefix, 'I')
 
         call add(l:output, {
-        \   'lnum': l:error['location']['row'],
-        \   'end_lnum': l:error['end_location']['row'],
+        \   'lnum': l:error['location']['line'],
+        \   'end_lnum': l:error['end_location']['line'],
         \   'col': l:error['location']['column'],
         \   'end_col': l:error['end_location']['column'],
         \   'text': l:error['message'],

--- a/test/handler/test_fortitude_handler.vader
+++ b/test/handler/test_fortitude_handler.vader
@@ -57,3 +57,57 @@ Execute(Simple fortitude handler run):
   \   }),
   \   ']',
   \ ])
+
+Execute(Old fortitude handler output with row):
+  AssertEqual
+  \ [
+  \   {
+  \     'lnum': 3,
+  \     'end_lnum': 3,
+  \     'col': 5,
+  \     'end_col': 18,
+  \     'text': '''implicit none'' missing ''external''',
+  \     'type': 'W',
+  \     'code': 'C003',
+  \   },
+  \   {
+  \     'col': 13,
+  \     'end_col': 14,
+  \     'end_lnum': 7,
+  \     'lnum': 7,
+  \     'text': 'Syntax error',
+  \     'type': 'E',
+  \     'code': 'E001',
+  \   },
+  \ ],
+  \ ale_linters#fortran#fortitude#Handle(bufnr(''), [
+  \   '[',
+  \   json_encode({
+  \     'code': 'C003',
+  \     'end_location': {'column': 18, 'row': 3},
+  \     'filename': '/home/user/documents/somefortranfile.f90',
+  \     'fix': {
+  \       'applicability': 'unsafe',
+  \       'edits': [
+  \         {
+  \           'content': ' (type, external)',
+  \           'end_location': {'column': 18, 'row': 3},
+  \           'location': {'column': 18, 'row': 3},
+  \         },
+  \       ],
+  \       'message': 'Add `(external)` to ''implicit none''',
+  \     },
+  \     'location': {'column': 5, 'row': 3},
+  \     'message': '''implicit none'' missing ''external'''
+  \   }),
+  \   ',',
+  \   json_encode({
+  \     'code': 'E001',
+  \     'end_location': {'column': 14, 'row': 7},
+  \     'filename': '/home/user/documents/somefortranfile.f90',
+  \     'fix': v:null,
+  \     'location': {'column': 13, 'row': 7},
+  \     'message': 'Syntax error',
+  \   }),
+  \   ']',
+  \ ])

--- a/test/handler/test_fortitude_handler.vader
+++ b/test/handler/test_fortitude_handler.vader
@@ -30,29 +30,29 @@ Execute(Simple fortitude handler run):
   \   '[',
   \   json_encode({
   \     'code': 'C003',
-  \     'end_location': {'column': 18, 'row': 3},
+  \     'end_location': {'column': 18, 'line': 3},
   \     'filename': '/home/user/documents/somefortranfile.f90',
   \     'fix': {
   \       'applicability': 'unsafe',
   \       'edits': [
   \         {
   \           'content': ' (type, external)',
-  \           'end_location': {'column': 18, 'row': 3},
-  \           'location': {'column': 18, 'row': 3},
+  \           'end_location': {'column': 18, 'line': 3},
+  \           'location': {'column': 18, 'line': 3},
   \         },
   \       ],
   \       'message': 'Add `(external)` to ''implicit none''',
   \     },
-  \     'location': {'column': 5, 'row': 3},
+  \     'location': {'column': 5, 'line': 3},
   \     'message': '''implicit none'' missing ''external'''
   \   }),
   \   ',',
   \   json_encode({
   \     'code': 'E001',
-  \     'end_location': {'column': 14, 'row': 7},
+  \     'end_location': {'column': 14, 'line': 7},
   \     'filename': '/home/user/documents/somefortranfile.f90',
   \     'fix': v:null,
-  \     'location': {'column': 13, 'row': 7},
+  \     'location': {'column': 13, 'line': 7},
   \     'message': 'Syntax error',
   \   }),
   \   ']',


### PR DESCRIPTION
Hi, 

fortitude has renamed the key `row` to `line` in the `location` and `end_location` field. They changed it in this commit PlasmaFAIR/fortitude@0eda11975096517b16bf30bf683011f83a24e55e.

This PR fixes this.