### PR TITLE
Fix LSP completion for multi-character prefixes

### DIFF
--- a/autoload/ale/completion.vim
+++ b/autoload/ale/completion.vim
@@ -220,6 +220,13 @@ function! ale#completion#GetTriggerCharacter(filetype, prefix, ...) abort
         return a:prefix
     endif
 
+    for l:char in l:char_list
+        if len(a:prefix) >= len(l:char)
+        \&& strpart(a:prefix, len(a:prefix) - len(l:char)) is# l:char
+            return l:char
+        endif
+    endfor
+
     return ''
 endfunction
 
@@ -242,7 +249,8 @@ function! ale#completion#Filter(
         "   foo.
         "       ^
         " We need to include all of the given suggestions.
-        if index(l:triggers, a:prefix) >= 0 || empty(a:prefix)
+        if !empty(ale#completion#GetTriggerCharacter(a:filetype, a:prefix, l:conn_id))
+        \|| empty(a:prefix)
             let l:filtered_suggestions = a:suggestions
         else
             let l:filtered_suggestions = []

--- a/test/completion/test_completion_filtering.vader
+++ b/test/completion/test_completion_filtering.vader
@@ -154,7 +154,7 @@ Execute(GetTriggerCharacter should use LSP triggers when conn_id provided):
   call ale#lsp#Register('test-lsp', '/project', '', {})
   let g:conn_id = 'test-lsp:/project'
   call ale#lsp#UpdateCapabilities(g:conn_id, {
-  \   'completionProvider': {'triggerCharacters': ['@', '#']},
+  \   'completionProvider': {'triggerCharacters': ['@', '#', ':']},
   \})
 
   " '@' is in LSP triggers
@@ -163,6 +163,8 @@ Execute(GetTriggerCharacter should use LSP triggers when conn_id provided):
   AssertEqual '', ale#completion#GetTriggerCharacter('python', '.', g:conn_id)
   " '#' is in LSP triggers
   AssertEqual '#', ale#completion#GetTriggerCharacter('python', '#', g:conn_id)
+  " '::' ends with the ':' trigger advertised by rust-analyzer
+  AssertEqual ':', ale#completion#GetTriggerCharacter('rust', '::', g:conn_id)
 
   call ale#lsp#RemoveConnectionWithID(g:conn_id)
   unlet g:conn_id
@@ -183,7 +185,7 @@ Execute(Filtering should use LSP trigger characters):
   call ale#lsp#Register('test-lsp-filter', '/project', '', {})
   let g:conn_id = 'test-lsp-filter:/project'
   call ale#lsp#UpdateCapabilities(g:conn_id, {
-  \   'completionProvider': {'triggerCharacters': ['@']},
+  \   'completionProvider': {'triggerCharacters': ['@', ':']},
   \})
 
   " Set up completion info with conn_id
@@ -192,6 +194,8 @@ Execute(Filtering should use LSP trigger characters):
 
   " '@' is LSP trigger - should return all suggestions
   AssertEqual b:suggestions, ale#completion#Filter(bufnr(''), 'python', b:suggestions, '@', 0)
+  " '::' ends with the ':' trigger advertised by rust-analyzer
+  AssertEqual b:suggestions, ale#completion#Filter(bufnr(''), 'rust', b:suggestions, '::', 0)
   " '.' is NOT LSP trigger - should filter
   AssertEqual [], ale#completion#Filter(bufnr(''), 'python', b:suggestions, '.', 0)
 


### PR DESCRIPTION
trying to fix rust auto completions